### PR TITLE
feat(pipeline): reset CLI — stage, source, and full reset + audit log

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -395,6 +395,121 @@ def _cmd_audit(*, last_n: int = 10) -> None:
         print()
 
 
+def _cmd_reset(
+    *,
+    stage: str | None,
+    source: str | None,
+    full: bool,
+    assume_yes: bool,
+    dry_run: bool,
+) -> None:
+    """Execute a pipeline reset. Writes an audit entry for every run."""
+    from pathlib import Path
+
+    from src.config import get_settings
+    from src.pipeline.reset import PipelineResetter, ResetScope
+
+    # Build the scope first — validates inputs before any confirmation.
+    provided = sum(1 for f in (stage, source, full) if f)
+    if provided != 1:
+        print("ERROR: reset requires exactly one of --stage, --source, --all.")
+        sys.exit(2)
+
+    if stage:
+        scope = ResetScope.stage_scope(stage)
+        summary_line = f"STAGE reset: prefix '{stage}/' and consumer offsets"
+    elif source:
+        scope = ResetScope.source_scope(source)
+        summary_line = f"SOURCE reset: all stage prefixes for source '{source}'"
+    else:
+        scope = ResetScope.full_scope()
+        summary_line = (
+            "FULL reset: every pipeline B2 prefix, every pipeline Kafka topic, "
+            "Neo4j hadith graph, PG hadith metadata. "
+            "Users/roles/sessions are PRESERVED."
+        )
+
+    print(f"=== Pipeline Reset ===\n  {summary_line}\n")
+
+    if scope.level == "full" and not assume_yes:
+        confirm = input("Type 'OBLITERATE' to proceed: ").strip()
+        if confirm != "OBLITERATE":
+            print("Aborted.")
+            sys.exit(1)
+
+    if dry_run:
+        print("Dry run — no changes were made. Scope validated.")
+        return
+
+    settings = get_settings()
+    object_store, kafka_admin, neo4j, pg = _build_reset_clients(settings)
+
+    resetter = PipelineResetter(
+        object_store=object_store,
+        kafka_admin=kafka_admin,
+        neo4j=neo4j,
+        pg=pg,
+        data_dir=Path(settings.data_raw_dir).parent,
+    )
+    report, _entry, audit_path = resetter.reset(scope)
+
+    print("\n=== Reset Complete ===")
+    print(f"  Level              : {report.level}")
+    print(f"  S3 prefixes deleted: {len(report.s3_prefixes_deleted)}")
+    print(f"  S3 objects deleted : {report.s3_objects_deleted}")
+    print(f"  Kafka topics reset : {len(report.kafka_topics_reset)}")
+    if report.level == "full":
+        print(f"  Neo4j rows deleted : {report.neo4j_rows_deleted}")
+        print(f"  PG rows deleted    : {report.pg_rows_deleted}")
+    print(f"  Duration (s)       : {report.duration_seconds}")
+    print(f"  Audit entry        : {audit_path}")
+
+
+def _build_reset_clients(settings: object) -> tuple[object, object, object, object]:
+    """Construct the four reset adapters from settings. Isolated for testability."""
+    # Imports kept inside the helper so unit tests that call _cmd_reset
+    # via monkey-patched adapters don't drag in kafka/neo4j/boto3.
+    import os
+
+    import boto3  # type: ignore[import-untyped]
+    import psycopg
+    from kafka.admin import KafkaAdminClient  # type: ignore[import-untyped]
+    from neo4j import GraphDatabase
+
+    from src.pipeline.reset_adapters import (
+        KafkaPythonAdmin,
+        Neo4jHadithResetter,
+        PgHadithMetadataResetter,
+    )
+
+    class _Store:
+        def __init__(self, bucket: str, endpoint_url: str | None) -> None:
+            self.bucket = bucket
+            self._client = boto3.client(
+                "s3", **({"endpoint_url": endpoint_url} if endpoint_url else {})
+            )
+
+        @property
+        def client(self) -> object:
+            return self._client
+
+    bucket = os.environ.get("PIPELINE_BUCKET", "noorinalabs-pipeline")
+    endpoint_url = os.environ.get("S3_ENDPOINT_URL")
+    bootstrap = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
+
+    neo4j_cfg = getattr(settings, "neo4j")
+    pg_cfg = getattr(settings, "postgres")
+
+    return (
+        _Store(bucket=bucket, endpoint_url=endpoint_url),
+        KafkaPythonAdmin(KafkaAdminClient(bootstrap_servers=bootstrap)),
+        Neo4jHadithResetter(
+            GraphDatabase.driver(neo4j_cfg.uri, auth=(neo4j_cfg.user, neo4j_cfg.password))
+        ),
+        PgHadithMetadataResetter(psycopg.connect(pg_cfg.dsn)),
+    )
+
+
 def _cmd_pipeline() -> None:
     """Run the full pipeline: acquire -> parse -> resolve -> load -> enrich."""
     print("=== Full Pipeline Run ===\n")
@@ -495,6 +610,37 @@ def main() -> None:
 
     subparsers.add_parser("pipeline", help="Run the full pipeline end-to-end")
 
+    reset_parser = subparsers.add_parser(
+        "reset",
+        help="Reset pipeline state (stage, source, or full). Writes audit log.",
+    )
+    reset_group = reset_parser.add_mutually_exclusive_group(required=True)
+    reset_group.add_argument(
+        "--stage",
+        choices=["raw", "dedup", "enriched", "normalized", "staged"],
+        help="Wipe one B2 stage prefix + reset that stage's Kafka consumer offsets",
+    )
+    reset_group.add_argument(
+        "--source",
+        type=str,
+        help="Wipe all stage prefixes for one data source (e.g. sunnah-api)",
+    )
+    reset_group.add_argument(
+        "--all",
+        action="store_true",
+        help="Full reset: every prefix, every topic, Neo4j + PG hadith data (preserves users)",
+    )
+    reset_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the 'OBLITERATE' confirmation for --all. Required for non-interactive runs.",
+    )
+    reset_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate scope and print what would be reset without touching anything.",
+    )
+
     args = parser.parse_args()
 
     if args.command is None:
@@ -541,6 +687,14 @@ def main() -> None:
         _cmd_audit(last_n=args.last)
     elif args.command == "pipeline":
         _cmd_pipeline()
+    elif args.command == "reset":
+        _cmd_reset(
+            stage=args.stage,
+            source=args.source,
+            full=args.all,
+            assume_yes=args.yes,
+            dry_run=args.dry_run,
+        )
 
 
 if __name__ == "__main__":

--- a/src/pipeline/reset.py
+++ b/src/pipeline/reset.py
@@ -1,0 +1,299 @@
+"""Pipeline reset operations — stage, source, and full reset.
+
+Three reset scopes per issue #108:
+
+- **stage**: wipe one B2 prefix + reset consumer offsets for that stage's
+  Kafka topic. Use when a single stage produced bad output and needs
+  re-running.
+- **source**: wipe all B2 data for one source across every stage prefix.
+  Use when re-acquiring a source from scratch.
+- **full**: wipe every pipeline B2 prefix + every pipeline Kafka topic +
+  Neo4j hadith graph + PG hadith metadata. **Preserves** users, roles,
+  sessions, and Kafka broker/topic *definitions*.
+
+Every reset emits an audit entry to ``data/audit/`` via the existing
+``src/pipeline/audit.py`` module so operators have a record of who
+cleared what and when.
+
+All resource clients (``ObjectStore``, Kafka admin, Neo4j driver, PG
+connection) are injected so the unit suite can exercise reset logic
+against in-memory fakes without any infra.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from src.pipeline.audit import AuditEntry, create_audit_entry, write_audit_entry
+
+__all__ = [
+    "KafkaAdmin",
+    "Neo4jResetter",
+    "PgResetter",
+    "PipelineResetter",
+    "ResetReport",
+    "ResetScope",
+    "StageName",
+    "S3Prefix",
+]
+
+# Canonical stage → B2 prefix mapping. Matches issue #105 layout.
+STAGE_PREFIXES: dict[str, str] = {
+    "raw": "raw/",
+    "dedup": "dedup/",
+    "enriched": "enriched/",
+    "normalized": "normalized/",
+    "staged": "staged/",
+}
+
+# Canonical stage → Kafka topic mapping. Matches issue #106 contract.
+STAGE_TOPICS: dict[str, str] = {
+    "raw": "pipeline.raw.new",
+    "dedup": "pipeline.dedup.done",
+    "enriched": "pipeline.enrich.done",
+    "normalized": "pipeline.norm.done",
+}
+
+# All pipeline topics — used by full reset.
+ALL_PIPELINE_TOPICS: tuple[str, ...] = (
+    "pipeline.raw.new",
+    "pipeline.dedup.done",
+    "pipeline.enrich.done",
+    "pipeline.norm.done",
+    "pipeline.dlq",
+)
+
+StageName = str
+S3Prefix = str
+
+
+class _ObjectStoreProto(Protocol):
+    """Subset of the S3 client surface the resetter needs.
+
+    Matches ``workers/lib/object_store.py``'s ``ObjectStore`` client so
+    the same object works in both code paths.
+    """
+
+    bucket: str
+
+    @property
+    def client(self) -> Any: ...
+
+
+class KafkaAdmin(Protocol):
+    """Kafka admin surface. Wraps ``kafka-python``'s ``KafkaAdminClient``.
+
+    Only two methods needed — everything else we do is consumer-group
+    offset reset via the built-in kafka-consumer-groups CLI or programmatic
+    equivalent.
+    """
+
+    def reset_consumer_offsets(self, topic: str, group_id: str) -> None: ...
+    def delete_topic_data(self, topic: str) -> None: ...
+
+
+class Neo4jResetter(Protocol):
+    """Neo4j surface. ``truncate_hadith_graph`` deletes every node except
+    user-related labels (currently none live in Neo4j, but the contract
+    is future-proofed)."""
+
+    def truncate_hadith_graph(self) -> int: ...
+
+
+class PgResetter(Protocol):
+    """PostgreSQL surface. Truncates hadith metadata tables only —
+    never touches ``users``, ``roles``, ``user_roles``, ``sessions``."""
+
+    def truncate_hadith_metadata(self) -> int: ...
+
+
+@dataclass(frozen=True)
+class ResetScope:
+    """What to reset. Exactly one of the three factory classmethods is used."""
+
+    level: str  # "stage" | "source" | "full"
+    stage: str | None = None  # set when level == "stage"
+    source: str | None = None  # set when level == "source"
+    consumer_group: str | None = None  # defaults to stage name for stage reset
+
+    @classmethod
+    def stage_scope(cls, stage: str, *, consumer_group: str | None = None) -> ResetScope:
+        if stage not in STAGE_PREFIXES:
+            raise ValueError(f"unknown stage: {stage!r}. Known: {sorted(STAGE_PREFIXES)}")
+        return cls(level="stage", stage=stage, consumer_group=consumer_group or f"{stage}-worker")
+
+    @classmethod
+    def source_scope(cls, source: str) -> ResetScope:
+        if not source or "/" in source:
+            raise ValueError(f"invalid source identifier: {source!r}")
+        return cls(level="source", source=source)
+
+    @classmethod
+    def full_scope(cls) -> ResetScope:
+        return cls(level="full")
+
+
+@dataclass
+class ResetReport:
+    """What a reset actually did. Saved into the audit log summary."""
+
+    level: str
+    s3_prefixes_deleted: list[str] = field(default_factory=list)
+    s3_objects_deleted: int = 0
+    kafka_topics_reset: list[str] = field(default_factory=list)
+    neo4j_rows_deleted: int = 0
+    pg_rows_deleted: int = 0
+    duration_seconds: float = 0.0
+
+    def to_summary(self) -> dict[str, Any]:
+        return {
+            "level": self.level,
+            "s3_prefixes_deleted": self.s3_prefixes_deleted,
+            "s3_objects_deleted": self.s3_objects_deleted,
+            "kafka_topics_reset": self.kafka_topics_reset,
+            "neo4j_rows_deleted": self.neo4j_rows_deleted,
+            "pg_rows_deleted": self.pg_rows_deleted,
+        }
+
+
+class PipelineResetter:
+    """Coordinates B2 / Kafka / Neo4j / PG resets and writes audit entries.
+
+    Dependencies are injected so tests can exercise full reset flows
+    against fakes — no AWS, Kafka, Neo4j, or Postgres required.
+    """
+
+    def __init__(
+        self,
+        *,
+        object_store: _ObjectStoreProto,
+        kafka_admin: KafkaAdmin,
+        neo4j: Neo4jResetter,
+        pg: PgResetter,
+        data_dir: Path,
+    ) -> None:
+        self.object_store = object_store
+        self.kafka_admin = kafka_admin
+        self.neo4j = neo4j
+        self.pg = pg
+        self.data_dir = data_dir
+
+    def reset(self, scope: ResetScope) -> tuple[ResetReport, AuditEntry, Path]:
+        """Execute a reset and persist an audit entry.
+
+        Returns the report, the audit entry, and the path where the
+        audit entry was written.
+        """
+        start = time.monotonic()
+
+        if scope.level == "stage":
+            report = self._reset_stage(scope)
+        elif scope.level == "source":
+            report = self._reset_source(scope)
+        elif scope.level == "full":
+            report = self._reset_full()
+        else:
+            raise ValueError(f"unknown reset level: {scope.level!r}")
+
+        report.duration_seconds = round(time.monotonic() - start, 3)
+
+        entry = create_audit_entry(
+            stage=f"reset-{scope.level}",
+            duration_seconds=report.duration_seconds,
+            rows_affected=report.neo4j_rows_deleted + report.pg_rows_deleted,
+            summary=report.to_summary(),
+        )
+        path = write_audit_entry(self.data_dir, entry)
+        return report, entry, path
+
+    def _reset_stage(self, scope: ResetScope) -> ResetReport:
+        """Wipe one B2 prefix + reset that stage's consumer group offsets."""
+        assert scope.stage is not None
+        prefix = STAGE_PREFIXES[scope.stage]
+        topic = STAGE_TOPICS.get(scope.stage)
+
+        deleted = _delete_prefix(self.object_store, prefix)
+
+        topics_reset: list[str] = []
+        if topic is not None and scope.consumer_group is not None:
+            self.kafka_admin.reset_consumer_offsets(topic, scope.consumer_group)
+            topics_reset.append(topic)
+
+        return ResetReport(
+            level="stage",
+            s3_prefixes_deleted=[prefix],
+            s3_objects_deleted=deleted,
+            kafka_topics_reset=topics_reset,
+        )
+
+    def _reset_source(self, scope: ResetScope) -> ResetReport:
+        """Wipe every stage prefix for one source."""
+        assert scope.source is not None
+        source_prefixes = [f"{p}{scope.source}/" for p in STAGE_PREFIXES.values()]
+
+        total_deleted = 0
+        for sp in source_prefixes:
+            total_deleted += _delete_prefix(self.object_store, sp)
+
+        return ResetReport(
+            level="source",
+            s3_prefixes_deleted=source_prefixes,
+            s3_objects_deleted=total_deleted,
+        )
+
+    def _reset_full(self) -> ResetReport:
+        """Wipe every pipeline prefix, reset every pipeline topic, truncate
+        Neo4j hadith graph and PG hadith metadata. Preserves user/auth data."""
+        prefixes = list(STAGE_PREFIXES.values())
+        total_deleted = 0
+        for prefix in prefixes:
+            total_deleted += _delete_prefix(self.object_store, prefix)
+
+        topics_reset: list[str] = []
+        for topic in ALL_PIPELINE_TOPICS:
+            self.kafka_admin.delete_topic_data(topic)
+            topics_reset.append(topic)
+
+        neo4j_rows = self.neo4j.truncate_hadith_graph()
+        pg_rows = self.pg.truncate_hadith_metadata()
+
+        return ResetReport(
+            level="full",
+            s3_prefixes_deleted=prefixes,
+            s3_objects_deleted=total_deleted,
+            kafka_topics_reset=topics_reset,
+            neo4j_rows_deleted=neo4j_rows,
+            pg_rows_deleted=pg_rows,
+        )
+
+
+def _delete_prefix(store: _ObjectStoreProto, prefix: S3Prefix) -> int:
+    """Delete every object under ``prefix`` in ``store.bucket``.
+
+    Returns the number of objects deleted. Uses the paginated ``list_objects_v2``
+    surface so very large prefixes don't blow past a single-response limit.
+    """
+    client = store.client
+    deleted = 0
+
+    continuation: str | None = None
+    while True:
+        kwargs: dict[str, Any] = {"Bucket": store.bucket, "Prefix": prefix}
+        if continuation is not None:
+            kwargs["ContinuationToken"] = continuation
+        response = client.list_objects_v2(**kwargs)
+        contents = response.get("Contents", []) or []
+        if contents:
+            to_delete = [{"Key": obj["Key"]} for obj in contents]
+            client.delete_objects(Bucket=store.bucket, Delete={"Objects": to_delete, "Quiet": True})
+            deleted += len(to_delete)
+        if not response.get("IsTruncated"):
+            break
+        continuation = response.get("NextContinuationToken")
+        if continuation is None:
+            break
+
+    return deleted

--- a/src/pipeline/reset_adapters.py
+++ b/src/pipeline/reset_adapters.py
@@ -1,0 +1,107 @@
+"""Concrete Kafka / Neo4j / PG adapters used by :mod:`src.pipeline.reset`.
+
+Split out from the resetter so the core logic has no hard dependency on
+kafka-python or neo4j during unit tests. The CLI wires these adapters
+in; tests substitute their own fakes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["KafkaPythonAdmin", "Neo4jHadithResetter", "PgHadithMetadataResetter"]
+
+# Tables that hold hadith metadata. User/auth tables are explicitly excluded.
+# If new hadith tables are added, extend this list — NEVER add user tables.
+HADITH_METADATA_TABLES: tuple[str, ...] = (
+    "hadiths",
+    "narrators",
+    "narrator_mentions",
+    "collections",
+    "gradings",
+    "parallel_links",
+)
+
+# Labels in Neo4j that hold hadith-graph data.
+HADITH_NODE_LABELS: tuple[str, ...] = (
+    "Hadith",
+    "Narrator",
+    "Chain",
+    "Collection",
+    "Grading",
+    "HistoricalEvent",
+    "Location",
+)
+
+
+class KafkaPythonAdmin:
+    """kafka-python adapter for :class:`src.pipeline.reset.KafkaAdmin`.
+
+    ``delete_topic_data`` does NOT delete the topic definition — just its
+    records — by advancing all consumer groups past the high-water mark
+    and relying on retention to clear storage. This preserves topic
+    config (partitions, retention, compaction) across resets.
+    """
+
+    def __init__(self, admin_client: Any) -> None:
+        self._admin = admin_client
+
+    def reset_consumer_offsets(self, topic: str, group_id: str) -> None:
+        # kafka-python exposes ``alter_consumer_group_offsets`` via the
+        # underlying KafkaAdminClient. We set each partition to offset 0
+        # for the given group, which re-runs consumption from the start.
+        from kafka.admin.client import OffsetAndMetadata  # type: ignore[import-untyped]
+
+        metadata = self._admin.describe_topics([topic])
+        partitions = metadata[0]["partitions"] if metadata else []
+        new_offsets = {(topic, p["partition"]): OffsetAndMetadata(0, "") for p in partitions}
+        self._admin.alter_consumer_group_offsets(group_id, new_offsets)
+
+    def delete_topic_data(self, topic: str) -> None:
+        # Prefer ``delete_records`` (admin-only, retains topic config).
+        self._admin.delete_records({topic: -1})
+
+
+class Neo4jHadithResetter:
+    """Neo4j driver adapter. Truncates only the hadith-graph labels."""
+
+    def __init__(self, driver: Any) -> None:
+        self._driver = driver
+
+    def truncate_hadith_graph(self) -> int:
+        total = 0
+        with self._driver.session() as session:
+            for label in HADITH_NODE_LABELS:
+                # MATCH (n:Label) DETACH DELETE n — returns count so we
+                # can aggregate into the audit entry.
+                result = session.run(
+                    f"MATCH (n:{label}) WITH n, 1 AS _ DETACH DELETE n RETURN count(_) AS c"
+                )
+                record = result.single()
+                if record is not None:
+                    total += int(record["c"])
+        return total
+
+
+class PgHadithMetadataResetter:
+    """Postgres adapter. Truncates hadith metadata tables only —
+    user/auth/RBAC tables are NEVER touched."""
+
+    def __init__(self, connection: Any) -> None:
+        self._conn = connection
+
+    def truncate_hadith_metadata(self) -> int:
+        total = 0
+        with self._conn.cursor() as cur:
+            for table in HADITH_METADATA_TABLES:
+                # COUNT before TRUNCATE so the audit entry reflects what
+                # was actually wiped. CASCADE handles FK constraints
+                # within the hadith-metadata set — user tables have no
+                # FK into these tables by design.
+                cur.execute(f"SELECT count(*) FROM {table}")
+                row = cur.fetchone()
+                if row is not None:
+                    total += int(row[0])
+                cur.execute(f"TRUNCATE TABLE {table} CASCADE")
+        self._conn.commit()
+        return total

--- a/tests/test_pipeline/test_reset.py
+++ b/tests/test_pipeline/test_reset.py
@@ -1,0 +1,308 @@
+"""Pipeline reset behaviour: stage, source, and full reset flows.
+
+All tests use in-memory fakes — no AWS, Kafka, Neo4j, or Postgres
+required. The core logic lives in ``src.pipeline.reset`` and is
+deliberately free of hard infra deps so this suite is cheap to run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.pipeline.reset import (
+    ALL_PIPELINE_TOPICS,
+    STAGE_PREFIXES,
+    STAGE_TOPICS,
+    PipelineResetter,
+    ResetScope,
+)
+
+
+class _FakeS3Client:
+    """In-memory S3 client supporting ``list_objects_v2`` + ``delete_objects``."""
+
+    def __init__(self, objects: dict[tuple[str, str], bytes] | None = None) -> None:
+        self.objects: dict[tuple[str, str], bytes] = dict(objects or {})
+
+    def list_objects_v2(
+        self, *, Bucket: str, Prefix: str, ContinuationToken: str | None = None
+    ) -> dict[str, Any]:
+        keys = sorted(k for (b, k) in self.objects if b == Bucket and k.startswith(Prefix))
+        return {
+            "Contents": [{"Key": k} for k in keys],
+            "IsTruncated": False,
+        }
+
+    def delete_objects(self, *, Bucket: str, Delete: dict[str, Any]) -> dict[str, Any]:
+        for obj in Delete["Objects"]:
+            self.objects.pop((Bucket, obj["Key"]), None)
+        return {"Deleted": Delete["Objects"]}
+
+
+class _FakeStore:
+    def __init__(self, bucket: str, client: _FakeS3Client) -> None:
+        self.bucket = bucket
+        self._client = client
+
+    @property
+    def client(self) -> _FakeS3Client:
+        return self._client
+
+
+class _FakeKafkaAdmin:
+    def __init__(self) -> None:
+        self.offset_resets: list[tuple[str, str]] = []
+        self.topic_data_deletions: list[str] = []
+
+    def reset_consumer_offsets(self, topic: str, group_id: str) -> None:
+        self.offset_resets.append((topic, group_id))
+
+    def delete_topic_data(self, topic: str) -> None:
+        self.topic_data_deletions.append(topic)
+
+
+class _FakeNeo4j:
+    def __init__(self, rows: int = 0) -> None:
+        self._rows = rows
+        self.called = 0
+
+    def truncate_hadith_graph(self) -> int:
+        self.called += 1
+        return self._rows
+
+
+class _FakePg:
+    def __init__(self, rows: int = 0) -> None:
+        self._rows = rows
+        self.called = 0
+
+    def truncate_hadith_metadata(self) -> int:
+        self.called += 1
+        return self._rows
+
+
+@pytest.fixture
+def bucket_name() -> str:
+    return "noorinalabs-pipeline"
+
+
+@pytest.fixture
+def seeded_store(bucket_name: str) -> _FakeStore:
+    """Populate every stage prefix with two objects per source (2 sources)."""
+    objects: dict[tuple[str, str], bytes] = {}
+    for prefix in STAGE_PREFIXES.values():
+        for source in ("sunnah-api", "thaqalayn"):
+            objects[(bucket_name, f"{prefix}{source}/b1/file.parquet")] = b"x"
+            objects[(bucket_name, f"{prefix}{source}/b2/file.parquet")] = b"x"
+    return _FakeStore(bucket=bucket_name, client=_FakeS3Client(objects))
+
+
+@pytest.fixture
+def resetter(seeded_store: _FakeStore, tmp_path: Path) -> PipelineResetter:
+    return PipelineResetter(
+        object_store=seeded_store,
+        kafka_admin=_FakeKafkaAdmin(),
+        neo4j=_FakeNeo4j(rows=123),
+        pg=_FakePg(rows=456),
+        data_dir=tmp_path,
+    )
+
+
+def test_stage_reset_wipes_one_prefix_and_resets_consumer_offsets(
+    seeded_store: _FakeStore, tmp_path: Path, bucket_name: str
+) -> None:
+    kafka_admin = _FakeKafkaAdmin()
+    r = PipelineResetter(
+        object_store=seeded_store,
+        kafka_admin=kafka_admin,
+        neo4j=_FakeNeo4j(),
+        pg=_FakePg(),
+        data_dir=tmp_path,
+    )
+
+    report, _entry, audit_path = r.reset(ResetScope.stage_scope("dedup"))
+
+    assert report.level == "stage"
+    assert report.s3_prefixes_deleted == ["dedup/"]
+    assert report.s3_objects_deleted == 4  # 2 sources × 2 batches
+    assert report.kafka_topics_reset == [STAGE_TOPICS["dedup"]]
+    assert kafka_admin.offset_resets == [(STAGE_TOPICS["dedup"], "dedup-worker")]
+
+    # Other prefixes untouched.
+    remaining_prefixes = {k.split("/", 1)[0] + "/" for (_b, k) in seeded_store._client.objects}
+    assert "dedup/" not in remaining_prefixes
+    assert "raw/" in remaining_prefixes
+    assert "enriched/" in remaining_prefixes
+
+    assert audit_path.exists()
+
+
+def test_source_reset_wipes_all_stages_for_one_source_only(
+    seeded_store: _FakeStore, tmp_path: Path, bucket_name: str
+) -> None:
+    r = PipelineResetter(
+        object_store=seeded_store,
+        kafka_admin=_FakeKafkaAdmin(),
+        neo4j=_FakeNeo4j(),
+        pg=_FakePg(),
+        data_dir=tmp_path,
+    )
+
+    report, _entry, _path = r.reset(ResetScope.source_scope("sunnah-api"))
+
+    assert report.level == "source"
+    # 5 stage prefixes × 2 batches = 10 objects for one source.
+    assert report.s3_objects_deleted == 10
+
+    remaining = seeded_store._client.objects
+    assert all("sunnah-api" not in key for (_b, key) in remaining)
+    # Other source untouched.
+    assert any("thaqalayn" in key for (_b, key) in remaining)
+
+
+def test_full_reset_wipes_everything_and_calls_neo4j_and_pg(
+    seeded_store: _FakeStore, tmp_path: Path
+) -> None:
+    kafka_admin = _FakeKafkaAdmin()
+    neo4j = _FakeNeo4j(rows=100)
+    pg = _FakePg(rows=200)
+
+    r = PipelineResetter(
+        object_store=seeded_store,
+        kafka_admin=kafka_admin,
+        neo4j=neo4j,
+        pg=pg,
+        data_dir=tmp_path,
+    )
+
+    report, _entry, audit_path = r.reset(ResetScope.full_scope())
+
+    assert report.level == "full"
+    assert report.s3_objects_deleted == 20  # 5 prefixes × 2 sources × 2 batches
+    assert set(report.kafka_topics_reset) == set(ALL_PIPELINE_TOPICS)
+    assert kafka_admin.topic_data_deletions == list(ALL_PIPELINE_TOPICS)
+    assert report.neo4j_rows_deleted == 100
+    assert report.pg_rows_deleted == 200
+    assert neo4j.called == 1
+    assert pg.called == 1
+
+    # Store is now empty.
+    assert seeded_store._client.objects == {}
+    # Audit entry was persisted.
+    audit_data = json.loads(audit_path.read_text())
+    assert audit_data["stage"] == "reset-full"
+    assert audit_data["summary"]["level"] == "full"
+    assert audit_data["summary"]["s3_objects_deleted"] == 20
+    assert audit_data["rows_affected"] == 300  # neo4j + pg counted in audit
+
+
+def test_audit_entry_is_written_per_reset(resetter: PipelineResetter, tmp_path: Path) -> None:
+    resetter.reset(ResetScope.stage_scope("raw"))
+    resetter.reset(ResetScope.stage_scope("dedup"))
+
+    entries = sorted((tmp_path / "audit").glob("*.json"))
+    assert len(entries) == 2
+
+    stages = sorted(json.loads(p.read_text())["stage"] for p in entries)
+    assert stages == ["reset-stage", "reset-stage"]
+
+
+def test_stage_scope_rejects_unknown_stage() -> None:
+    with pytest.raises(ValueError, match="unknown stage"):
+        ResetScope.stage_scope("bogus")
+
+
+def test_source_scope_rejects_empty_or_slashed() -> None:
+    with pytest.raises(ValueError):
+        ResetScope.source_scope("")
+    with pytest.raises(ValueError):
+        ResetScope.source_scope("evil/../path")
+
+
+def test_full_reset_does_not_touch_user_tables_by_contract() -> None:
+    """Guard test — the adapters module must never list user tables.
+
+    Failure of this test would mean someone added a user table to the
+    hadith truncate list and needs to revert that change.
+    """
+    from src.pipeline.reset_adapters import HADITH_METADATA_TABLES
+
+    forbidden = {"users", "roles", "user_roles", "sessions", "subscriptions"}
+    overlap = set(HADITH_METADATA_TABLES) & forbidden
+    assert overlap == set(), f"user tables leaked into hadith truncate list: {overlap}"
+
+
+def test_stage_reset_with_custom_consumer_group(seeded_store: _FakeStore, tmp_path: Path) -> None:
+    kafka_admin = _FakeKafkaAdmin()
+    r = PipelineResetter(
+        object_store=seeded_store,
+        kafka_admin=kafka_admin,
+        neo4j=_FakeNeo4j(),
+        pg=_FakePg(),
+        data_dir=tmp_path,
+    )
+
+    r.reset(ResetScope.stage_scope("enriched", consumer_group="custom-group"))
+
+    assert kafka_admin.offset_resets == [(STAGE_TOPICS["enriched"], "custom-group")]
+
+
+def test_duration_is_recorded_in_report_and_audit(
+    resetter: PipelineResetter, tmp_path: Path
+) -> None:
+    report, entry, path = resetter.reset(ResetScope.stage_scope("raw"))
+
+    assert report.duration_seconds >= 0.0
+    assert entry.duration_seconds == report.duration_seconds
+
+    audit_data = json.loads(path.read_text())
+    assert audit_data["duration_seconds"] == report.duration_seconds
+
+
+def test_paginated_s3_deletion(bucket_name: str, tmp_path: Path) -> None:
+    """Resetter must handle truncated list_objects_v2 responses."""
+
+    class _PagingClient(_FakeS3Client):
+        """Paginates the initial snapshot across two pages regardless of deletions
+        that happen between the two list calls. Models real S3 list-then-delete."""
+
+        def __init__(self, objects: dict[tuple[str, str], bytes]) -> None:
+            super().__init__(objects)
+            self._snapshot: list[str] | None = None
+
+        def list_objects_v2(
+            self, *, Bucket: str, Prefix: str, ContinuationToken: str | None = None
+        ) -> dict[str, Any]:
+            if ContinuationToken is None:
+                self._snapshot = sorted(
+                    k for (b, k) in self.objects if b == Bucket and k.startswith(Prefix)
+                )
+                return {
+                    "Contents": [{"Key": k} for k in self._snapshot[:1]],
+                    "IsTruncated": True,
+                    "NextContinuationToken": "tok",
+                }
+            assert self._snapshot is not None
+            return {
+                "Contents": [{"Key": k} for k in self._snapshot[1:]],
+                "IsTruncated": False,
+            }
+
+    objects = {(bucket_name, f"raw/sunnah-api/b1/{i}.parquet"): b"x" for i in range(3)}
+    store = _FakeStore(bucket=bucket_name, client=_PagingClient(objects))
+    r = PipelineResetter(
+        object_store=store,
+        kafka_admin=_FakeKafkaAdmin(),
+        neo4j=_FakeNeo4j(),
+        pg=_FakePg(),
+        data_dir=tmp_path,
+    )
+
+    report, _entry, _path = r.reset(ResetScope.stage_scope("raw"))
+
+    assert report.s3_objects_deleted == 3
+    assert store._client.objects == {}


### PR DESCRIPTION
## Summary
Implements [noorinalabs/noorinalabs-main#108](https://github.com/noorinalabs/noorinalabs-main/issues/108) — the CLI half. Three reset scopes wired into `isnad-ingest reset`, each emitting an audit entry via the existing `src/pipeline/audit.py` module.

- `isnad-ingest reset --stage {raw|dedup|enriched|normalized|staged}` — wipes one B2 prefix + resets that stage's Kafka consumer-group offsets so the stage can be re-run
- `isnad-ingest reset --source {source-id}` — wipes every stage prefix for one data source (re-acquire from scratch)
- `isnad-ingest reset --all` — wipes every pipeline B2 prefix, clears every pipeline Kafka topic's records (topic *definitions* preserved), truncates Neo4j hadith graph labels, truncates PG hadith metadata tables. **Never** touches users / roles / user_roles / sessions / subscriptions.

Supporting flags: `--yes` (skip the interactive `OBLITERATE` confirmation for `--all`), `--dry-run` (validate scope without touching anything).

## Architecture
- `src/pipeline/reset.py` — pure coordination layer. Adapters injected via `Protocol`s (`KafkaAdmin`, `Neo4jResetter`, `PgResetter`, `_ObjectStoreProto`) so the tests drive the full flow with in-memory fakes.
- `src/pipeline/reset_adapters.py` — concrete `kafka-python` / `neo4j` / `psycopg` adapters. `HADITH_METADATA_TABLES` and `HADITH_NODE_LABELS` are hardcoded allow-lists so user tables can never leak into a truncate path. A guard test asserts this invariant.
- `src/cli.py` — new `reset` subparser with mutually-exclusive mode flags + confirmation prompt.

## Verification
- 10/10 new unit tests passing (no Kafka / S3 / Neo4j / PG required — all fakes)
- 7/7 existing `test_audit.py` still passing
- `ruff check` + `ruff format --check` clean
- CLI validated: `isnad-ingest reset --help` prints mutually-exclusive groups correctly

## Scope note — CLI-only PR
Issue #108 also calls for "Admin dashboard buttons for each reset level (with confirmation modal)" and references "#109 (Admin dashboard data management)". The referenced #109 issue **does not currently exist in the tracker** (it was renumbered to the CI-merge-block hook). This PR delivers the CLI + audit log half; the admin UI buttons should be a separate PR landing once an admin-dashboard data-management issue is filed or re-filed. Flagging this for Program Director.

## TechDebt attestation
- **Admin dashboard UI buttons deferred** — awaits the referenced (missing) admin-dashboard issue.
- **No HTTP endpoint** — reset is CLI-only. If admin dashboard needs to invoke reset, it will either call a new endpoint (follow-up) or shell-exec the CLI (not recommended).
- **Consumer-group offset reset** uses `OffsetAndMetadata(0)` for every partition — benign idempotent rewind, but does not distinguish between "never consumed" and "partition empty".
- **PG COUNT + TRUNCATE race** — audit count is read just before truncate, so writes arriving in between would be under-counted. Acceptable for admin-initiated resets where the caller stops producers first; noted for future hardening (table lock or atomic `TRUNCATE ... RETURNING` equivalent).

## Disabled CI jobs
None.

## Review
Review requested (2-reviewer charter): @Santiago Ferreira (release coordinator — infra touchpoints) and @Nurul Hakim (per team-lead assignment).

---
Part of noorinalabs/noorinalabs-main#108

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>