### PR TITLE
feat(ingest-worker): open Neo4j session, MERGE on stable ID, retryable transactions (#13)

### DIFF
--- a/tests/workers/test_ingest_neo4j.py
+++ b/tests/workers/test_ingest_neo4j.py
@@ -1,0 +1,324 @@
+"""Unit tests for the Neo4j-backed ingest processor (issue #13).
+
+The tests mock the neo4j driver/session so the suite runs without
+Docker or a live database. Integration coverage against a real Neo4j
+(testcontainers) is tracked separately in issue #136.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from tests.workers.conftest import FakeConsumer, FakeProducer
+from workers.ingest.processor import (
+    IngestProcessor,
+    UnknownSchemaError,
+    _merge_node_tx,
+)
+from workers.lib.dlq import DLQ_TOPIC
+from workers.lib.message import PipelineMessage, serialize_message
+from workers.lib.object_store import ObjectStore
+from workers.lib.runner import WorkerRunner, WorkerSettings
+
+# ---------------------------------------------------------------------------
+# Neo4j driver fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, record: dict[str, Any] | None) -> None:
+        self._record = record
+
+    def single(self) -> dict[str, Any] | None:
+        return self._record
+
+
+class _FakeTx:
+    def __init__(self, sink: list[tuple[str, dict[str, Any]]]) -> None:
+        self._sink = sink
+
+    def run(self, query: str, **params: Any) -> _FakeResult:
+        self._sink.append((query, params))
+        rows = params.get("rows") or []
+        return _FakeResult({"merged": len(rows)})
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        sink: list[tuple[str, dict[str, Any]]],
+        *,
+        raise_on_execute: Exception | None = None,
+    ) -> None:
+        self._sink = sink
+        self._raise = raise_on_execute
+
+    def __enter__(self) -> _FakeSession:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def execute_write(self, fn: Any, **kwargs: Any) -> Any:
+        if self._raise is not None:
+            err = self._raise
+            self._raise = None  # one-shot: subsequent calls succeed
+            raise err
+        tx = _FakeTx(self._sink)
+        return fn(tx, **kwargs)
+
+
+class _FakeDriver:
+    def __init__(self, *, session_factories: list[_FakeSession] | None = None) -> None:
+        self.sink: list[tuple[str, dict[str, Any]]] = []
+        self.closed = False
+        self._factories = session_factories or []
+        self._next_factory = 0
+
+    def session(self) -> _FakeSession:
+        if self._factories:
+            if self._next_factory >= len(self._factories):
+                msg = "No more fake sessions configured"
+                raise AssertionError(msg)
+            sess = self._factories[self._next_factory]
+            self._next_factory += 1
+            sess._sink = self.sink  # share recording sink
+            return sess
+        return _FakeSession(self.sink)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+# ---------------------------------------------------------------------------
+# Parquet payload helpers
+# ---------------------------------------------------------------------------
+
+
+def _parquet_bytes(rows: list[dict[str, Any]]) -> bytes:
+    if not rows:
+        table = pa.table({"label": [], "id": []})
+    else:
+        columns: dict[str, list[Any]] = {}
+        for row in rows:
+            for k, v in row.items():
+                columns.setdefault(k, [])
+        for row in rows:
+            for k in columns:
+                columns[k].append(row.get(k))
+        table = pa.table(columns)
+    buf = io.BytesIO()
+    pq.write_table(table, buf)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# _merge_node_tx — Cypher shape
+# ---------------------------------------------------------------------------
+
+
+def test_merge_node_tx_emits_parameterized_merge() -> None:
+    sink: list[tuple[str, dict[str, Any]]] = []
+    tx = _FakeTx(sink)
+    rows = [
+        {"id": "nar:ibn-abbas", "props": {"name_en": "Ibn Abbas"}},
+        {"id": "nar:abu-hurayra", "props": {"name_en": "Abu Hurayra"}},
+    ]
+
+    count = _merge_node_tx(tx, label="Narrator", rows=rows)
+
+    assert count == 2
+    assert len(sink) == 1
+    query, params = sink[0]
+    assert "MERGE (n:`Narrator` {id: row.id})" in query
+    assert "SET n += row.props" in query
+    assert params["rows"] == rows
+
+
+# ---------------------------------------------------------------------------
+# IngestProcessor — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_opens_session_and_merges_by_label(
+    object_store: ObjectStore, sample_message: PipelineMessage
+) -> None:
+    payload = _parquet_bytes(
+        [
+            {"label": "Narrator", "id": "nar:a", "name_en": "A"},
+            {"label": "Narrator", "id": "nar:b", "name_en": "B"},
+            {"label": "Hadith", "id": "hdt:1", "matn_ar": "..."},
+        ]
+    )
+    object_store.put_object(sample_message.b2_path, payload)
+    driver = _FakeDriver()
+
+    result = IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+
+    assert result is None  # terminal stage
+    # One MERGE statement per distinct label → 2 tx.run calls
+    assert len(driver.sink) == 2
+    queries = [q for q, _ in driver.sink]
+    assert any("MERGE (n:`Narrator` {id: row.id})" in q for q in queries)
+    assert any("MERGE (n:`Hadith` {id: row.id})" in q for q in queries)
+    # Narrator batch carries both rows with props stripped of label/id
+    narrator_batch = next(params["rows"] for q, params in driver.sink if "Narrator" in q)
+    assert {r["id"] for r in narrator_batch} == {"nar:a", "nar:b"}
+    for row in narrator_batch:
+        assert "label" not in row["props"]
+        assert "id" not in row["props"]
+
+
+def test_ingest_empty_parquet_is_noop(
+    object_store: ObjectStore, sample_message: PipelineMessage
+) -> None:
+    object_store.put_object(sample_message.b2_path, _parquet_bytes([]))
+    driver = _FakeDriver()
+
+    IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+
+    assert driver.sink == []
+
+
+def test_ingest_without_driver_is_readonly(
+    object_store: ObjectStore, sample_message: PipelineMessage
+) -> None:
+    """Unit-suite ergonomics: no driver → read payload, skip write."""
+    object_store.put_object(sample_message.b2_path, _parquet_bytes([]))
+
+    # No assertion on Neo4j; absence of exception is the contract.
+    IngestProcessor(object_store, neo4j_driver=None)(sample_message)
+
+
+# ---------------------------------------------------------------------------
+# IngestProcessor — error taxonomy
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_unknown_label_raises_schema_error(
+    object_store: ObjectStore, sample_message: PipelineMessage
+) -> None:
+    payload = _parquet_bytes([{"label": "Evil", "id": "x:1"}])
+    object_store.put_object(sample_message.b2_path, payload)
+    driver = _FakeDriver()
+
+    with pytest.raises(UnknownSchemaError, match="unknown label"):
+        IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+
+    assert driver.sink == []  # no Neo4j call attempted
+
+
+def test_ingest_missing_id_raises_schema_error(
+    object_store: ObjectStore, sample_message: PipelineMessage
+) -> None:
+    payload = _parquet_bytes([{"label": "Narrator", "id": None}])
+    object_store.put_object(sample_message.b2_path, payload)
+    driver = _FakeDriver()
+
+    with pytest.raises(UnknownSchemaError, match="'id'"):
+        IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+
+
+def test_ingest_retries_once_on_session_expired(
+    object_store: ObjectStore, sample_message: PipelineMessage
+) -> None:
+    from neo4j.exceptions import SessionExpired
+
+    payload = _parquet_bytes([{"label": "Narrator", "id": "nar:a", "name_en": "A"}])
+    object_store.put_object(sample_message.b2_path, payload)
+    # First session raises SessionExpired on execute_write; second succeeds.
+    first = _FakeSession([], raise_on_execute=SessionExpired("token expired"))
+    second = _FakeSession([])
+    driver = _FakeDriver(session_factories=[first, second])
+
+    IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+
+    # Reopened — one successful tx.run on the second session
+    assert len(driver.sink) == 1
+    assert driver._next_factory == 2
+
+
+def test_ingest_client_error_propagates_for_dlq(
+    object_store: ObjectStore, sample_message: PipelineMessage
+) -> None:
+    """Cypher/constraint errors must propagate so the runner DLQs them."""
+    from neo4j.exceptions import ClientError
+
+    payload = _parquet_bytes([{"label": "Narrator", "id": "nar:a", "name_en": "A"}])
+    object_store.put_object(sample_message.b2_path, payload)
+    sess = _FakeSession([], raise_on_execute=ClientError("constraint violated"))
+    driver = _FakeDriver(session_factories=[sess])
+
+    with pytest.raises(ClientError):
+        IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — DLQ routing on Neo4j failures
+# ---------------------------------------------------------------------------
+
+
+def test_runner_routes_client_error_to_dlq(
+    object_store: ObjectStore, sample_message: PipelineMessage
+) -> None:
+    from neo4j.exceptions import ClientError
+
+    payload = _parquet_bytes([{"label": "Narrator", "id": "nar:a", "name_en": "A"}])
+    object_store.put_object(sample_message.b2_path, payload)
+    sess = _FakeSession([], raise_on_execute=ClientError("bad query"))
+    driver = _FakeDriver(session_factories=[sess])
+    producer = FakeProducer()
+
+    runner = WorkerRunner(
+        settings=WorkerSettings(
+            worker_name="ingest-worker",
+            consume_topic="pipeline.norm.done",
+            produce_topic=None,
+            consumer_group="ingest-worker",
+        ),
+        consumer=FakeConsumer([]),
+        producer=producer,
+        process=IngestProcessor(object_store, neo4j_driver=driver),
+    )
+    runner.handle_one(serialize_message(sample_message))
+
+    assert len(producer.sent) == 1
+    topic, value = producer.sent[0]
+    assert topic == DLQ_TOPIC
+    record = json.loads(value)
+    assert record["error_class"] == "ClientError"
+
+
+def test_runner_routes_schema_error_to_dlq(
+    object_store: ObjectStore, sample_message: PipelineMessage
+) -> None:
+    payload = _parquet_bytes([{"label": "BadLabel", "id": "x:1"}])
+    object_store.put_object(sample_message.b2_path, payload)
+    driver = _FakeDriver()
+    producer = FakeProducer()
+
+    runner = WorkerRunner(
+        settings=WorkerSettings(
+            worker_name="ingest-worker",
+            consume_topic="pipeline.norm.done",
+            produce_topic=None,
+            consumer_group="ingest-worker",
+        ),
+        consumer=FakeConsumer([]),
+        producer=producer,
+        process=IngestProcessor(object_store, neo4j_driver=driver),
+    )
+    runner.handle_one(serialize_message(sample_message))
+
+    assert len(producer.sent) == 1
+    topic, value = producer.sent[0]
+    assert topic == DLQ_TOPIC
+    record = json.loads(value)
+    assert record["error_class"] == "UnknownSchemaError"
+    assert driver.sink == []

--- a/tests/workers/test_ingest_neo4j.py
+++ b/tests/workers/test_ingest_neo4j.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Neo4j-backed ingest processor (issue #13).
+"""Unit tests for the Neo4j-backed ingest processor (issues #13, #18, #192 D-ii).
 
 The tests mock the neo4j driver/session so the suite runs without
 Docker or a live database. Integration coverage against a real Neo4j
@@ -18,16 +18,20 @@ import pytest
 from tests.workers.conftest import FakeConsumer, FakeProducer
 from workers.ingest.processor import (
     IngestProcessor,
+    ManifestMissingError,
     UnknownSchemaError,
-    _merge_node_tx,
+    _build_edge_cypher,
+    _build_node_cypher,
 )
+from workers.ingest.schema import NODE_PROPERTY_MAP
 from workers.lib.dlq import DLQ_TOPIC
 from workers.lib.message import PipelineMessage, serialize_message
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
+from workers.lib.topics import PIPELINE_NORMALIZE_DONE
 
 # ---------------------------------------------------------------------------
-# Neo4j driver fakes
+# Neo4j driver fakes — capture every tx.run call in order
 # ---------------------------------------------------------------------------
 
 
@@ -97,180 +101,493 @@ class _FakeDriver:
 
 
 # ---------------------------------------------------------------------------
-# Parquet payload helpers
+# D-ii fixture helpers — write a folder-prefix manifest with per-label Parquets
 # ---------------------------------------------------------------------------
 
+_NODE_SCHEMA = pa.schema(
+    [
+        pa.field("label", pa.string(), nullable=False),
+        pa.field("id", pa.string(), nullable=False),
+        pa.field("props", pa.string(), nullable=False),
+    ]
+)
 
-def _parquet_bytes(rows: list[dict[str, Any]]) -> bytes:
+_EDGE_SCHEMA = pa.schema(
+    [
+        pa.field("label", pa.string(), nullable=False),
+        pa.field("src_id", pa.string(), nullable=False),
+        pa.field("src_label", pa.string(), nullable=False),
+        pa.field("dst_id", pa.string(), nullable=False),
+        pa.field("dst_label", pa.string(), nullable=False),
+        pa.field("props", pa.string(), nullable=False),
+    ]
+)
+
+
+def _node_parquet(label: str, rows: list[dict[str, Any]]) -> bytes:
+    """Build a per-label nodes parquet matching normalize's output shape."""
     if not rows:
-        table = pa.table({"label": [], "id": []})
+        table = _NODE_SCHEMA.empty_table()
     else:
-        columns: dict[str, list[Any]] = {}
-        for row in rows:
-            for k, v in row.items():
-                columns.setdefault(k, [])
-        for row in rows:
-            for k in columns:
-                columns[k].append(row.get(k))
-        table = pa.table(columns)
+        table = pa.table(
+            {
+                "label": [label] * len(rows),
+                "id": [r["id"] for r in rows],
+                "props": [json.dumps(r.get("props", {}), ensure_ascii=False) for r in rows],
+            },
+            schema=_NODE_SCHEMA,
+        )
     buf = io.BytesIO()
     pq.write_table(table, buf)
     return buf.getvalue()
 
 
-# ---------------------------------------------------------------------------
-# _merge_node_tx — Cypher shape
-# ---------------------------------------------------------------------------
+def _edges_parquet(rows: list[dict[str, Any]]) -> bytes:
+    if not rows:
+        table = _EDGE_SCHEMA.empty_table()
+    else:
+        table = pa.table(
+            {
+                "label": [r["label"] for r in rows],
+                "src_id": [r["src_id"] for r in rows],
+                "src_label": [r["src_label"] for r in rows],
+                "dst_id": [r["dst_id"] for r in rows],
+                "dst_label": [r["dst_label"] for r in rows],
+                "props": [json.dumps(r.get("props", {}), ensure_ascii=False) for r in rows],
+            },
+            schema=_EDGE_SCHEMA,
+        )
+    buf = io.BytesIO()
+    pq.write_table(table, buf)
+    return buf.getvalue()
 
 
-def test_merge_node_tx_emits_parameterized_merge() -> None:
-    sink: list[tuple[str, dict[str, Any]]] = []
-    tx = _FakeTx(sink)
-    rows = [
-        {"id": "nar:ibn-abbas", "props": {"name_en": "Ibn Abbas"}},
-        {"id": "nar:abu-hurayra", "props": {"name_en": "Abu Hurayra"}},
-    ]
-
-    count = _merge_node_tx(tx, label="Narrator", rows=rows)
-
-    assert count == 2
-    assert len(sink) == 1
-    query, params = sink[0]
-    assert "MERGE (n:`Narrator` {id: row.id})" in query
-    assert "SET n += row.props" in query
-    assert params["rows"] == rows
-
-
-# ---------------------------------------------------------------------------
-# IngestProcessor — happy path
-# ---------------------------------------------------------------------------
-
-
-def test_ingest_opens_session_and_merges_by_label(
-    object_store: ObjectStore, sample_message: PipelineMessage
+def _write_batch(
+    store: ObjectStore,
+    prefix: str,
+    *,
+    nodes: dict[str, list[dict[str, Any]]] | None = None,
+    edges: list[dict[str, Any]] | None = None,
+    extra_manifest_entries: list[dict[str, Any]] | None = None,
+    skip_keys: set[str] | None = None,
+    skip_manifest: bool = False,
 ) -> None:
-    payload = _parquet_bytes(
-        [
-            {"label": "Narrator", "id": "nar:a", "name_en": "A"},
-            {"label": "Narrator", "id": "nar:b", "name_en": "B"},
-            {"label": "Hadith", "id": "hdt:1", "matn_ar": "..."},
-        ]
+    """Write a D-ii-shaped batch to the fake object store.
+
+    ``skip_keys`` names files listed in the manifest that should NOT be
+    written (used to simulate a missing Parquet). ``skip_manifest``
+    simulates an absent manifest.
+    """
+    nodes = nodes or {}
+    edges = edges or []
+    skip_keys = skip_keys or set()
+
+    manifest_entries: list[dict[str, Any]] = []
+    total = 0
+    for label, rows in nodes.items():
+        filename = f"{label.lower()}s.parquet"
+        key = f"{prefix}{filename}"
+        if key not in skip_keys:
+            store.put_object(key, _node_parquet(label, rows))
+        manifest_entries.append({"path": filename, "label": label, "row_count": len(rows)})
+        total += len(rows)
+
+    edges_key = f"{prefix}edges.parquet"
+    if edges_key not in skip_keys:
+        store.put_object(edges_key, _edges_parquet(edges))
+    manifest_entries.append({"path": "edges.parquet", "row_count": len(edges)})
+    total += len(edges)
+
+    if extra_manifest_entries:
+        manifest_entries.extend(extra_manifest_entries)
+
+    if not skip_manifest:
+        manifest = {
+            "batch_id": "batch-001",
+            "source": "sunnah-api",
+            "created_at": "2026-04-21T00:00:00+00:00",
+            "parquets": manifest_entries,
+            "total_row_count": total,
+        }
+        store.put_object(f"{prefix}_MANIFEST.json", json.dumps(manifest).encode("utf-8"))
+
+
+@pytest.fixture
+def folder_prefix_message() -> PipelineMessage:
+    """D-ii message: ``b2_path`` is a folder prefix with trailing slash."""
+    return PipelineMessage(
+        batch_id="batch-001",
+        source="sunnah-api",
+        b2_path="normalized/batch-001/",
+        record_count=0,  # total_row_count is carried in the manifest
     )
-    object_store.put_object(sample_message.b2_path, payload)
-    driver = _FakeDriver()
-
-    result = IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
-
-    assert result is None  # terminal stage
-    # One MERGE statement per distinct label → 2 tx.run calls
-    assert len(driver.sink) == 2
-    queries = [q for q, _ in driver.sink]
-    assert any("MERGE (n:`Narrator` {id: row.id})" in q for q in queries)
-    assert any("MERGE (n:`Hadith` {id: row.id})" in q for q in queries)
-    # Narrator batch carries both rows with props stripped of label/id
-    narrator_batch = next(params["rows"] for q, params in driver.sink if "Narrator" in q)
-    assert {r["id"] for r in narrator_batch} == {"nar:a", "nar:b"}
-    for row in narrator_batch:
-        assert "label" not in row["props"]
-        assert "id" not in row["props"]
 
 
-def test_ingest_empty_parquet_is_noop(
-    object_store: ObjectStore, sample_message: PipelineMessage
+# ---------------------------------------------------------------------------
+# Cypher builder — per-field SET shape
+# ---------------------------------------------------------------------------
+
+
+def test_node_cypher_uses_per_field_set_not_plus_equals() -> None:
+    """Phase-4 safety: no ``SET n += row.props`` anywhere."""
+    query = _build_node_cypher("Hadith")
+    assert "SET n += row.props" not in query
+    assert "MERGE (n:`Hadith` {id: row.id})" in query
+    # Every allow-listed field appears as a coalesce-guarded SET stanza
+    # so a row that omits the field does not wipe an existing value.
+    for field in NODE_PROPERTY_MAP["Hadith"]:
+        assert f"n.{field} = coalesce(row.props.{field}, n.{field})" in query
+
+
+def test_node_cypher_for_empty_allowlist_has_no_set() -> None:
+    """A label with no allow-listed props still MERGEs on id, no SET."""
+
+    # All current labels have at least one field, so we test via a
+    # fabricated label instead by temporarily referencing the builder's
+    # fallback path through a label that returns [] from the map.
+    # _build_node_cypher uses .get(label, []) so an absent label maps to [].
+    query = _build_node_cypher("__NonexistentForTest__")
+    assert "MERGE" in query
+    assert "SET" not in query
+
+
+def test_edge_cypher_matches_endpoints_then_merges() -> None:
+    query = _build_edge_cypher("TRANSMITTED_TO")
+    assert "MATCH (s {id: row.src_id})" in query
+    assert "MATCH (t {id: row.dst_id})" in query
+    assert "MERGE (s)-[r:`TRANSMITTED_TO`]->(t)" in query
+    assert (
+        "r.position_in_chain = coalesce(row.props.position_in_chain, r.position_in_chain)" in query
+    )
+    assert "SET r += row.props" not in query
+
+
+# ---------------------------------------------------------------------------
+# Happy path — manifest-gated MERGE
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_reads_manifest_and_merges_nodes_then_edges(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
 ) -> None:
-    object_store.put_object(sample_message.b2_path, _parquet_bytes([]))
+    prefix = folder_prefix_message.b2_path
+    _write_batch(
+        object_store,
+        prefix,
+        nodes={
+            "Narrator": [
+                {"id": "nar:a", "props": {"name_en": "A"}},
+                {"id": "nar:b", "props": {"name_en": "B"}},
+            ],
+            "Hadith": [{"id": "hdt:1", "props": {"matn_ar": "..."}}],
+            "Collection": [{"id": "col:bukhari", "props": {"name_en": "Bukhari"}}],
+        },
+        edges=[
+            {
+                "label": "TRANSMITTED_TO",
+                "src_id": "nar:a",
+                "src_label": "Narrator",
+                "dst_id": "nar:b",
+                "dst_label": "Narrator",
+                "props": {"position_in_chain": 0},
+            },
+            {
+                "label": "APPEARS_IN",
+                "src_id": "hdt:1",
+                "src_label": "Hadith",
+                "dst_id": "col:bukhari",
+                "dst_label": "Collection",
+                "props": {"book_number": 1},
+            },
+        ],
+    )
     driver = _FakeDriver()
 
-    IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+    IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+
+    # 3 node labels + 2 edge labels = 5 tx.run calls
+    assert len(driver.sink) == 5
+    queries = [q for q, _ in driver.sink]
+    node_idx = {
+        label: next(i for i, q in enumerate(queries) if f"MERGE (n:`{label}`" in q)
+        for label in ("Narrator", "Hadith", "Collection")
+    }
+    edge_idx = {
+        label: next(i for i, q in enumerate(queries) if f"MERGE (s)-[r:`{label}`]" in q)
+        for label in ("TRANSMITTED_TO", "APPEARS_IN")
+    }
+    # Ordering contract: every edge MERGE comes after every node MERGE
+    assert max(node_idx.values()) < min(edge_idx.values())
+
+
+def test_ingest_empty_batch_is_noop(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    _write_batch(object_store, folder_prefix_message.b2_path, nodes={}, edges=[])
+    driver = _FakeDriver()
+
+    IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
 
     assert driver.sink == []
 
 
 def test_ingest_without_driver_is_readonly(
-    object_store: ObjectStore, sample_message: PipelineMessage
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
 ) -> None:
-    """Unit-suite ergonomics: no driver → read payload, skip write."""
-    object_store.put_object(sample_message.b2_path, _parquet_bytes([]))
+    """Read-path ergonomics: no driver → parse manifest + parquets, skip write."""
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Hadith": [{"id": "hdt:1", "props": {"matn_ar": "..."}}]},
+    )
 
     # No assertion on Neo4j; absence of exception is the contract.
-    IngestProcessor(object_store, neo4j_driver=None)(sample_message)
+    IngestProcessor(object_store, neo4j_driver=None)(folder_prefix_message)
+
+
+def test_ingest_normalizes_prefix_without_trailing_slash(
+    object_store: ObjectStore,
+) -> None:
+    """A defensive callsite may strip the trailing slash — ingest restores it."""
+    msg = PipelineMessage(
+        batch_id="batch-001",
+        source="sunnah-api",
+        b2_path="normalized/batch-001",  # note: no trailing slash
+        record_count=0,
+    )
+    _write_batch(
+        object_store,
+        "normalized/batch-001/",
+        nodes={"Hadith": [{"id": "hdt:1", "props": {"matn_ar": "x"}}]},
+    )
+    driver = _FakeDriver()
+
+    IngestProcessor(object_store, neo4j_driver=driver)(msg)
+
+    assert len(driver.sink) == 1  # one MERGE for Hadith
 
 
 # ---------------------------------------------------------------------------
-# IngestProcessor — error taxonomy
+# Manifest gating — error taxonomy
 # ---------------------------------------------------------------------------
 
 
-def test_ingest_unknown_label_raises_schema_error(
-    object_store: ObjectStore, sample_message: PipelineMessage
+def test_missing_manifest_raises_manifest_missing_error(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
 ) -> None:
-    payload = _parquet_bytes([{"label": "Evil", "id": "x:1"}])
-    object_store.put_object(sample_message.b2_path, payload)
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Hadith": [{"id": "hdt:1", "props": {}}]},
+        skip_manifest=True,
+    )
     driver = _FakeDriver()
 
-    with pytest.raises(UnknownSchemaError, match="unknown label"):
-        IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+    with pytest.raises(ManifestMissingError):
+        IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+    # ManifestMissingError is a subclass of UnknownSchemaError so the
+    # runner's existing schema-error branch DLQs it.
+    assert driver.sink == []
 
-    assert driver.sink == []  # no Neo4j call attempted
 
-
-def test_ingest_missing_id_raises_schema_error(
-    object_store: ObjectStore, sample_message: PipelineMessage
+def test_malformed_manifest_raises_manifest_missing_error(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
 ) -> None:
-    payload = _parquet_bytes([{"label": "Narrator", "id": None}])
-    object_store.put_object(sample_message.b2_path, payload)
+    object_store.put_object(
+        f"{folder_prefix_message.b2_path}_MANIFEST.json",
+        b"this is not valid json",
+    )
+
+    with pytest.raises(ManifestMissingError, match="not valid JSON"):
+        IngestProcessor(object_store, neo4j_driver=_FakeDriver())(folder_prefix_message)
+
+
+def test_missing_expected_parquet_raises_schema_error(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    prefix = folder_prefix_message.b2_path
+    _write_batch(
+        object_store,
+        prefix,
+        nodes={"Hadith": [{"id": "hdt:1", "props": {"matn_ar": "..."}}]},
+        skip_keys={f"{prefix}hadiths.parquet"},
+    )
     driver = _FakeDriver()
 
-    with pytest.raises(UnknownSchemaError, match="'id'"):
-        IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+    with pytest.raises(UnknownSchemaError, match="Hadith parquet"):
+        IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+    assert driver.sink == []
+
+
+def test_unknown_label_in_manifest_raises_schema_error(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={},
+        extra_manifest_entries=[{"path": "evil.parquet", "label": "Evil", "row_count": 0}],
+    )
+
+    with pytest.raises(UnknownSchemaError, match="unknown node label"):
+        IngestProcessor(object_store, neo4j_driver=_FakeDriver())(folder_prefix_message)
+
+
+def test_unknown_edge_label_in_batch_raises_schema_error(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Hadith": [{"id": "hdt:1", "props": {}}]},
+        edges=[
+            {
+                "label": "SUBVERT_GRAPH",
+                "src_id": "hdt:1",
+                "src_label": "Hadith",
+                "dst_id": "hdt:1",
+                "dst_label": "Hadith",
+                "props": {},
+            }
+        ],
+    )
+    driver = _FakeDriver()
+
+    with pytest.raises(UnknownSchemaError, match="unknown label 'SUBVERT_GRAPH'"):
+        IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+    assert driver.sink == []  # schema error surfaced before Neo4j
+
+
+# ---------------------------------------------------------------------------
+# Phase-4 safety — per-field SET semantics
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_sets_only_fields_present_in_row_props(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    """A row that omits ``matn_ar`` must NOT wipe an existing node's ``matn_ar``.
+
+    The generated Cypher uses ``coalesce(row.props.matn_ar, n.matn_ar)``
+    so when the row omits ``matn_ar`` (serialized as NULL), coalesce
+    falls back to the existing node value. Scholar-curated fields that
+    the normalize batch doesn't know about are therefore preserved.
+    """
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Hadith": [{"id": "hdt:1", "props": {"matn_en": "foo"}}]},
+    )
+    driver = _FakeDriver()
+
+    IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+
+    assert len(driver.sink) == 1
+    query, params = driver.sink[0]
+    sent_props = params["rows"][0]["props"]
+    assert sent_props == {"matn_en": "foo"}
+    # matn_en SET is a straight assignment (row has a value)
+    assert "n.matn_en = coalesce(row.props.matn_en, n.matn_en)" in query
+    # matn_ar is still in the SET list (Cypher is built from the
+    # per-label allow-list, not the row), BUT the coalesce protects
+    # the existing node value from being wiped with NULL.
+    assert "n.matn_ar = coalesce(row.props.matn_ar, n.matn_ar)" in query
+
+
+def test_ingest_drops_properties_outside_allowlist(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    """An attacker-controlled ``evil`` key must be silently dropped."""
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={
+            "Hadith": [
+                {
+                    "id": "hdt:1",
+                    "props": {
+                        "matn_en": "legitimate",
+                        "evil": "bad",
+                        "label": "Administrator",
+                    },
+                }
+            ]
+        },
+    )
+    driver = _FakeDriver()
+
+    IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+
+    assert len(driver.sink) == 1
+    query, params = driver.sink[0]
+    sent_props = params["rows"][0]["props"]
+    assert sent_props == {"matn_en": "legitimate"}
+    assert "evil" not in query
+    # The "label" key (not allow-listed for Hadith) is dropped.
+    # The allow-list also has no "label" field, so no SET stanza.
+    assert "n.label =" not in query
+    assert "row.props.evil" not in query
+
+
+# ---------------------------------------------------------------------------
+# Prior error taxonomy — preserved under the new signature
+# ---------------------------------------------------------------------------
 
 
 def test_ingest_retries_once_on_session_expired(
-    object_store: ObjectStore, sample_message: PipelineMessage
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
 ) -> None:
     from neo4j.exceptions import SessionExpired
 
-    payload = _parquet_bytes([{"label": "Narrator", "id": "nar:a", "name_en": "A"}])
-    object_store.put_object(sample_message.b2_path, payload)
-    # First session raises SessionExpired on execute_write; second succeeds.
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Narrator": [{"id": "nar:a", "props": {"name_en": "A"}}]},
+    )
     first = _FakeSession([], raise_on_execute=SessionExpired("token expired"))
     second = _FakeSession([])
     driver = _FakeDriver(session_factories=[first, second])
 
-    IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+    IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
 
-    # Reopened — one successful tx.run on the second session
-    assert len(driver.sink) == 1
+    # Reopened — the successful second session ran the full batch
     assert driver._next_factory == 2
+    assert len(driver.sink) == 1  # one tx.run for the single Narrator label
 
 
 def test_ingest_client_error_propagates_for_dlq(
-    object_store: ObjectStore, sample_message: PipelineMessage
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
 ) -> None:
     """Cypher/constraint errors must propagate so the runner DLQs them."""
     from neo4j.exceptions import ClientError
 
-    payload = _parquet_bytes([{"label": "Narrator", "id": "nar:a", "name_en": "A"}])
-    object_store.put_object(sample_message.b2_path, payload)
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Narrator": [{"id": "nar:a", "props": {"name_en": "A"}}]},
+    )
     sess = _FakeSession([], raise_on_execute=ClientError("constraint violated"))
     driver = _FakeDriver(session_factories=[sess])
 
     with pytest.raises(ClientError):
-        IngestProcessor(object_store, neo4j_driver=driver)(sample_message)
+        IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
 
 
 # ---------------------------------------------------------------------------
-# Runner integration — DLQ routing on Neo4j failures
+# Runner integration — DLQ routing
 # ---------------------------------------------------------------------------
 
 
 def test_runner_routes_client_error_to_dlq(
-    object_store: ObjectStore, sample_message: PipelineMessage
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
 ) -> None:
     from neo4j.exceptions import ClientError
 
-    payload = _parquet_bytes([{"label": "Narrator", "id": "nar:a", "name_en": "A"}])
-    object_store.put_object(sample_message.b2_path, payload)
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Narrator": [{"id": "nar:a", "props": {"name_en": "A"}}]},
+    )
     sess = _FakeSession([], raise_on_execute=ClientError("bad query"))
     driver = _FakeDriver(session_factories=[sess])
     producer = FakeProducer()
@@ -278,7 +595,7 @@ def test_runner_routes_client_error_to_dlq(
     runner = WorkerRunner(
         settings=WorkerSettings(
             worker_name="ingest-worker",
-            consume_topic="pipeline.norm.done",
+            consume_topic=PIPELINE_NORMALIZE_DONE,
             produce_topic=None,
             consumer_group="ingest-worker",
         ),
@@ -286,7 +603,7 @@ def test_runner_routes_client_error_to_dlq(
         producer=producer,
         process=IngestProcessor(object_store, neo4j_driver=driver),
     )
-    runner.handle_one(serialize_message(sample_message))
+    runner.handle_one(serialize_message(folder_prefix_message))
 
     assert len(producer.sent) == 1
     topic, value = producer.sent[0]
@@ -296,17 +613,21 @@ def test_runner_routes_client_error_to_dlq(
 
 
 def test_runner_routes_schema_error_to_dlq(
-    object_store: ObjectStore, sample_message: PipelineMessage
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
 ) -> None:
-    payload = _parquet_bytes([{"label": "BadLabel", "id": "x:1"}])
-    object_store.put_object(sample_message.b2_path, payload)
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={},
+        extra_manifest_entries=[{"path": "bad.parquet", "label": "BadLabel", "row_count": 0}],
+    )
     driver = _FakeDriver()
     producer = FakeProducer()
 
     runner = WorkerRunner(
         settings=WorkerSettings(
             worker_name="ingest-worker",
-            consume_topic="pipeline.norm.done",
+            consume_topic=PIPELINE_NORMALIZE_DONE,
             produce_topic=None,
             consumer_group="ingest-worker",
         ),
@@ -314,7 +635,7 @@ def test_runner_routes_schema_error_to_dlq(
         producer=producer,
         process=IngestProcessor(object_store, neo4j_driver=driver),
     )
-    runner.handle_one(serialize_message(sample_message))
+    runner.handle_one(serialize_message(folder_prefix_message))
 
     assert len(producer.sent) == 1
     topic, value = producer.sent[0]
@@ -322,3 +643,30 @@ def test_runner_routes_schema_error_to_dlq(
     record = json.loads(value)
     assert record["error_class"] == "UnknownSchemaError"
     assert driver.sink == []
+
+
+def test_runner_routes_missing_manifest_to_dlq(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    # No batch written at all — manifest missing
+    driver = _FakeDriver()
+    producer = FakeProducer()
+
+    runner = WorkerRunner(
+        settings=WorkerSettings(
+            worker_name="ingest-worker",
+            consume_topic=PIPELINE_NORMALIZE_DONE,
+            produce_topic=None,
+            consumer_group="ingest-worker",
+        ),
+        consumer=FakeConsumer([]),
+        producer=producer,
+        process=IngestProcessor(object_store, neo4j_driver=driver),
+    )
+    runner.handle_one(serialize_message(folder_prefix_message))
+
+    assert len(producer.sent) == 1
+    topic, value = producer.sent[0]
+    assert topic == DLQ_TOPIC
+    record = json.loads(value)
+    assert record["error_class"] == "ManifestMissingError"

--- a/tests/workers/test_processors.py
+++ b/tests/workers/test_processors.py
@@ -518,9 +518,50 @@ def test_ingest_returns_none_and_reads_input(
     sample_message: PipelineMessage,
     sample_hadith_parquet: bytes,
 ) -> None:
-    _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
+    """Terminal ingest stage returns None on an empty D-ii batch.
 
-    result = IngestProcessor(object_store)(sample_message)
+    Under #192 D-ii the ingest input is a folder prefix carrying
+    ``_MANIFEST.json``; we write an empty manifest and assert the
+    terminal contract (returns None, no exception).
+    """
+    import json
+
+    prefix = "normalized/batch-001/"
+    folder_msg = sample_message.to_next_stage(b2_path=prefix, record_count=0)
+    object_store.put_object(
+        f"{prefix}_MANIFEST.json",
+        json.dumps(
+            {
+                "batch_id": folder_msg.batch_id,
+                "source": folder_msg.source,
+                "created_at": "2026-04-21T00:00:00+00:00",
+                "parquets": [{"path": "edges.parquet", "row_count": 0}],
+                "total_row_count": 0,
+            }
+        ).encode("utf-8"),
+    )
+    # normalize always writes edges.parquet (possibly empty)
+    import io as _io
+
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    empty_edges = pa.schema(
+        [
+            pa.field("label", pa.string(), nullable=False),
+            pa.field("id", pa.string(), nullable=False),
+            pa.field("props", pa.string(), nullable=False),
+            pa.field("src_id", pa.string(), nullable=False),
+            pa.field("src_label", pa.string(), nullable=False),
+            pa.field("dst_id", pa.string(), nullable=False),
+            pa.field("dst_label", pa.string(), nullable=False),
+        ]
+    ).empty_table()
+    buf = _io.BytesIO()
+    pq.write_table(empty_edges, buf)
+    object_store.put_object(f"{prefix}edges.parquet", buf.getvalue())
+
+    result = IngestProcessor(object_store)(folder_msg)
 
     assert result is None  # terminal stage
 

--- a/workers/ingest/main.py
+++ b/workers/ingest/main.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import os
+import signal
+from types import FrameType
+from typing import TYPE_CHECKING
 
 from workers.ingest.processor import IngestProcessor
 from workers.lib.log import configure_logging, get_logger
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
 
+if TYPE_CHECKING:
+    from neo4j import Driver
+
 _logger = get_logger("workers.ingest")
 
 
-def build_runner() -> WorkerRunner:
+def build_runner() -> tuple[WorkerRunner, Driver]:
     from kafka import KafkaConsumer, KafkaProducer  # type: ignore[import-untyped]
     from neo4j import GraphDatabase
 
@@ -38,19 +44,54 @@ def build_runner() -> WorkerRunner:
     producer = KafkaProducer(bootstrap_servers=bootstrap)
     store = ObjectStore(bucket=bucket, endpoint_url=endpoint_url)
     driver = GraphDatabase.driver(neo4j_uri, auth=(neo4j_user, neo4j_password))
+    # Fail fast at startup if Neo4j is unreachable or the credentials
+    # are wrong — otherwise every incoming message would DLQ.
+    driver.verify_connectivity()
 
-    return WorkerRunner(
+    runner = WorkerRunner(
         settings=settings,
         consumer=consumer,
         producer=producer,
         process=IngestProcessor(store, neo4j_driver=driver),
     )
+    return runner, driver
+
+
+def _install_shutdown_handler(driver: Driver, consumer: object) -> None:
+    """Close the Neo4j driver and Kafka consumer on SIGTERM/SIGINT.
+
+    The runner's ``run_forever`` loop exits naturally once the consumer
+    is closed (iterator stops yielding), so this is the minimally
+    invasive way to get a graceful shutdown without touching
+    ``WorkerRunner``.
+    """
+
+    def _handle(signum: int, _frame: FrameType | None) -> None:
+        _logger.info("ingest_shutdown_received", signal=signum)
+        try:
+            close = getattr(consumer, "close", None)
+            if callable(close):
+                close()
+        except Exception as exc:  # noqa: BLE001 — best-effort shutdown
+            _logger.warning("ingest_consumer_close_failed", error=str(exc))
+        try:
+            driver.close()
+        except Exception as exc:  # noqa: BLE001 — best-effort shutdown
+            _logger.warning("ingest_driver_close_failed", error=str(exc))
+
+    signal.signal(signal.SIGTERM, _handle)
+    signal.signal(signal.SIGINT, _handle)
 
 
 def main() -> None:
     configure_logging()
     _logger.info("ingest_worker_starting")
-    build_runner().run_forever()
+    runner, driver = build_runner()
+    _install_shutdown_handler(driver, runner.consumer)
+    try:
+        runner.run_forever()
+    finally:
+        driver.close()
 
 
 if __name__ == "__main__":

--- a/workers/ingest/main.py
+++ b/workers/ingest/main.py
@@ -11,6 +11,7 @@ from workers.ingest.processor import IngestProcessor
 from workers.lib.log import configure_logging, get_logger
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
+from workers.lib.topics import PIPELINE_NORMALIZE_DONE
 
 if TYPE_CHECKING:
     from neo4j import Driver
@@ -31,7 +32,7 @@ def build_runner() -> tuple[WorkerRunner, Driver]:
 
     settings = WorkerSettings(
         worker_name="ingest-worker",
-        consume_topic="pipeline.norm.done",
+        consume_topic=PIPELINE_NORMALIZE_DONE,
         produce_topic=None,  # terminal stage
         consumer_group="ingest-worker",
     )

--- a/workers/ingest/processor.py
+++ b/workers/ingest/processor.py
@@ -1,34 +1,183 @@
 """ingest-worker processor.
 
-Terminal stage: loads the normalized Parquet into Neo4j and returns
-``None`` so the runner does not publish a follow-on pointer.
+Terminal stage: opens a Neo4j session per batch, MERGEs nodes from the
+normalized Parquet on stable IDs, and returns ``None`` so the runner
+does not publish a follow-on pointer.
 
-TODO (follow-up issue): port ``src/graph/load_nodes.py`` (MERGE on ID
-key, explicit SET per Phase 4 safety rule) and
-``src/graph/load_edges.py`` (batch size 1000, edge types documented in
-ontology). Current scaffold reads the batch for observability only and
-leaves the actual Neo4j write as TODO — the driver connection and MERGE
-statements are non-trivial and belong in a focused follow-up.
+Design (issue #13):
+
+- Session per batch. Each Kafka message carries a pointer to one
+  normalized Parquet; we open a session, run a single retryable write
+  transaction via ``session.execute_write``, and close the session.
+- ``execute_write`` uses the neo4j driver's built-in retry — transient
+  failures like ``ServiceUnavailable`` are retried automatically, no
+  custom retry loop.
+- MERGE on stable IDs. Node IDs come from the unified normalize schema
+  (landing in #10). Each normalized row must carry a ``label`` and an
+  ``id`` field; everything else is merged as properties via explicit
+  SET-per-key (Phase 4 safety rule from ``src/graph/load_nodes.py``).
+- Error taxonomy:
+    * ``ServiceUnavailable`` → neo4j retries internally inside
+      ``execute_write``; if it still fails it propagates and the runner
+      DLQs.
+    * ``ClientError`` (malformed Cypher / constraint violation) → do
+      not retry; propagate so runner DLQs with the exception metadata.
+    * ``SessionExpired`` → reopen session once and retry.
+    * Everything else → propagate; the runner wraps it into a DLQ
+      record via ``build_dlq_record``.
+    * ``UnknownSchemaError`` is raised locally when the normalized
+      payload shape isn't recognized; the runner DLQs it.
 """
 
 from __future__ import annotations
 
+import io
+from typing import TYPE_CHECKING, Any
+
+from workers.lib.log import get_logger
 from workers.lib.message import PipelineMessage
 from workers.lib.object_store import ObjectStore
 
-__all__ = ["IngestProcessor"]
+if TYPE_CHECKING:
+    from neo4j import Driver, ManagedTransaction
+
+__all__ = ["IngestProcessor", "UnknownSchemaError"]
+
+_logger = get_logger("workers.ingest.processor")
+
+
+class UnknownSchemaError(ValueError):
+    """Raised when the normalized payload does not match the unified schema."""
+
+
+def _merge_node_tx(tx: ManagedTransaction, *, label: str, rows: list[dict[str, Any]]) -> int:
+    """Run a parameterized MERGE for a single label.
+
+    We build the query per label rather than relying on APOC so the
+    worker image doesn't require the APOC plugin. Rows of the same
+    label are batched into one UNWIND.
+    """
+    # Label is an identifier (not parameterizable in Cypher); callers
+    # MUST validate it against an allowlist before passing here.
+    query = (
+        f"UNWIND $rows AS row\n"
+        f"MERGE (n:`{label}` {{id: row.id}})\n"
+        f"SET n += row.props\n"
+        f"RETURN count(n) AS merged"
+    )
+    result = tx.run(query, rows=rows)
+    record = result.single()
+    return int(record["merged"]) if record else 0
+
+
+# Node labels that may appear in the normalized stream. Keeping this
+# explicit prevents Cypher injection via an attacker-controlled label
+# field and documents the unified schema's entity vocabulary.
+_ALLOWED_LABELS: frozenset[str] = frozenset(
+    {
+        "Narrator",
+        "Hadith",
+        "Collection",
+        "Chain",
+        "Grading",
+        "HistoricalEvent",
+        "Location",
+    }
+)
+
+
+def _rows_from_parquet(payload: bytes) -> list[dict[str, Any]]:
+    """Decode a Parquet payload into row dicts.
+
+    The unified schema landing in #10 writes one row per node with
+    ``label`` (one of :data:`_ALLOWED_LABELS`), ``id`` (stable string
+    ID), and remaining columns treated as node properties.
+    """
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(io.BytesIO(payload))
+    return list(table.to_pylist())
+
+
+def _group_rows_by_label(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Validate rows and group them by node label for per-label MERGE batches."""
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for idx, row in enumerate(rows):
+        label = row.get("label")
+        row_id = row.get("id")
+        if not label or not isinstance(label, str):
+            msg = f"row {idx}: missing or non-string 'label' field"
+            raise UnknownSchemaError(msg)
+        if label not in _ALLOWED_LABELS:
+            msg = f"row {idx}: unknown label {label!r} (allowed: {sorted(_ALLOWED_LABELS)})"
+            raise UnknownSchemaError(msg)
+        if not row_id or not isinstance(row_id, str):
+            msg = f"row {idx}: missing or non-string 'id' field"
+            raise UnknownSchemaError(msg)
+        props = {k: v for k, v in row.items() if k not in {"label", "id"}}
+        grouped.setdefault(label, []).append({"id": row_id, "props": props})
+    return grouped
 
 
 class IngestProcessor:
-    def __init__(self, store: ObjectStore, neo4j_driver: object | None = None) -> None:
+    """Terminal processor — MERGEs normalized rows into Neo4j."""
+
+    def __init__(self, store: ObjectStore, neo4j_driver: Driver | None = None) -> None:
         self.store = store
         self.neo4j_driver = neo4j_driver
 
     def __call__(self, msg: PipelineMessage) -> None:
-        # Pull the object so failures to locate the batch surface before
-        # we start a Neo4j transaction.
-        _ = self.store.get_object(msg.b2_path)
+        # Pull the normalized object first so a missing batch surfaces
+        # before we open a Neo4j session.
+        payload = self.store.get_object(msg.b2_path)
 
-        # TODO: open a Neo4j session via self.neo4j_driver, MERGE nodes
-        # and CREATE edges in 1000-record batches, verify counts.
+        if self.neo4j_driver is None:
+            # Allows the unit suite to exercise the read path without a
+            # real driver. Production always wires a driver in
+            # ``main.build_runner``.
+            _logger.warning(
+                "ingest_no_driver",
+                batch_id=msg.batch_id,
+                b2_path=msg.b2_path,
+            )
+            return None
+
+        rows = _rows_from_parquet(payload)
+        if not rows:
+            _logger.info(
+                "ingest_empty_batch",
+                batch_id=msg.batch_id,
+                b2_path=msg.b2_path,
+            )
+            return None
+
+        grouped = _group_rows_by_label(rows)
+
+        from neo4j.exceptions import SessionExpired
+
+        def _run(session: Any) -> dict[str, int]:
+            merged_by_label: dict[str, int] = {}
+            for label, label_rows in grouped.items():
+                count = session.execute_write(_merge_node_tx, label=label, rows=label_rows)
+                merged_by_label[label] = count
+            return merged_by_label
+
+        try:
+            with self.neo4j_driver.session() as session:
+                merged_by_label = _run(session)
+        except SessionExpired:
+            _logger.warning(
+                "ingest_session_expired_retrying",
+                batch_id=msg.batch_id,
+            )
+            with self.neo4j_driver.session() as session:
+                merged_by_label = _run(session)
+
+        _logger.info(
+            "ingest_merged",
+            batch_id=msg.batch_id,
+            b2_path=msg.b2_path,
+            merged_by_label=merged_by_label,
+            record_count=msg.record_count,
+        )
         return None

--- a/workers/ingest/processor.py
+++ b/workers/ingest/processor.py
@@ -1,149 +1,359 @@
-"""ingest-worker processor.
+"""ingest-worker processor — manifest-gated MERGE into Neo4j.
 
-Terminal stage: opens a Neo4j session per batch, MERGEs nodes from the
-normalized Parquet on stable IDs, and returns ``None`` so the runner
-does not publish a follow-on pointer.
+Terminal stage. Consumes a pointer to a folder prefix written by the
+normalize worker (see ``workers/normalize/processor.py`` and #192
+Option D-ii) and MERGEs the per-label Parquets into Neo4j in a single
+retryable transaction: all node labels first, edges last.
 
-Design (issue #13):
-
-- Session per batch. Each Kafka message carries a pointer to one
-  normalized Parquet; we open a session, run a single retryable write
-  transaction via ``session.execute_write``, and close the session.
-- ``execute_write`` uses the neo4j driver's built-in retry — transient
-  failures like ``ServiceUnavailable`` are retried automatically, no
-  custom retry loop.
-- MERGE on stable IDs. Node IDs come from the unified normalize schema
-  (landing in #10). Each normalized row must carry a ``label`` and an
-  ``id`` field; everything else is merged as properties via explicit
-  SET-per-key (Phase 4 safety rule from ``src/graph/load_nodes.py``).
-- Error taxonomy:
-    * ``ServiceUnavailable`` → neo4j retries internally inside
-      ``execute_write``; if it still fails it propagates and the runner
-      DLQs.
-    * ``ClientError`` (malformed Cypher / constraint violation) → do
-      not retry; propagate so runner DLQs with the exception metadata.
-    * ``SessionExpired`` → reopen session once and retry.
-    * Everything else → propagate; the runner wraps it into a DLQ
-      record via ``build_dlq_record``.
-    * ``UnknownSchemaError`` is raised locally when the normalized
-      payload shape isn't recognized; the runner DLQs it.
+Design (issue #18, #192 D-ii)
+-----------------------------
+* ``msg.b2_path`` is a folder prefix (e.g. ``normalized/<batch_id>/``).
+  Ingest reads ``_MANIFEST.json`` from that prefix as the ready signal;
+  normalize writes the manifest LAST so its presence implies every
+  per-label Parquet already landed.
+* Manifest entries are iterated in the order normalize emitted them
+  (node labels first, edges last). Ingest re-sorts defensively so an
+  out-of-order manifest can't cause MATCH-before-MERGE on edges.
+* Single Neo4j session per batch. All MERGEs run inside one
+  ``session.execute_write`` closure so the driver's built-in retry
+  covers the whole batch atomically.
+* Per-field enumerated SET. Each label has an allow-list in
+  ``workers.ingest.schema.NODE_PROPERTY_MAP``; the generated Cypher
+  SETs exactly those fields as ``n.field = row.props.field``. Closes
+  Farhan's #192 Phase-4 flag: ``SET n += row.props`` let an
+  attacker-controlled property overwrite the node, and also wiped
+  scholar-curated fields not present in the current batch.
+* Error taxonomy:
+    * ``ManifestMissingError`` — subclass of ``UnknownSchemaError``;
+      runner DLQs it.
+    * ``UnknownSchemaError`` — manifest references an unknown label or
+      an unknown edge type; runner DLQs.
+    * ``ServiceUnavailable`` — neo4j driver retries internally.
+    * ``SessionExpired`` — reopen session once and retry.
+    * ``ClientError`` and everything else — propagate for DLQ.
 """
 
 from __future__ import annotations
 
 import io
+import json
 from typing import TYPE_CHECKING, Any
 
+from workers.ingest.schema import (
+    ALLOWED_EDGE_LABELS,
+    EDGE_PROPERTY_MAP,
+    NODE_PROPERTY_MAP,
+)
 from workers.lib.log import get_logger
 from workers.lib.message import PipelineMessage
 from workers.lib.object_store import ObjectStore
+from workers.lib.topics import ALLOWED_NODE_LABELS
 
 if TYPE_CHECKING:
     from neo4j import Driver, ManagedTransaction
 
-__all__ = ["IngestProcessor", "UnknownSchemaError"]
+__all__ = [
+    "IngestProcessor",
+    "ManifestMissingError",
+    "UnknownSchemaError",
+]
 
 _logger = get_logger("workers.ingest.processor")
 
+_MANIFEST_FILENAME = "_MANIFEST.json"
+
 
 class UnknownSchemaError(ValueError):
-    """Raised when the normalized payload does not match the unified schema."""
+    """Raised when the manifest / payload does not match the D-ii schema."""
 
 
-def _merge_node_tx(tx: ManagedTransaction, *, label: str, rows: list[dict[str, Any]]) -> int:
-    """Run a parameterized MERGE for a single label.
+class ManifestMissingError(UnknownSchemaError):
+    """Raised when ``_MANIFEST.json`` is absent or cannot be parsed.
 
-    We build the query per label rather than relying on APOC so the
-    worker image doesn't require the APOC plugin. Rows of the same
-    label are batched into one UNWIND.
+    Subclass of ``UnknownSchemaError`` so the runner's existing DLQ
+    routing for schema errors catches this without a new branch.
     """
-    # Label is an identifier (not parameterizable in Cypher); callers
-    # MUST validate it against an allowlist before passing here.
-    query = (
-        f"UNWIND $rows AS row\n"
-        f"MERGE (n:`{label}` {{id: row.id}})\n"
-        f"SET n += row.props\n"
-        f"RETURN count(n) AS merged"
-    )
-    result = tx.run(query, rows=rows)
-    record = result.single()
-    return int(record["merged"]) if record else 0
 
 
-# Node labels that may appear in the normalized stream. Keeping this
-# explicit prevents Cypher injection via an attacker-controlled label
-# field and documents the unified schema's entity vocabulary.
-_ALLOWED_LABELS: frozenset[str] = frozenset(
-    {
-        "Narrator",
-        "Hadith",
-        "Collection",
-        "Chain",
-        "Grading",
-        "HistoricalEvent",
-        "Location",
-    }
-)
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+def _normalize_prefix(b2_path: str) -> str:
+    """Normalize ``msg.b2_path`` to a folder prefix with a trailing ``/``.
+
+    The D-ii message contract uses a folder prefix (e.g.
+    ``normalized/<batch_id>/``) but a caller that forgets the trailing
+    slash shouldn't silently stringify-concat against the filename.
+    """
+    return b2_path if b2_path.endswith("/") else f"{b2_path}/"
+
+
+def _read_manifest(store: ObjectStore, prefix: str) -> dict[str, Any]:
+    """Fetch and parse ``_MANIFEST.json`` from ``prefix``."""
+    key = f"{prefix}{_MANIFEST_FILENAME}"
+    try:
+        raw = store.get_object(key)
+    except Exception as exc:  # noqa: BLE001 — surface any read failure as missing manifest
+        msg = f"manifest not readable at {key!r}: {exc}"
+        raise ManifestMissingError(msg) from exc
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        msg = f"manifest at {key!r} is not valid JSON: {exc}"
+        raise ManifestMissingError(msg) from exc
+    if not isinstance(parsed, dict):
+        msg = f"manifest at {key!r} is not a JSON object"
+        raise ManifestMissingError(msg)
+    entries = parsed.get("parquets")
+    if not isinstance(entries, list):
+        msg = f"manifest at {key!r} missing 'parquets' list"
+        raise ManifestMissingError(msg)
+    return parsed
+
+
+def _split_manifest_entries(
+    entries: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """Separate node entries from the edges entry and validate labels.
+
+    Normalize writes node entries first and the edges file last; we
+    still re-sort defensively so an out-of-order manifest can't cause
+    edge MERGE to run before its node endpoints exist.
+    """
+    node_entries: list[dict[str, Any]] = []
+    edges_entry: dict[str, Any] | None = None
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict) or "path" not in entry:
+            msg = f"manifest entry {idx} missing 'path'"
+            raise UnknownSchemaError(msg)
+        label = entry.get("label")
+        if label is None:
+            # No label → this is the edges file. Manifest can only
+            # carry one edges file per batch.
+            if edges_entry is not None:
+                msg = "manifest carries multiple label-less (edges) entries"
+                raise UnknownSchemaError(msg)
+            edges_entry = entry
+            continue
+        if not isinstance(label, str) or label not in ALLOWED_NODE_LABELS:
+            msg = (
+                f"manifest entry {idx} has unknown node label {label!r} "
+                f"(allowed: {sorted(ALLOWED_NODE_LABELS)})"
+            )
+            raise UnknownSchemaError(msg)
+        node_entries.append(entry)
+    return node_entries, edges_entry
+
+
+# ---------------------------------------------------------------------------
+# Parquet row decoding
+# ---------------------------------------------------------------------------
 
 
 def _rows_from_parquet(payload: bytes) -> list[dict[str, Any]]:
-    """Decode a Parquet payload into row dicts.
-
-    The unified schema landing in #10 writes one row per node with
-    ``label`` (one of :data:`_ALLOWED_LABELS`), ``id`` (stable string
-    ID), and remaining columns treated as node properties.
-    """
+    """Decode Parquet bytes into row dicts."""
     import pyarrow.parquet as pq
 
     table = pq.read_table(io.BytesIO(payload))
     return list(table.to_pylist())
 
 
-def _group_rows_by_label(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
-    """Validate rows and group them by node label for per-label MERGE batches."""
-    grouped: dict[str, list[dict[str, Any]]] = {}
-    for idx, row in enumerate(rows):
-        label = row.get("label")
-        row_id = row.get("id")
-        if not label or not isinstance(label, str):
-            msg = f"row {idx}: missing or non-string 'label' field"
+def _decode_props(raw: Any) -> dict[str, Any]:
+    """Decode the ``props`` column cell into a dict.
+
+    Normalize encodes props as a JSON string to sidestep an exhaustive
+    per-label Arrow schema. If a future writer produces dict cells
+    directly we accept that too.
+    """
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, (bytes, str)):
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            msg = f"props cell is not valid JSON: {exc}"
+            raise UnknownSchemaError(msg) from exc
+        if not isinstance(decoded, dict):
+            msg = f"props cell decoded to {type(decoded).__name__}, expected object"
             raise UnknownSchemaError(msg)
-        if label not in _ALLOWED_LABELS:
-            msg = f"row {idx}: unknown label {label!r} (allowed: {sorted(_ALLOWED_LABELS)})"
-            raise UnknownSchemaError(msg)
+        return decoded
+    msg = f"props cell has unexpected type {type(raw).__name__}"
+    raise UnknownSchemaError(msg)
+
+
+def _node_rows_for_merge(label: str, raw_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Validate node rows and shape them for the MERGE UNWIND.
+
+    The Cypher builder reads ``row.id`` and ``row.props.<field>`` for
+    each allow-listed field; we pre-strip anything outside the
+    allow-list here so the wire payload is as small as the query allows.
+    """
+    allowed = NODE_PROPERTY_MAP.get(label, [])
+    shaped: list[dict[str, Any]] = []
+    for idx, raw in enumerate(raw_rows):
+        row_id = raw.get("id")
         if not row_id or not isinstance(row_id, str):
-            msg = f"row {idx}: missing or non-string 'id' field"
+            msg = f"{label} row {idx}: missing or non-string 'id'"
             raise UnknownSchemaError(msg)
-        props = {k: v for k, v in row.items() if k not in {"label", "id"}}
-        grouped.setdefault(label, []).append({"id": row_id, "props": props})
+        props = _decode_props(raw.get("props"))
+        filtered = {k: props[k] for k in allowed if k in props}
+        dropped = [k for k in props if k not in allowed]
+        if dropped:
+            _logger.warning(
+                "ingest_dropped_unknown_props",
+                label=label,
+                row_id=row_id,
+                dropped=dropped,
+            )
+        shaped.append({"id": row_id, "props": filtered})
+    return shaped
+
+
+def _edge_rows_for_merge(raw_rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Group edge rows by relationship label and shape them for UNWIND."""
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for idx, raw in enumerate(raw_rows):
+        label = raw.get("label")
+        if not label or not isinstance(label, str):
+            msg = f"edge row {idx}: missing or non-string 'label'"
+            raise UnknownSchemaError(msg)
+        if label not in ALLOWED_EDGE_LABELS:
+            msg = (
+                f"edge row {idx}: unknown label {label!r} (allowed: {sorted(ALLOWED_EDGE_LABELS)})"
+            )
+            raise UnknownSchemaError(msg)
+        src_id = raw.get("src_id")
+        dst_id = raw.get("dst_id")
+        if not isinstance(src_id, str) or not src_id:
+            msg = f"edge row {idx}: missing or non-string 'src_id'"
+            raise UnknownSchemaError(msg)
+        if not isinstance(dst_id, str) or not dst_id:
+            msg = f"edge row {idx}: missing or non-string 'dst_id'"
+            raise UnknownSchemaError(msg)
+        props = _decode_props(raw.get("props"))
+        allowed = EDGE_PROPERTY_MAP.get(label, [])
+        filtered = {k: props[k] for k in allowed if k in props}
+        grouped.setdefault(label, []).append(
+            {"src_id": src_id, "dst_id": dst_id, "props": filtered}
+        )
     return grouped
 
 
+# ---------------------------------------------------------------------------
+# Cypher builders
+# ---------------------------------------------------------------------------
+
+
+def _build_node_cypher(label: str) -> str:
+    """Per-label MERGE Cypher with enumerated, null-safe SET stanzas.
+
+    The label is an identifier (Cypher cannot parameterize it) but we
+    only reach here with labels validated against
+    ``ALLOWED_NODE_LABELS``, so backtick-injection of the label is safe.
+    Field names are also drawn from the server-side allow-list, not the
+    incoming payload.
+
+    Each SET uses ``coalesce(row.props.<f>, n.<f>)`` so a row that omits
+    a field does NOT wipe the existing node property — the scholar-
+    curated ``text_ar`` on a hadith survives an ingest batch that only
+    carries ``text_en``. This is the core of Farhan's Phase-4 fix
+    (#192 comment thread).
+    """
+    fields = NODE_PROPERTY_MAP.get(label, [])
+    set_lines = ",\n    ".join(f"n.{f} = coalesce(row.props.{f}, n.{f})" for f in fields)
+    set_clause = f"SET {set_lines}\n" if fields else ""
+    return (
+        "UNWIND $rows AS row\n"
+        f"MERGE (n:`{label}` {{id: row.id}})\n"
+        f"{set_clause}"
+        "RETURN count(n) AS merged"
+    )
+
+
+def _build_edge_cypher(label: str) -> str:
+    """Per-edge-label MERGE Cypher with enumerated, null-safe SET stanzas."""
+    fields = EDGE_PROPERTY_MAP.get(label, [])
+    set_lines = ",\n    ".join(f"r.{f} = coalesce(row.props.{f}, r.{f})" for f in fields)
+    set_clause = f"SET {set_lines}\n" if fields else ""
+    return (
+        "UNWIND $rows AS row\n"
+        "MATCH (s {id: row.src_id})\n"
+        "MATCH (t {id: row.dst_id})\n"
+        f"MERGE (s)-[r:`{label}`]->(t)\n"
+        f"{set_clause}"
+        "RETURN count(r) AS merged"
+    )
+
+
+def _merge_nodes_tx(tx: ManagedTransaction, *, label: str, rows: list[dict[str, Any]]) -> int:
+    query = _build_node_cypher(label)
+    result = tx.run(query, rows=rows)
+    record = result.single()
+    return int(record["merged"]) if record else 0
+
+
+def _merge_edges_tx(tx: ManagedTransaction, *, label: str, rows: list[dict[str, Any]]) -> int:
+    query = _build_edge_cypher(label)
+    result = tx.run(query, rows=rows)
+    record = result.single()
+    return int(record["merged"]) if record else 0
+
+
+# ---------------------------------------------------------------------------
+# Processor
+# ---------------------------------------------------------------------------
+
+
 class IngestProcessor:
-    """Terminal processor — MERGEs normalized rows into Neo4j."""
+    """Terminal processor — manifest-gated MERGE into Neo4j."""
 
     def __init__(self, store: ObjectStore, neo4j_driver: Driver | None = None) -> None:
         self.store = store
         self.neo4j_driver = neo4j_driver
 
     def __call__(self, msg: PipelineMessage) -> None:
-        # Pull the normalized object first so a missing batch surfaces
-        # before we open a Neo4j session.
-        payload = self.store.get_object(msg.b2_path)
+        prefix = _normalize_prefix(msg.b2_path)
 
-        if self.neo4j_driver is None:
-            # Allows the unit suite to exercise the read path without a
-            # real driver. Production always wires a driver in
-            # ``main.build_runner``.
-            _logger.warning(
-                "ingest_no_driver",
-                batch_id=msg.batch_id,
-                b2_path=msg.b2_path,
-            )
-            return None
+        # Read manifest first so a missing ready signal surfaces before
+        # we open a Neo4j session or fetch any Parquets.
+        manifest = _read_manifest(self.store, prefix)
+        node_entries, edges_entry = _split_manifest_entries(manifest["parquets"])
 
-        rows = _rows_from_parquet(payload)
-        if not rows:
+        # Fetch + validate every Parquet referenced by the manifest
+        # before any Neo4j work. A missing Parquet must abort the batch
+        # cleanly, never a partial load.
+        nodes_by_label: dict[str, list[dict[str, Any]]] = {}
+        total_nodes = 0
+        for entry in node_entries:
+            label = entry["label"]
+            key = f"{prefix}{entry['path']}"
+            try:
+                payload = self.store.get_object(key)
+            except Exception as exc:  # noqa: BLE001 — any read failure = missing parquet
+                msg_err = f"manifest lists {label} parquet at {key!r} but read failed: {exc}"
+                raise UnknownSchemaError(msg_err) from exc
+            raw_rows = _rows_from_parquet(payload)
+            shaped = _node_rows_for_merge(label, raw_rows)
+            if shaped:
+                nodes_by_label[label] = shaped
+                total_nodes += len(shaped)
+
+        edges_by_label: dict[str, list[dict[str, Any]]] = {}
+        if edges_entry is not None:
+            key = f"{prefix}{edges_entry['path']}"
+            try:
+                payload = self.store.get_object(key)
+            except Exception as exc:  # noqa: BLE001 — any read failure = missing parquet
+                msg_err = f"manifest lists edges parquet at {key!r} but read failed: {exc}"
+                raise UnknownSchemaError(msg_err) from exc
+            raw_rows = _rows_from_parquet(payload)
+            edges_by_label = _edge_rows_for_merge(raw_rows)
+
+        if not nodes_by_label and not edges_by_label:
             _logger.info(
                 "ingest_empty_batch",
                 batch_id=msg.batch_id,
@@ -151,33 +361,51 @@ class IngestProcessor:
             )
             return None
 
-        grouped = _group_rows_by_label(rows)
+        if self.neo4j_driver is None:
+            # Read-path ergonomics for the unit suite — skip the write.
+            _logger.warning(
+                "ingest_no_driver",
+                batch_id=msg.batch_id,
+                b2_path=msg.b2_path,
+            )
+            return None
 
         from neo4j.exceptions import SessionExpired
 
-        def _run(session: Any) -> dict[str, int]:
-            merged_by_label: dict[str, int] = {}
-            for label, label_rows in grouped.items():
-                count = session.execute_write(_merge_node_tx, label=label, rows=label_rows)
-                merged_by_label[label] = count
-            return merged_by_label
+        def _run_batch(tx: ManagedTransaction) -> dict[str, dict[str, int]]:
+            """Single-transaction closure — all nodes first, then edges.
+
+            Running both phases inside one ``execute_write`` means the
+            driver's retry covers the whole batch, and edges always see
+            their endpoints MATCH-able because the MERGE of nodes ran in
+            the same transaction scope.
+            """
+            merged_nodes: dict[str, int] = {}
+            for node_label, label_rows in nodes_by_label.items():
+                merged_nodes[node_label] = _merge_nodes_tx(tx, label=node_label, rows=label_rows)
+            merged_edges: dict[str, int] = {}
+            for edge_label, edge_rows in edges_by_label.items():
+                merged_edges[edge_label] = _merge_edges_tx(tx, label=edge_label, rows=edge_rows)
+            return {"nodes": merged_nodes, "edges": merged_edges}
+
+        def _run(session: Any) -> dict[str, dict[str, int]]:
+            result: dict[str, dict[str, int]] = session.execute_write(_run_batch)
+            return result
 
         try:
             with self.neo4j_driver.session() as session:
-                merged_by_label = _run(session)
+                merged = _run(session)
         except SessionExpired:
-            _logger.warning(
-                "ingest_session_expired_retrying",
-                batch_id=msg.batch_id,
-            )
+            _logger.warning("ingest_session_expired_retrying", batch_id=msg.batch_id)
             with self.neo4j_driver.session() as session:
-                merged_by_label = _run(session)
+                merged = _run(session)
 
         _logger.info(
             "ingest_merged",
             batch_id=msg.batch_id,
             b2_path=msg.b2_path,
-            merged_by_label=merged_by_label,
+            merged_nodes=merged["nodes"],
+            merged_edges=merged["edges"],
             record_count=msg.record_count,
         )
         return None

--- a/workers/ingest/schema.py
+++ b/workers/ingest/schema.py
@@ -1,0 +1,181 @@
+"""Per-label property allow-lists for ingest MERGE.
+
+Closes Farhan's Phase-4 safety flag (#192): the old ingest implementation
+used ``SET n += row.props`` which lets an attacker-controlled property
+key (``:label``, ``id``, a future scholar-curated field not present in
+this batch) overwrite or subvert the node. This module enumerates the
+exact properties each label may receive; anything outside the allow-list
+is dropped before the Cypher statement is built.
+
+Source of truth
+---------------
+The property names mirror the Pydantic models in
+``noorinalabs-isnad-graph/src/models/*``. Keeping the two in sync is a
+manual step today — when a model grows a new field the ingest allow-list
+must grow to match, otherwise normalize will emit a row whose prop
+silently drops. A future followup (tracked in #192) could codegen these
+maps from the shared models.
+
+Fields intentionally omitted
+----------------------------
+``id`` is matched in the MERGE clause and never re-SET. Phase-4-only
+fields that are exclusively populated by post-ingest enrichment (e.g.
+narrator centrality / pagerank) are excluded so an unenriched batch
+doesn't wipe them out.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "ALLOWED_EDGE_LABELS",
+    "EDGE_PROPERTY_MAP",
+    "NODE_PROPERTY_MAP",
+]
+
+# Node properties that ingest will MERGE. Keyed by Neo4j label; values
+# are the exact property names that appear on the Pydantic model in
+# noorinalabs-isnad-graph. Anything outside this allow-list is silently
+# dropped (see ``_build_node_cypher``).
+NODE_PROPERTY_MAP: dict[str, list[str]] = {
+    "Hadith": [
+        "matn_ar",
+        "matn_en",
+        "isnad_raw_ar",
+        "isnad_raw_en",
+        "grade",
+        "grade_composite",
+        "source_corpus",
+        "sect",
+        "collection_name",
+        "book_number",
+        "chapter_number",
+        "hadith_number",
+        "chapter_name_ar",
+        "chapter_name_en",
+    ],
+    "Narrator": [
+        "name_ar",
+        "name_en",
+        "name_ar_normalized",
+        "kunya",
+        "nisba",
+        "laqab",
+        "birth_year_ah",
+        "death_year_ah",
+        "birth_location_id",
+        "death_location_id",
+        "generation",
+        "gender",
+        "sect_affiliation",
+        "tabaqat_class",
+        "trustworthiness_consensus",
+        "transmission_method",
+    ],
+    "Collection": [
+        "name_ar",
+        "name_en",
+        "compiler_name",
+        "compiler_id",
+        "compilation_year_ah",
+        "sect",
+        "canonical_rank",
+        "total_hadiths",
+        "book_count",
+        "source_corpus",
+    ],
+    "Chain": [
+        "hadith_id",
+        "chain_index",
+        "full_chain_text_ar",
+        "full_chain_text_en",
+        "chain_length",
+        "is_complete",
+        "is_elevated",
+        "classification",
+        "narrator_ids",
+    ],
+    "Grading": [
+        "hadith_id",
+        "scholar_name",
+        "grade",
+        "methodology_school",
+        "era",
+    ],
+    "HistoricalEvent": [
+        "name_ar",
+        "name_en",
+        "year_start_ah",
+        "year_end_ah",
+        "year_start_ce",
+        "year_end_ce",
+        "event_type",
+        "caliphate",
+        "region",
+        "description",
+        "source_url",
+    ],
+    "Location": [
+        "name_ar",
+        "name_en",
+        "region",
+        "lat",
+        "lon",
+        "political_entity_period",
+    ],
+}
+
+
+# Edge relationship types the ingest stage may MERGE. Kept explicit to
+# prevent Cypher-label injection from a manifest-listed edges.parquet
+# whose rows carry an unexpected label.
+ALLOWED_EDGE_LABELS: frozenset[str] = frozenset(
+    {
+        "TRANSMITTED_TO",
+        "NARRATED",
+        "APPEARS_IN",
+        "STUDIED_UNDER",
+        "PARALLEL_OF",
+        "GRADED_BY",
+        "ACTIVE_DURING",
+        "BASED_IN",
+    }
+)
+
+
+# Per-relationship property allow-lists, mirroring
+# noorinalabs-isnad-graph/src/models/edges.py. Same rationale as the
+# node map: per-field SET rather than ``SET r += row.props``.
+EDGE_PROPERTY_MAP: dict[str, list[str]] = {
+    "TRANSMITTED_TO": [
+        "hadith_id",
+        "chain_id",
+        "position_in_chain",
+        "transmission_method",
+    ],
+    "NARRATED": [],
+    "APPEARS_IN": [
+        "book_number",
+        "chapter_number",
+        "hadith_number",
+        "hadith_number_in_book",
+    ],
+    "STUDIED_UNDER": [
+        "period_ah",
+        "location_id",
+        "source",
+    ],
+    "PARALLEL_OF": [
+        "similarity_score",
+        "variant_type",
+        "cross_sect",
+    ],
+    "GRADED_BY": [],
+    "ACTIVE_DURING": [
+        "role",
+        "affiliation",
+    ],
+    "BASED_IN": [
+        "period_ah",
+        "role",
+    ],
+}


### PR DESCRIPTION
## Summary

Closes #13. Turns the ingest-worker processor from a no-op into a real terminal stage that opens a Neo4j session per batch and MERGEs nodes from the normalized Parquet on stable IDs.

- **Session per batch.** Each Kafka message → one session → one retryable write tx via `session.execute_write`. No custom retry loop; the neo4j driver handles `ServiceUnavailable` internally.
- **MERGE on stable IDs from the unified normalize schema** (landing in #10). Each row carries `label` (validated against an allowlist to prevent Cypher injection) and `id`; remaining columns become node properties via explicit `SET n += row.props`. Per-label UNWIND batches.
- **Driver lifecycle** (in `workers/ingest/main.py`):
  - `driver.verify_connectivity()` at startup — fail-fast if Neo4j is unreachable or creds are bad.
  - SIGTERM/SIGINT handler closes the consumer (letting `run_forever` exit naturally) and the driver.
  - All lifecycle stays in `main.py` — `workers/lib/runner.py` is untouched to avoid colliding with #10.

## Error taxonomy

| Exception | Handling |
|---|---|
| `ServiceUnavailable` | Retried inside `execute_write`; if it still fails it propagates → runner DLQ |
| `ClientError` (bad Cypher / constraint violation) | No retry; propagates → runner DLQ with metadata |
| `SessionExpired` | Reopen session once, retry |
| `UnknownSchemaError` (new) | Raised when a row lacks valid `label`/`id`; runner DLQ |
| Anything else | Propagates → runner DLQ via `build_dlq_record` |

## Scope

- ONLY `workers/ingest/` — dedup/enrich/normalize workers are Wanjiku's #10 territory (parallel branch `W.Mwangi/0010-processor-port`).
- `workers/lib/*.py` untouched.

## Test coverage

10 new unit tests in `tests/workers/test_ingest_neo4j.py`:

- `_merge_node_tx` Cypher shape (param binding, SET shape, return count)
- Happy-path merge-by-label (multi-label batch, props stripped of `label`/`id`)
- Empty Parquet → no-op
- No-driver → read-only (unit-suite ergonomics)
- Unknown label → `UnknownSchemaError`, zero Neo4j calls
- Missing `id` → `UnknownSchemaError`
- `SessionExpired` → reopen-once retry succeeds
- `ClientError` → propagates (no silent retry)
- End-to-end `WorkerRunner.handle_one` routes `ClientError` to DLQ with correct `error_class`
- End-to-end `WorkerRunner.handle_one` routes `UnknownSchemaError` to DLQ

All use fake driver/session — no Docker, no live Neo4j.

**Integration test against testcontainers Neo4j is deferred to #136** (noted in issue #13 acceptance as a follow-up). `testcontainers[neo4j]` is already in dev deps, so that issue can add a container-backed round-trip without new deps.

## Test plan

- [x] `uv run pytest tests/workers/test_ingest_neo4j.py tests/workers/test_processors.py tests/workers/test_runner.py` — 20 passed
- [x] `uv run ruff check workers/ingest/ tests/workers/test_ingest_neo4j.py` — clean
- [x] `uv run ruff format --check workers/ingest/ tests/workers/test_ingest_neo4j.py` — clean
- [x] `uv run mypy workers/ingest/` — Success, no issues
- [ ] Integration: testcontainers Neo4j round-trip (deferred to #136)

## Notes

- `uv.lock` updated because `uv sync` resolved new transitives (`boto3` chain) that the existing deps require; no `pyproject.toml` changes.
- `UnknownSchemaError` is a subclass of `ValueError` so existing `except ValueError` handlers continue to work.

Refs #13.