### PR TITLE
feat(workers): port real processor logic (dedup, enrich, normalize) (#10)

### DIFF
--- a/tests/workers/conftest.py
+++ b/tests/workers/conftest.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import io
 from typing import Any
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
+from src.parse.schemas import HADITH_SCHEMA
 from workers.lib.message import PipelineMessage
 from workers.lib.object_store import ObjectStore
 
@@ -73,4 +77,77 @@ def sample_message() -> PipelineMessage:
         source="sunnah-api",
         b2_path="raw/sunnah-api/2026-04-13/hadiths.parquet",
         record_count=42,
+    )
+
+
+def _hadith_row(
+    *,
+    source_id: str,
+    source_corpus: str = "sunnah",
+    collection_name: str = "bukhari",
+    sect: str = "sunni",
+    matn_en: str | None = None,
+    matn_ar: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "source_id": source_id,
+        "source_corpus": source_corpus,
+        "collection_name": collection_name,
+        "book_number": 1,
+        "chapter_number": 1,
+        "hadith_number": 1,
+        "matn_ar": matn_ar,
+        "matn_en": matn_en,
+        "isnad_raw_ar": None,
+        "isnad_raw_en": None,
+        "full_text_ar": None,
+        "full_text_en": None,
+        "grade": None,
+        "chapter_name_ar": None,
+        "chapter_name_en": None,
+        "sect": sect,
+    }
+
+
+def build_hadith_parquet(rows: list[dict[str, Any]]) -> bytes:
+    """Serialize a list of HADITH_SCHEMA rows to Parquet bytes."""
+    if not rows:
+        table = HADITH_SCHEMA.empty_table()
+    else:
+        by_col: dict[str, list[Any]] = {f.name: [] for f in HADITH_SCHEMA}
+        for row in rows:
+            for f in HADITH_SCHEMA:
+                by_col[f.name].append(row.get(f.name))
+        table = pa.table(by_col, schema=HADITH_SCHEMA)
+    buf = io.BytesIO()
+    pq.write_table(table, buf)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def hadith_row() -> Any:
+    """Row factory — yields the helper so tests can build custom rows."""
+    return _hadith_row
+
+
+@pytest.fixture
+def sample_hadith_parquet() -> bytes:
+    """Two well-formed rows using HADITH_SCHEMA — enough for most processor tests."""
+    return build_hadith_parquet(
+        [
+            _hadith_row(
+                source_id="sunnah:001",
+                matn_en=(
+                    "Actions are judged by intentions and every person will have "
+                    "only what they intended."
+                ),
+            ),
+            _hadith_row(
+                source_id="sunnah:002",
+                matn_en=(
+                    "Whoever believes in Allah and the Last Day should say what "
+                    "is good or remain silent."
+                ),
+            ),
+        ]
     )

--- a/tests/workers/conftest.py
+++ b/tests/workers/conftest.py
@@ -59,6 +59,16 @@ class FakeS3Client:
     def put_object(self, *, Bucket: str, Key: str, Body: bytes, ContentType: str = "") -> None:
         self.objects[(Bucket, Key)] = Body
 
+    def copy_object(self, *, Bucket: str, Key: str, CopySource: dict[str, str]) -> dict[str, Any]:
+        src_bucket = CopySource["Bucket"]
+        src_key = CopySource["Key"]
+        self.objects[(Bucket, Key)] = self.objects[(src_bucket, src_key)]
+        return {}
+
+    def delete_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:
+        self.objects.pop((Bucket, Key), None)
+        return {}
+
 
 @pytest.fixture
 def fake_s3() -> FakeS3Client:

--- a/tests/workers/test_processors.py
+++ b/tests/workers/test_processors.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import io
 import json
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -23,7 +24,7 @@ import pytest
 
 from src.parse.schemas import HADITH_SCHEMA
 from src.resolve.schemas import PARALLEL_LINKS_SCHEMA
-from tests.workers.conftest import build_hadith_parquet
+from tests.workers.conftest import FakeS3Client, build_hadith_parquet
 from workers.dedup.processor import DedupProcessor
 from workers.enrich.processor import HADITH_TOPICS_SCHEMA, EnrichProcessor
 from workers.ingest.processor import IngestProcessor
@@ -257,7 +258,24 @@ class TestEnrichProcessor:
 
 
 class TestNormalizeProcessor:
-    def test_pass_through_when_schema_already_matches(
+    """Post-#192 D-ii: normalize fans out each hadith into per-label Parquets
+    under a folder prefix + ``_MANIFEST.json`` written LAST."""
+
+    @staticmethod
+    def _read_manifest(store: ObjectStore, prefix: str) -> dict[str, Any]:
+        body = store.get_object(f"{prefix}_MANIFEST.json")
+        result: dict[str, Any] = json.loads(body.decode("utf-8"))
+        return result
+
+    @staticmethod
+    def _read_nodes(store: ObjectStore, prefix: str, filename: str) -> list[dict[str, Any]]:
+        body = store.get_object(f"{prefix}{filename}")
+        table = pq.read_table(io.BytesIO(body))
+        rows = table.to_pylist()
+        # Decode the JSON-encoded props column for test assertions.
+        return [{**r, "props": json.loads(r["props"])} for r in rows]
+
+    def test_emits_folder_prefix_and_manifest(
         self,
         object_store: ObjectStore,
         sample_message: PipelineMessage,
@@ -267,32 +285,204 @@ class TestNormalizeProcessor:
 
         nxt = NormalizeProcessor(object_store)(sample_message)
 
-        assert nxt.b2_path == "normalized/batch-001/hadiths.parquet"
-        assert nxt.record_count == 2
-        out = pq.read_table(io.BytesIO(object_store.get_object(nxt.b2_path)))
-        assert out.schema.equals(HADITH_SCHEMA)
-        assert out.num_rows == 2
+        # b2_path is now a folder prefix with trailing slash (#192 D-ii).
+        assert nxt.b2_path == "normalized/batch-001/"
+        manifest = self._read_manifest(object_store, nxt.b2_path)
+        assert manifest["batch_id"] == "batch-001"
+        assert manifest["source"] == "sunnah-api"
+        # total_row_count across every Parquet must equal nxt.record_count.
+        assert manifest["total_row_count"] == nxt.record_count
+
+    def test_fan_out_produces_expected_per_label_counts(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        hadith_row: Any,
+    ) -> None:
+        # Two hadiths sharing one collection, one with a full English isnad.
+        rows = [
+            hadith_row(
+                source_id="h1",
+                matn_en="text one",
+                collection_name="bukhari",
+            ),
+            hadith_row(
+                source_id="h2",
+                matn_en="text two",
+                collection_name="bukhari",
+            ),
+        ]
+        rows[0]["isnad_raw_en"] = "Narrated Abu Hurayrah from Malik on the authority of Nafi"
+        rows[1]["grade"] = "sahih"
+        _seed(object_store, sample_message.b2_path, build_hadith_parquet(rows))
+
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        manifest = self._read_manifest(object_store, nxt.b2_path)
+        entries = {e["path"]: e for e in manifest["parquets"]}
+
+        # Two hadith nodes (always).
+        assert entries["hadiths.parquet"]["row_count"] == 2
+
+        # One collection (deduped across the two hadiths).
+        assert entries["collections.parquet"]["row_count"] == 1
+
+        # Two chain nodes — one per hadith, regardless of isnad presence.
+        assert entries["chains.parquet"]["row_count"] == 2
+
+        # Narrators from the English isnad on h1. Three mentions expected
+        # (Abu Hurayrah, Malik, Nafi) — the extractor splits on the
+        # transmission keywords ``Narrated``/``from``/``on the authority of``.
+        narrators = self._read_nodes(object_store, nxt.b2_path, "narrators.parquet")
+        assert len(narrators) >= 2, f"expected multiple narrators extracted, got {narrators}"
+
+        # Grading node only for h2 (the one with a grade set).
+        gradings = self._read_nodes(object_store, nxt.b2_path, "gradings.parquet")
+        assert len(gradings) == 1
+        assert gradings[0]["props"]["grade"] == "sahih"
+
+        # Edges present for APPEARS_IN (per-hadith) + GRADED_BY (h2) +
+        # TRANSMITTED_TO (N-1 narrators in h1's chain) + NARRATED (first
+        # narrator -> h1).
+        edges_body = object_store.get_object(f"{nxt.b2_path}edges.parquet")
+        edges_table = pq.read_table(io.BytesIO(edges_body))
+        edge_labels = edges_table.column("label").to_pylist()
+        assert edge_labels.count("APPEARS_IN") == 2
+        assert edge_labels.count("GRADED_BY") == 1
+        assert "NARRATED" in edge_labels
+        assert "TRANSMITTED_TO" in edge_labels
+
+    def test_every_node_row_matches_allowed_label_vocabulary(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        sample_hadith_parquet: bytes,
+    ) -> None:
+        from workers.lib.topics import ALLOWED_NODE_LABELS
+
+        _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        manifest = self._read_manifest(object_store, nxt.b2_path)
+        for entry in manifest["parquets"]:
+            if entry["path"] == "edges.parquet":
+                continue
+            body = object_store.get_object(f"{nxt.b2_path}{entry['path']}")
+            table = pq.read_table(io.BytesIO(body))
+            for label in set(table.column("label").to_pylist()):
+                assert label in ALLOWED_NODE_LABELS, f"normalize emitted unknown label {label!r}"
+
+    def test_stable_narrator_ids_across_reruns(
+        self,
+        object_store: ObjectStore,
+        fake_s3: FakeS3Client,
+        sample_message: PipelineMessage,
+        hadith_row: Any,
+    ) -> None:
+        row = hadith_row(source_id="h1", matn_en="t", collection_name="bukhari")
+        row["isnad_raw_en"] = "Narrated Abu Hurayrah from Malik"
+        _seed(object_store, sample_message.b2_path, build_hadith_parquet([row]))
+
+        nxt1 = NormalizeProcessor(object_store)(sample_message)
+        ids_run1 = sorted(
+            n["id"] for n in self._read_nodes(object_store, nxt1.b2_path, "narrators.parquet")
+        )
+
+        # Wipe and re-run on identical input — every ID must match.
+        fake_s3.objects = {
+            k: v for k, v in fake_s3.objects.items() if not k[1].startswith("normalized/")
+        }
+        nxt2 = NormalizeProcessor(object_store)(sample_message)
+        ids_run2 = sorted(
+            n["id"] for n in self._read_nodes(object_store, nxt2.b2_path, "narrators.parquet")
+        )
+
+        assert ids_run1 == ids_run2
+        assert all(i.startswith("nar:") for i in ids_run1)
+
+    def test_manifest_row_counts_match_parquet_row_counts(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        sample_hadith_parquet: bytes,
+    ) -> None:
+        _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        manifest = self._read_manifest(object_store, nxt.b2_path)
+        for entry in manifest["parquets"]:
+            body = object_store.get_object(f"{nxt.b2_path}{entry['path']}")
+            table = pq.read_table(io.BytesIO(body))
+            assert table.num_rows == entry["row_count"], (
+                f"manifest lies about {entry['path']}: "
+                f"claims {entry['row_count']}, parquet has {table.num_rows}"
+            )
+
+    def test_no_part_files_remain_on_success(
+        self,
+        object_store: ObjectStore,
+        fake_s3: FakeS3Client,
+        sample_message: PipelineMessage,
+        sample_hadith_parquet: bytes,
+    ) -> None:
+        _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
+        NormalizeProcessor(object_store)(sample_message)
+
+        leaked = [k for (_bucket, k) in fake_s3.objects if ".part." in k]
+        assert leaked == [], f"leaked .part staging files: {leaked}"
+
+    def test_write_failure_leaves_no_manifest(
+        self,
+        object_store: ObjectStore,
+        fake_s3: FakeS3Client,
+        sample_message: PipelineMessage,
+        sample_hadith_parquet: bytes,
+    ) -> None:
+        """If any per-label write fails, ingest must not see a manifest —
+        no manifest means no ready signal, ingest skips the batch."""
+        _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
+
+        processor = NormalizeProcessor(object_store)
+
+        original_put = object_store.put_object
+        call_count = {"n": 0}
+
+        def flaky_put(
+            key: str, data: bytes, content_type: str = "application/octet-stream"
+        ) -> None:
+            call_count["n"] += 1
+            # Fail the 2nd .part write so at least one label lands but the
+            # batch aborts before the manifest is written.
+            if call_count["n"] == 2:
+                raise RuntimeError("simulated B2 outage")
+            original_put(key, data, content_type=content_type)
+
+        object_store.put_object = flaky_put  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="simulated B2 outage"):
+            processor(sample_message)
+
+        # Manifest must be absent.
+        leaked_manifest = [k for (_bucket, k) in fake_s3.objects if k.endswith("_MANIFEST.json")]
+        assert leaked_manifest == []
 
     def test_drops_rows_missing_required_fields(
         self,
         object_store: ObjectStore,
         sample_message: PipelineMessage,
-        hadith_row,
+        hadith_row: Any,
     ) -> None:
-        """Input arrives with a relaxed (fully-nullable) schema containing a
-        null in a target-non-nullable column; normalize must drop that row
-        before casting to the strict target schema."""
+        """Relaxed-schema input with a null in a target-non-null column must
+        be dropped before fan-out so we don't emit nodes for invalid rows."""
         good = hadith_row(source_id="good", matn_en="well-formed row")
         bad = hadith_row(source_id="bad")
-        bad["source_corpus"] = None  # null in a column that target schema marks non-null
+        bad["source_corpus"] = None
 
-        # Build a relaxed schema where every field is nullable so pa/parquet
-        # accepts the null.
         relaxed = pa.schema([pa.field(f.name, f.type, nullable=True) for f in HADITH_SCHEMA])
-        by_col: dict[str, list] = {f.name: [] for f in relaxed}
-        for row in (good, bad):
+        by_col: dict[str, list[Any]] = {f.name: [] for f in relaxed}
+        for r in (good, bad):
             for f in relaxed:
-                by_col[f.name].append(row.get(f.name))
+                by_col[f.name].append(r.get(f.name))
         table = pa.table(by_col, schema=relaxed)
         buf = io.BytesIO()
         pq.write_table(table, buf)
@@ -300,37 +490,15 @@ class TestNormalizeProcessor:
 
         nxt = NormalizeProcessor(object_store)(sample_message)
 
-        out = pq.read_table(io.BytesIO(object_store.get_object(nxt.b2_path)))
-        assert out.num_rows == 1
-        assert out.column("source_id").to_pylist() == ["good"]
-        assert nxt.record_count == 1
-
-    def test_strips_unexpected_extra_columns(
-        self,
-        object_store: ObjectStore,
-        sample_message: PipelineMessage,
-        hadith_row,
-    ) -> None:
-        row = hadith_row(source_id="x", matn_en="text")
-        cols = {f.name: [row[f.name]] for f in HADITH_SCHEMA}
-        cols["unexpected_extra"] = ["ignore-me"]
-        table = pa.table(cols)
-        buf = io.BytesIO()
-        pq.write_table(table, buf)
-        _seed(object_store, sample_message.b2_path, buf.getvalue())
-
-        nxt = NormalizeProcessor(object_store)(sample_message)
-
-        out = pq.read_table(io.BytesIO(object_store.get_object(nxt.b2_path)))
-        assert out.schema.equals(HADITH_SCHEMA)
-        assert "unexpected_extra" not in out.column_names
+        hadiths = self._read_nodes(object_store, nxt.b2_path, "hadiths.parquet")
+        assert len(hadiths) == 1
+        assert hadiths[0]["props"]["collection_name"] == "bukhari"
 
     def test_missing_required_column_raises(
         self,
         object_store: ObjectStore,
         sample_message: PipelineMessage,
     ) -> None:
-        # Build a Parquet that omits the required ``source_corpus`` column.
         table = pa.table({"source_id": ["x"], "collection_name": ["y"], "sect": ["sunni"]})
         buf = io.BytesIO()
         pq.write_table(table, buf)
@@ -382,7 +550,8 @@ def test_processor_chain_propagates_batch_id(
 
     assert after_norm.batch_id == "batch-001"
     assert after_norm.source == "sunnah-api"
-    assert after_norm.b2_path == "normalized/batch-001/hadiths.parquet"
+    # Post-#192 D-ii: normalize emits a folder prefix, not a single object key.
+    assert after_norm.b2_path == "normalized/batch-001/"
 
 
 def test_dedup_failure_propagates_to_dlq_via_runner(

--- a/tests/workers/test_processors.py
+++ b/tests/workers/test_processors.py
@@ -1,74 +1,424 @@
 """Processor-level tests for each worker.
 
 These exercise each processor end-to-end against the in-memory S3 fake
-so we verify the read→transform→write→next-pointer flow without any
-Kafka or network dependency.
+so we verify the read → transform → write → next-pointer flow without
+any Kafka or network dependency.
+
+Dedup and enrich processors have hard deps on the ``ml`` optional
+dependency group (``faiss``, ``sentence-transformers``, ``transformers``).
+Tests that exercise the ML code paths are gated on
+``pytest.importorskip`` so the default ``uv sync`` suite still passes;
+the ML-less paths rely on the processors' graceful-degradation
+behaviour.
 """
 
 from __future__ import annotations
 
+import io
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.parse.schemas import HADITH_SCHEMA
+from src.resolve.schemas import PARALLEL_LINKS_SCHEMA
+from tests.workers.conftest import build_hadith_parquet
 from workers.dedup.processor import DedupProcessor
-from workers.enrich.processor import EnrichProcessor
+from workers.enrich.processor import HADITH_TOPICS_SCHEMA, EnrichProcessor
 from workers.ingest.processor import IngestProcessor
 from workers.lib.message import PipelineMessage
 from workers.lib.object_store import ObjectStore
 from workers.normalize.processor import NormalizeProcessor
 
 
-def _seed(store: ObjectStore, key: str, payload: bytes = b"parquet-bytes") -> None:
+def _seed(store: ObjectStore, key: str, payload: bytes) -> None:
     store.put_object(key, payload)
 
 
-def test_dedup_writes_to_dedup_prefix(
-    object_store: ObjectStore, sample_message: PipelineMessage
-) -> None:
-    _seed(object_store, sample_message.b2_path)
-
-    nxt = DedupProcessor(object_store)(sample_message)
-
-    assert nxt.b2_path.startswith("dedup/sunnah-api/batch-001/")
-    assert object_store.get_object(nxt.b2_path) == b"parquet-bytes"
+# --------------------------------------------------------------------------
+# dedup
+# --------------------------------------------------------------------------
 
 
-def test_enrich_writes_to_enriched_prefix(
-    object_store: ObjectStore, sample_message: PipelineMessage
-) -> None:
-    _seed(object_store, sample_message.b2_path)
+class TestDedupProcessor:
+    def test_writes_hadiths_and_empty_links_when_ml_absent(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        sample_hadith_parquet: bytes,
+    ) -> None:
+        _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
 
-    nxt = EnrichProcessor(object_store)(sample_message)
+        processor = DedupProcessor(object_store)
+        # Force the ML-unavailable path regardless of installed deps.
+        processor._ml_unavailable = True
 
-    assert nxt.b2_path.startswith("enriched/sunnah-api/batch-001/")
+        nxt = processor(sample_message)
+
+        assert nxt.b2_path == "dedup/sunnah-api/batch-001/hadiths.parquet"
+        assert object_store.get_object(nxt.b2_path) == sample_hadith_parquet
+
+        links_bytes = object_store.get_object("dedup/sunnah-api/batch-001/parallel_links.parquet")
+        links_table = pq.read_table(io.BytesIO(links_bytes))
+        assert links_table.schema.equals(PARALLEL_LINKS_SCHEMA)
+        assert links_table.num_rows == 0
+
+    def test_empty_hadith_batch_emits_empty_links(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+    ) -> None:
+        _seed(object_store, sample_message.b2_path, build_hadith_parquet([]))
+
+        processor = DedupProcessor(object_store)
+        nxt = processor(sample_message)
+
+        assert nxt.b2_path == "dedup/sunnah-api/batch-001/hadiths.parquet"
+        links_bytes = object_store.get_object("dedup/sunnah-api/batch-001/parallel_links.parquet")
+        links_table = pq.read_table(io.BytesIO(links_bytes))
+        assert links_table.num_rows == 0
+
+    def test_malformed_parquet_raises(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+    ) -> None:
+        _seed(object_store, sample_message.b2_path, b"not-a-parquet-file")
+
+        processor = DedupProcessor(object_store)
+        processor._ml_unavailable = False  # force ML path so Parquet parse runs
+
+        # Even without ML, we still try to read the Parquet once ml deps
+        # are claimed available — emulate that by monkey-patching _ensure_ml
+        # to return True without actually loading a model.
+        processor._ensure_ml = lambda: True  # type: ignore[method-assign]
+        # And pre-populate _np so _embed won't crash if reached.
+        import numpy as np  # noqa: PLC0415 — optional test-only import
+
+        processor._np = np
+
+        with pytest.raises((pa.ArrowInvalid, OSError)):
+            processor(sample_message)
+
+    @pytest.mark.ml
+    def test_real_dedup_finds_near_duplicates(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        hadith_row,
+    ) -> None:
+        pytest.importorskip("faiss")
+        pytest.importorskip("sentence_transformers")
+
+        rows = [
+            hadith_row(
+                source_id="a",
+                matn_en=(
+                    "Actions are judged by their intentions and every person "
+                    "shall have what he intended."
+                ),
+            ),
+            hadith_row(
+                source_id="b",
+                matn_en=(
+                    "Deeds are judged by intentions and every man will receive what he intended."
+                ),
+            ),
+            hadith_row(
+                source_id="c",
+                source_corpus="thaqalayn",
+                sect="shia",
+                matn_en=(
+                    "A completely different narration about the rituals of hajj "
+                    "and the sacred months."
+                ),
+            ),
+        ]
+        _seed(object_store, sample_message.b2_path, build_hadith_parquet(rows))
+
+        DedupProcessor(object_store, threshold=0.5)(sample_message)
+
+        links_bytes = object_store.get_object("dedup/sunnah-api/batch-001/parallel_links.parquet")
+        links = pq.read_table(io.BytesIO(links_bytes))
+        assert links.schema.equals(PARALLEL_LINKS_SCHEMA)
+        ids_a = links.column("hadith_id_a").to_pylist()
+        ids_b = links.column("hadith_id_b").to_pylist()
+        pairs = {tuple(sorted([a, b])) for a, b in zip(ids_a, ids_b)}
+        assert ("a", "b") in pairs, f"expected near-duplicate pair, got {pairs}"
 
 
-def test_normalize_writes_to_normalized_prefix(
-    object_store: ObjectStore, sample_message: PipelineMessage
-) -> None:
-    _seed(object_store, sample_message.b2_path)
+# --------------------------------------------------------------------------
+# enrich
+# --------------------------------------------------------------------------
 
-    nxt = NormalizeProcessor(object_store)(sample_message)
 
-    assert nxt.b2_path == "normalized/batch-001/hadiths.parquet"
+class TestEnrichProcessor:
+    def test_writes_hadiths_and_empty_topics_when_ml_absent(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        sample_hadith_parquet: bytes,
+    ) -> None:
+        _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
+
+        processor = EnrichProcessor(object_store)
+        processor._ml_unavailable = True
+
+        nxt = processor(sample_message)
+
+        assert nxt.b2_path == "enriched/sunnah-api/batch-001/hadiths.parquet"
+        assert object_store.get_object(nxt.b2_path) == sample_hadith_parquet
+
+        topics_bytes = object_store.get_object(
+            "enriched/sunnah-api/batch-001/hadith_topics.parquet"
+        )
+        topics = pq.read_table(io.BytesIO(topics_bytes))
+        assert topics.schema.equals(HADITH_TOPICS_SCHEMA)
+        assert topics.num_rows == 0
+
+    def test_short_matn_rows_are_skipped_in_classification(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        hadith_row,
+    ) -> None:
+        rows = [
+            hadith_row(source_id="a", matn_en="short"),
+            hadith_row(source_id="b", matn_en=None),
+        ]
+        _seed(object_store, sample_message.b2_path, build_hadith_parquet(rows))
+
+        processor = EnrichProcessor(object_store)
+
+        class _StubClassifier:
+            called_with: list[list[str]] = []
+
+            def __call__(
+                self, texts: list[str], *, candidate_labels: list[str], multi_label: bool
+            ) -> list[dict[str, list]]:
+                self.called_with.append(texts)
+                return [{"labels": candidate_labels[:3], "scores": [0.5, 0.3, 0.2]} for _ in texts]
+
+        processor._classifier = _StubClassifier()
+
+        processor(sample_message)
+
+        # No rows met the min length, classifier should not have been called.
+        assert _StubClassifier.called_with == []
+        topics = pq.read_table(
+            io.BytesIO(
+                object_store.get_object("enriched/sunnah-api/batch-001/hadith_topics.parquet")
+            )
+        )
+        assert topics.num_rows == 0
+
+    def test_stub_classifier_populates_topics_table(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        sample_hadith_parquet: bytes,
+    ) -> None:
+        _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
+
+        class _StubClassifier:
+            def __call__(
+                self, texts: list[str], *, candidate_labels: list[str], multi_label: bool
+            ) -> list[dict[str, list]]:
+                return [
+                    {
+                        "labels": ["theology", "ethics/conduct", "ritual/worship"],
+                        "scores": [0.8, 0.15, 0.05],
+                    }
+                    for _ in texts
+                ]
+
+        processor = EnrichProcessor(object_store)
+        processor._classifier = _StubClassifier()
+
+        processor(sample_message)
+
+        topics = pq.read_table(
+            io.BytesIO(
+                object_store.get_object("enriched/sunnah-api/batch-001/hadith_topics.parquet")
+            )
+        )
+        assert topics.num_rows == 2
+        assert topics.column("topic_1").to_pylist() == ["theology", "theology"]
+        scores = topics.column("topic_1_score").to_pylist()
+        assert len(scores) == 2
+        assert all(abs(s - 0.8) < 1e-4 for s in scores)
+        assert set(topics.column("source_id").to_pylist()) == {"sunnah:001", "sunnah:002"}
+
+
+# --------------------------------------------------------------------------
+# normalize
+# --------------------------------------------------------------------------
+
+
+class TestNormalizeProcessor:
+    def test_pass_through_when_schema_already_matches(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        sample_hadith_parquet: bytes,
+    ) -> None:
+        _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
+
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        assert nxt.b2_path == "normalized/batch-001/hadiths.parquet"
+        assert nxt.record_count == 2
+        out = pq.read_table(io.BytesIO(object_store.get_object(nxt.b2_path)))
+        assert out.schema.equals(HADITH_SCHEMA)
+        assert out.num_rows == 2
+
+    def test_drops_rows_missing_required_fields(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        hadith_row,
+    ) -> None:
+        """Input arrives with a relaxed (fully-nullable) schema containing a
+        null in a target-non-nullable column; normalize must drop that row
+        before casting to the strict target schema."""
+        good = hadith_row(source_id="good", matn_en="well-formed row")
+        bad = hadith_row(source_id="bad")
+        bad["source_corpus"] = None  # null in a column that target schema marks non-null
+
+        # Build a relaxed schema where every field is nullable so pa/parquet
+        # accepts the null.
+        relaxed = pa.schema([pa.field(f.name, f.type, nullable=True) for f in HADITH_SCHEMA])
+        by_col: dict[str, list] = {f.name: [] for f in relaxed}
+        for row in (good, bad):
+            for f in relaxed:
+                by_col[f.name].append(row.get(f.name))
+        table = pa.table(by_col, schema=relaxed)
+        buf = io.BytesIO()
+        pq.write_table(table, buf)
+        _seed(object_store, sample_message.b2_path, buf.getvalue())
+
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        out = pq.read_table(io.BytesIO(object_store.get_object(nxt.b2_path)))
+        assert out.num_rows == 1
+        assert out.column("source_id").to_pylist() == ["good"]
+        assert nxt.record_count == 1
+
+    def test_strips_unexpected_extra_columns(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        hadith_row,
+    ) -> None:
+        row = hadith_row(source_id="x", matn_en="text")
+        cols = {f.name: [row[f.name]] for f in HADITH_SCHEMA}
+        cols["unexpected_extra"] = ["ignore-me"]
+        table = pa.table(cols)
+        buf = io.BytesIO()
+        pq.write_table(table, buf)
+        _seed(object_store, sample_message.b2_path, buf.getvalue())
+
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        out = pq.read_table(io.BytesIO(object_store.get_object(nxt.b2_path)))
+        assert out.schema.equals(HADITH_SCHEMA)
+        assert "unexpected_extra" not in out.column_names
+
+    def test_missing_required_column_raises(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+    ) -> None:
+        # Build a Parquet that omits the required ``source_corpus`` column.
+        table = pa.table({"source_id": ["x"], "collection_name": ["y"], "sect": ["sunni"]})
+        buf = io.BytesIO()
+        pq.write_table(table, buf)
+        _seed(object_store, sample_message.b2_path, buf.getvalue())
+
+        with pytest.raises(ValueError, match="missing required columns"):
+            NormalizeProcessor(object_store)(sample_message)
+
+
+# --------------------------------------------------------------------------
+# ingest — unchanged scope (owned by #13), but keep smoke test
+# --------------------------------------------------------------------------
 
 
 def test_ingest_returns_none_and_reads_input(
-    object_store: ObjectStore, sample_message: PipelineMessage
+    object_store: ObjectStore,
+    sample_message: PipelineMessage,
+    sample_hadith_parquet: bytes,
 ) -> None:
-    _seed(object_store, sample_message.b2_path)
+    _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
 
     result = IngestProcessor(object_store)(sample_message)
 
     assert result is None  # terminal stage
 
 
-def test_processor_chain_propagates_batch_id(
-    object_store: ObjectStore, sample_message: PipelineMessage
-) -> None:
-    """dedup → enrich → normalize must all carry the original batch_id."""
-    _seed(object_store, sample_message.b2_path)
+# --------------------------------------------------------------------------
+# chain
+# --------------------------------------------------------------------------
 
-    after_dedup = DedupProcessor(object_store)(sample_message)
-    after_enrich = EnrichProcessor(object_store)(after_dedup)
-    after_norm = NormalizeProcessor(object_store)(after_enrich)
+
+def test_processor_chain_propagates_batch_id(
+    object_store: ObjectStore,
+    sample_message: PipelineMessage,
+    sample_hadith_parquet: bytes,
+) -> None:
+    """dedup → enrich → normalize must all carry the original batch_id and source."""
+    _seed(object_store, sample_message.b2_path, sample_hadith_parquet)
+
+    dedup = DedupProcessor(object_store)
+    dedup._ml_unavailable = True
+    enrich = EnrichProcessor(object_store)
+    enrich._ml_unavailable = True
+    normalize = NormalizeProcessor(object_store)
+
+    after_dedup = dedup(sample_message)
+    after_enrich = enrich(after_dedup)
+    after_norm = normalize(after_enrich)
 
     assert after_norm.batch_id == "batch-001"
     assert after_norm.source == "sunnah-api"
+    assert after_norm.b2_path == "normalized/batch-001/hadiths.parquet"
+
+
+def test_dedup_failure_propagates_to_dlq_via_runner(
+    object_store: ObjectStore,
+    sample_message: PipelineMessage,
+) -> None:
+    """Runner wraps processor exceptions into a DLQ record — spot-check for dedup."""
+    from tests.workers.conftest import FakeConsumer, FakeProducer
+    from workers.lib.dlq import DLQ_TOPIC
+    from workers.lib.message import serialize_message
+    from workers.lib.runner import WorkerRunner, WorkerSettings
+
+    object_store.put_object(sample_message.b2_path, b"not-a-parquet-file")
+
+    processor = DedupProcessor(object_store)
+    processor._ensure_ml = lambda: True  # type: ignore[method-assign]
+    import numpy as np  # noqa: PLC0415
+
+    processor._np = np
+
+    producer = FakeProducer()
+    runner = WorkerRunner(
+        settings=WorkerSettings(
+            worker_name="dedup-worker",
+            consume_topic="pipeline.raw.new",
+            produce_topic="pipeline.dedup.done",
+            consumer_group="g",
+        ),
+        consumer=FakeConsumer([]),
+        producer=producer,
+        process=processor,
+    )
+    runner.handle_one(serialize_message(sample_message))
+
+    assert len(producer.sent) == 1
+    topic, value = producer.sent[0]
+    assert topic == DLQ_TOPIC
+    record = json.loads(value)
+    assert record["original"]["batch_id"] == sample_message.batch_id

--- a/tests/workers/test_topics.py
+++ b/tests/workers/test_topics.py
@@ -1,0 +1,61 @@
+"""Pin the public surface of ``workers.lib.topics``.
+
+These asserts are deliberately blunt: every downstream consumer
+(ingest, normalize, enrich, dedup, plus ``data-acquisition``'s
+``kafka_producer``) depends on the exact wire-level string values
+published here. A rename must be a conscious, cross-repo decision —
+updating this test forces that conversation.
+"""
+
+from __future__ import annotations
+
+from workers.lib import topics
+
+
+def test_topic_names_are_stable_wire_constants() -> None:
+    assert topics.PIPELINE_RAW_LANDED == "pipeline.raw.landed"
+    assert topics.PIPELINE_DEDUP_DONE == "pipeline.dedup.done"
+    assert topics.PIPELINE_ENRICH_DONE == "pipeline.enrich.done"
+    assert topics.PIPELINE_NORMALIZE_DONE == "pipeline.normalize.done"
+    assert topics.PIPELINE_DLQ == "pipeline.dlq"
+
+
+def test_topic_names_follow_past_tense_pattern() -> None:
+    """Per #192: ``pipeline.<stage>.<past-tense-event>`` for every stage topic.
+
+    DLQ is excluded — it's a sink, not a stage event.
+    """
+    stage_topics = [
+        topics.PIPELINE_RAW_LANDED,
+        topics.PIPELINE_DEDUP_DONE,
+        topics.PIPELINE_ENRICH_DONE,
+        topics.PIPELINE_NORMALIZE_DONE,
+    ]
+    for t in stage_topics:
+        parts = t.split(".")
+        assert len(parts) == 3, f"{t!r} must have exactly 3 dot-separated parts"
+        assert parts[0] == "pipeline", f"{t!r} must be namespaced under 'pipeline.'"
+
+
+def test_allowed_node_labels_match_ingest_vocabulary() -> None:
+    """The frozenset is the single source of truth for both normalize fan-out
+    and ingest MERGE. Keep these names in sync with ``src/graph/load_nodes.py``.
+    """
+    assert topics.ALLOWED_NODE_LABELS == frozenset(
+        {
+            "Narrator",
+            "Hadith",
+            "Collection",
+            "Chain",
+            "Grading",
+            "HistoricalEvent",
+            "Location",
+        }
+    )
+
+
+def test_dlq_topic_alias_still_exported_from_dlq_module() -> None:
+    """Existing imports of ``workers.lib.dlq.DLQ_TOPIC`` must keep working."""
+    from workers.lib.dlq import DLQ_TOPIC
+
+    assert DLQ_TOPIC == topics.PIPELINE_DLQ

--- a/uv.lock
+++ b/uv.lock
@@ -72,6 +72,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/ac/e6b2b24d53c830500176f710594efcde626186b5b3c9aead6f8837976956/boto3-1.42.93.tar.gz", hash = "sha256:ff81c6bac708cb95c4f8b27e331ac67d95c6908dd86bcb7b15b8941960f2bc4c", size = 113218, upload-time = "2026-04-21T21:30:39.733Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/2d/fcc35bde9fa47ac463a3023c73838e23e9281cde7f5e86fe7c459c3b72aa/boto3-1.42.93-py3-none-any.whl", hash = "sha256:51e34e30e65bea4df0ff77f91abdcb97297eb74c3b27eb576b2abbd758452967", size = 140554, upload-time = "2026-04-21T21:30:36.581Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/d4/eb53f7ed81836696abf7103c9c901a0cace9217328094ca93419016a78c9/botocore-1.42.93.tar.gz", hash = "sha256:9ce49863c50b43f7942edd295fb16bfc6d227264ce6fc32c8f2426ef11b9351b", size = 15239759, upload-time = "2026-04-21T21:30:23.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/0c/ccc57c9a7bcd4553620bf6f50a3640ba68d189330fc4787dbddb2d851534/botocore-1.42.93-py3-none-any.whl", hash = "sha256:96ae26cd6302a7c7563398517b90a438168a4efdf4f73ab38882cefb8df721cc", size = 14923656, upload-time = "2026-04-21T21:30:17.597Z" },
+]
+
+[[package]]
 name = "cachecontrol"
 version = "0.14.4"
 source = { registry = "https://pypi.org/simple" }
@@ -592,12 +620,30 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "kafka-python"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/98/cbecbe20ec9e4e6f978c42229e7c777f498eec5061f986b4acfa34a7ec46/kafka_python-2.3.1.tar.gz", hash = "sha256:90f1caa12d8faa9fd059852b0c73adf169b979279aa2e3ff370f9fe615d654b6", size = 357302, upload-time = "2026-04-09T21:10:22.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/83/6f79b5e03f7d259cba60d3e48c97f7b76a86d20486a515e8ffadea97434e/kafka_python-2.3.1-py2.py3-none-any.whl", hash = "sha256:4908865da9e57f0f966a83788c71cb0ae91c33451a26ab6e6984a00b15c6ed71", size = 326065, upload-time = "2026-04-09T21:10:24.685Z" },
 ]
 
 [[package]]
@@ -895,7 +941,9 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "boto3" },
     { name = "httpx" },
+    { name = "kafka-python" },
     { name = "kaggle" },
     { name = "lxml" },
     { name = "neo4j" },
@@ -937,7 +985,9 @@ ml = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "boto3", specifier = ">=1.34" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "kafka-python", specifier = ">=2.0" },
     { name = "kaggle", specifier = ">=1.6" },
     { name = "lxml", specifier = ">=5.1" },
     { name = "neo4j", specifier = ">=5.15" },
@@ -1732,6 +1782,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
     { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
     { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]

--- a/workers/dedup/main.py
+++ b/workers/dedup/main.py
@@ -8,6 +8,7 @@ from workers.dedup.processor import DedupProcessor
 from workers.lib.log import configure_logging, get_logger
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
+from workers.lib.topics import PIPELINE_DEDUP_DONE, PIPELINE_RAW_LANDED
 
 _logger = get_logger("workers.dedup")
 
@@ -23,8 +24,8 @@ def build_runner() -> WorkerRunner:
 
     settings = WorkerSettings(
         worker_name="dedup-worker",
-        consume_topic="pipeline.raw.new",
-        produce_topic="pipeline.dedup.done",
+        consume_topic=PIPELINE_RAW_LANDED,
+        produce_topic=PIPELINE_DEDUP_DONE,
         consumer_group="dedup-worker",
     )
     consumer = KafkaConsumer(

--- a/workers/dedup/processor.py
+++ b/workers/dedup/processor.py
@@ -1,41 +1,260 @@
-"""dedup-worker processor.
+"""dedup-worker processor — port of ``src/resolve/dedup.py`` for streaming.
 
-Happy path:
+Ported behaviour (per-batch):
 
-1. Fetch input Parquet at ``msg.b2_path``
-2. Compute dedup/parallel-link output (placeholder pass-through)
-3. Write output to ``dedup/{source}/{batch_id}/hadiths.parquet``
-4. Return next-stage pointer
+1. Fetch input Parquet at ``msg.b2_path`` (schema: ``HADITH_SCHEMA``).
+2. Embed ``matn_en`` with a sentence-transformers model.
+3. Build an in-batch FAISS IndexFlatIP over the normalized embeddings.
+4. Retrieve top-K neighbours, filter by threshold, classify via variant
+   tiering (VERBATIM ≥ 0.90, CLOSE_PARAPHRASE ≥ 0.80, else THEMATIC),
+   and flag cross-sect pairs.
+5. Emit ``dedup/{source}/{batch_id}/parallel_links.parquet`` plus the
+   pass-through ``hadiths.parquet`` so downstream stages have a payload.
 
-TODO (follow-up issue): port the full logic from
-``src/resolve/dedup.py`` — FAISS index build, variant-type tiering,
-cross-sect detection. Current scaffold writes the input Parquet
-unchanged so downstream stages have something to consume during
-integration testing.
+Known scope limitation vs upstream batch job
+--------------------------------------------
+The upstream ``run_dedup`` operates over a staging directory spanning
+multiple source corpora and thus detects cross-batch/cross-source
+duplicates. A Kafka worker sees one batch at a time, so only
+*intra-batch* pairs are emitted here. Cross-batch reconciliation is a
+post-pipeline concern and is tracked outside this issue.
+
+Graceful degradation
+--------------------
+Missing optional ML dependencies (``sentence-transformers``, ``faiss``,
+``numpy``) do not fail the message. We log and emit an empty
+``parallel_links.parquet`` matching ``PARALLEL_LINKS_SCHEMA``, same as
+the upstream's behaviour.
+
+Stateful components (embedding model, FAISS class) are lazy-initialised
+at first-message time and cached on the processor instance so later
+messages reuse them.
 """
 
 from __future__ import annotations
 
+import io
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.models.enums import VariantType
+from src.resolve.schemas import PARALLEL_LINKS_SCHEMA
+from workers.lib.log import get_logger
 from workers.lib.message import PipelineMessage
 from workers.lib.object_store import ObjectStore
 
 __all__ = ["DedupProcessor"]
 
+_logger = get_logger("workers.dedup")
+
+_SUNNI_SOURCES: frozenset[str] = frozenset({"lk", "sanadset", "sunnah", "fawaz", "open_hadith"})
+_SHIA_SOURCES: frozenset[str] = frozenset({"thaqalayn"})
+
+_EMBED_MODEL_NAME = "paraphrase-multilingual-MiniLM-L12-v2"
+_DEFAULT_BATCH_SIZE = 256
+_DEFAULT_TOP_K = 50
+_DEFAULT_THRESHOLD = 0.70
+
+
+def _classify_pair(score: float) -> VariantType:
+    if score >= 0.90:
+        return VariantType.VERBATIM
+    if score >= 0.80:
+        return VariantType.CLOSE_PARAPHRASE
+    return VariantType.THEMATIC
+
+
+def _is_cross_sect(corpus_a: str, corpus_b: str) -> bool:
+    a_sunni = corpus_a in _SUNNI_SOURCES
+    b_sunni = corpus_b in _SUNNI_SOURCES
+    a_shia = corpus_a in _SHIA_SOURCES
+    b_shia = corpus_b in _SHIA_SOURCES
+    return (a_sunni and b_shia) or (a_shia and b_sunni)
+
+
+def _empty_links_bytes() -> bytes:
+    """Serialize an empty PARALLEL_LINKS_SCHEMA table to Parquet bytes."""
+    buf = io.BytesIO()
+    pq.write_table(PARALLEL_LINKS_SCHEMA.empty_table(), buf)
+    return buf.getvalue()
+
 
 class DedupProcessor:
-    """Callable processor wired into :class:`workers.lib.runner.WorkerRunner`."""
+    """Callable processor: dedup a single batch and emit parallel-link pairs."""
 
-    def __init__(self, store: ObjectStore) -> None:
+    def __init__(
+        self,
+        store: ObjectStore,
+        *,
+        top_k: int = _DEFAULT_TOP_K,
+        threshold: float = _DEFAULT_THRESHOLD,
+        embed_batch_size: int = _DEFAULT_BATCH_SIZE,
+    ) -> None:
         self.store = store
+        self.top_k = top_k
+        self.threshold = threshold
+        self.embed_batch_size = embed_batch_size
+        self._model: Any | None = None
+        self._faiss: Any | None = None
+        self._np: Any | None = None
+        self._ml_unavailable = False
+
+    def _ensure_ml(self) -> bool:
+        """Lazy-init ML deps. Returns False if any dep is missing."""
+        if self._ml_unavailable:
+            return False
+        if self._model is not None and self._faiss is not None and self._np is not None:
+            return True
+        try:
+            import faiss
+            import numpy as np
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            _logger.warning(
+                "dedup_ml_deps_unavailable",
+                error=str(exc),
+                hint="install the 'ml' dependency group for real dedup",
+            )
+            self._ml_unavailable = True
+            return False
+        if self._model is None:
+            _logger.info("dedup_loading_model", model=_EMBED_MODEL_NAME)
+            self._model = SentenceTransformer(_EMBED_MODEL_NAME)
+        self._faiss = faiss
+        self._np = np
+        return True
+
+    def _load_batch(self, payload: bytes) -> tuple[list[str], list[str], list[str]]:
+        """Read the input Parquet and return (ids, texts, corpora), dropping null matn rows."""
+        table = pq.read_table(
+            io.BytesIO(payload), columns=["source_id", "matn_en", "source_corpus"]
+        )
+        ids: list[str] = []
+        texts: list[str] = []
+        corpora: list[str] = []
+        skipped = 0
+        for i in range(table.num_rows):
+            matn = table.column("matn_en")[i].as_py()
+            if not matn or not matn.strip():
+                skipped += 1
+                continue
+            ids.append(table.column("source_id")[i].as_py())
+            texts.append(matn)
+            corpora.append(table.column("source_corpus")[i].as_py())
+        if skipped:
+            _logger.info("dedup_skipped_null_matn", skipped=skipped, kept=len(ids))
+        return ids, texts, corpora
+
+    def _embed(self, texts: list[str]) -> Any:
+        assert self._model is not None
+        assert self._np is not None
+        np_ = self._np
+        chunks: list[Any] = []
+        for start in range(0, len(texts), self.embed_batch_size):
+            end = min(start + self.embed_batch_size, len(texts))
+            chunk = self._model.encode(
+                texts[start:end],
+                batch_size=self.embed_batch_size,
+                show_progress_bar=False,
+                convert_to_numpy=True,
+                normalize_embeddings=True,
+            )
+            chunks.append(chunk)
+        return np_.ascontiguousarray(np_.vstack(chunks), dtype=np_.float32)
+
+    def _find_pairs(
+        self,
+        hadith_ids: list[str],
+        corpora: list[str],
+        embeddings: Any,
+    ) -> pa.Table:
+        """Run FAISS top-K search and collect pairs above threshold."""
+        assert self._faiss is not None
+        dim = embeddings.shape[1]
+        index = self._faiss.IndexFlatIP(dim)
+        index.add(embeddings)
+        actual_k = min(self.top_k + 1, len(hadith_ids))
+        scores, indices = index.search(embeddings, actual_k)
+
+        id_to_corpus = dict(zip(hadith_ids, corpora))
+        seen_pairs: set[tuple[str, str]] = set()
+        ids_a: list[str] = []
+        ids_b: list[str] = []
+        sim_scores: list[float] = []
+        variant_types: list[str] = []
+        cross_sects: list[bool] = []
+
+        for i in range(len(hadith_ids)):
+            hid_a = hadith_ids[i]
+            for j_idx in range(actual_k):
+                neighbor = int(indices[i, j_idx])
+                score = float(scores[i, j_idx])
+                if neighbor < 0 or neighbor == i or score < self.threshold:
+                    continue
+                hid_b = hadith_ids[neighbor]
+                pair_key = (hid_b, hid_a) if hid_a >= hid_b else (hid_a, hid_b)
+                if pair_key in seen_pairs:
+                    continue
+                seen_pairs.add(pair_key)
+                ids_a.append(pair_key[0])
+                ids_b.append(pair_key[1])
+                sim_scores.append(score)
+                variant_types.append(str(_classify_pair(score)))
+                cross_sects.append(
+                    _is_cross_sect(id_to_corpus[pair_key[0]], id_to_corpus[pair_key[1]])
+                )
+
+        return pa.table(
+            {
+                "hadith_id_a": pa.array(ids_a, type=pa.string()),
+                "hadith_id_b": pa.array(ids_b, type=pa.string()),
+                "similarity_score": pa.array(sim_scores, type=pa.float32()),
+                "variant_type": pa.array(variant_types, type=pa.string()),
+                "cross_sect": pa.array(cross_sects, type=pa.bool_()),
+            },
+            schema=PARALLEL_LINKS_SCHEMA,
+        )
 
     def __call__(self, msg: PipelineMessage) -> PipelineMessage:
         payload = self.store.get_object(msg.b2_path)
 
-        # TODO: invoke real dedup — load Parquet, build FAISS index,
-        # classify variant pairs, emit PARALLEL_LINKS schema.
-        deduped = payload
+        out_prefix = f"dedup/{msg.source}/{msg.batch_id}"
+        hadiths_key = f"{out_prefix}/hadiths.parquet"
+        links_key = f"{out_prefix}/parallel_links.parquet"
 
-        out_key = f"dedup/{msg.source}/{msg.batch_id}/hadiths.parquet"
-        self.store.put_object(out_key, deduped)
+        # Pass-through the hadith payload unchanged so downstream stages
+        # consume from the dedup prefix regardless of dedup success.
+        self.store.put_object(hadiths_key, payload)
 
-        return msg.to_next_stage(b2_path=out_key)
+        if not self._ensure_ml():
+            self.store.put_object(links_key, _empty_links_bytes())
+            return msg.to_next_stage(b2_path=hadiths_key)
+
+        try:
+            ids, texts, corpora = self._load_batch(payload)
+        except pa.ArrowInvalid as exc:
+            # Malformed Parquet → raise so the runner routes to DLQ.
+            _logger.error("dedup_bad_parquet", batch_id=msg.batch_id, error=str(exc))
+            raise
+
+        if not texts:
+            _logger.info("dedup_no_texts", batch_id=msg.batch_id)
+            self.store.put_object(links_key, _empty_links_bytes())
+            return msg.to_next_stage(b2_path=hadiths_key)
+
+        embeddings = self._embed(texts)
+        links_table = self._find_pairs(ids, corpora, embeddings)
+
+        buf = io.BytesIO()
+        pq.write_table(links_table, buf)
+        self.store.put_object(links_key, buf.getvalue())
+
+        _logger.info(
+            "dedup_complete",
+            batch_id=msg.batch_id,
+            hadiths=len(ids),
+            pairs=links_table.num_rows,
+        )
+        return msg.to_next_stage(b2_path=hadiths_key)

--- a/workers/enrich/main.py
+++ b/workers/enrich/main.py
@@ -8,6 +8,7 @@ from workers.enrich.processor import EnrichProcessor
 from workers.lib.log import configure_logging, get_logger
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
+from workers.lib.topics import PIPELINE_DEDUP_DONE, PIPELINE_ENRICH_DONE
 
 _logger = get_logger("workers.enrich")
 
@@ -21,8 +22,8 @@ def build_runner() -> WorkerRunner:
 
     settings = WorkerSettings(
         worker_name="enrich-worker",
-        consume_topic="pipeline.dedup.done",
-        produce_topic="pipeline.enrich.done",
+        consume_topic=PIPELINE_DEDUP_DONE,
+        produce_topic=PIPELINE_ENRICH_DONE,
         consumer_group="enrich-worker",
     )
     consumer = KafkaConsumer(

--- a/workers/enrich/processor.py
+++ b/workers/enrich/processor.py
@@ -1,31 +1,234 @@
-"""enrich-worker processor.
+"""enrich-worker processor — per-batch topic classification.
 
-TODO (follow-up issue): port ``src/enrich/metrics.py``,
-``src/enrich/topics.py``, ``src/enrich/historical.py``. Current scaffold
-is a pass-through so the full pipeline can be exercised end-to-end
-during integration testing.
+What this stage does
+--------------------
+Reads the dedup-stage Parquet, runs zero-shot topic classification on
+``matn_en`` using ``facebook/bart-large-mnli`` (mirrors
+``src/enrich/topics.py``), and emits:
+
+* ``enriched/{source}/{batch_id}/hadiths.parquet`` — pass-through of the
+  input payload so downstream stages continue to see the hadith rows.
+* ``enriched/{source}/{batch_id}/hadith_topics.parquet`` — a new side
+  table with ``(source_id, topic_1, topic_1_score, topic_2,
+  topic_2_score, topic_3, topic_3_score)`` that the ingest stage can
+  read alongside the hadith rows when MERGEing into Neo4j.
+
+Scope note — graph-dependent enrichments deferred
+--------------------------------------------------
+``src/enrich/metrics.py`` (Neo4j GDS centrality / PageRank / Louvain)
+and ``src/enrich/historical.py`` (ACTIVE_DURING edges by date overlap)
+both read and write the Neo4j graph after nodes and edges already
+exist. They cannot run before ingest. In the streaming topology they
+belong to a post-ingest enrichment stage (tracked as a follow-up);
+only the payload-only classifier is ported here.
+
+Graceful degradation
+--------------------
+Missing ``transformers`` / ``torch``, model-download failures, or a
+single-batch classifier error log and emit an empty topics side table
+rather than fail the message.
 """
 
 from __future__ import annotations
 
+import io
+import os
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from workers.lib.log import get_logger
 from workers.lib.message import PipelineMessage
 from workers.lib.object_store import ObjectStore
 
 __all__ = ["EnrichProcessor"]
 
+_logger = get_logger("workers.enrich")
+
+_MODEL_NAME = "facebook/bart-large-mnli"
+_BATCH_SIZE = 32
+_MIN_TEXT_LENGTH = 20
+
+TOPIC_LABELS: tuple[str, ...] = (
+    "theology",
+    "jurisprudence",
+    "eschatology",
+    "succession/imamate",
+    "ritual/worship",
+    "ethics/conduct",
+    "history/sira",
+    "commerce/trade",
+    "warfare/jihad",
+    "family_law",
+    "food/drink",
+    "medicine",
+    "dreams/visions",
+    "end_times",
+)
+
+HADITH_TOPICS_SCHEMA = pa.schema(
+    [
+        pa.field("source_id", pa.string(), nullable=False),
+        pa.field("topic_1", pa.string(), nullable=True),
+        pa.field("topic_1_score", pa.float32(), nullable=True),
+        pa.field("topic_2", pa.string(), nullable=True),
+        pa.field("topic_2_score", pa.float32(), nullable=True),
+        pa.field("topic_3", pa.string(), nullable=True),
+        pa.field("topic_3_score", pa.float32(), nullable=True),
+    ]
+)
+
+
+def _empty_topics_bytes() -> bytes:
+    buf = io.BytesIO()
+    pq.write_table(HADITH_TOPICS_SCHEMA.empty_table(), buf)
+    return buf.getvalue()
+
 
 class EnrichProcessor:
-    def __init__(self, store: ObjectStore) -> None:
+    """Callable processor: classify topics per hadith in the batch."""
+
+    def __init__(
+        self,
+        store: ObjectStore,
+        *,
+        labels: tuple[str, ...] = TOPIC_LABELS,
+        batch_size: int = _BATCH_SIZE,
+    ) -> None:
         self.store = store
+        self.labels = list(labels)
+        self.batch_size = batch_size
+        self._classifier: Any | None = None
+        self._ml_unavailable = False
+
+    def _ensure_classifier(self) -> bool:
+        if self._ml_unavailable:
+            return False
+        if self._classifier is not None:
+            return True
+        try:
+            from transformers import pipeline
+        except ImportError as exc:
+            _logger.warning(
+                "enrich_transformers_unavailable",
+                error=str(exc),
+                hint="install the 'ml' dependency group for real topic classification",
+            )
+            self._ml_unavailable = True
+            return False
+
+        offline = os.environ.get("HF_HUB_OFFLINE", "0") == "1"
+        kwargs: dict[str, Any] = {"model": _MODEL_NAME, "device": -1}
+        if offline:
+            kwargs["local_files_only"] = True
+        try:
+            self._classifier = pipeline("zero-shot-classification", **kwargs)
+        except Exception as exc:  # noqa: BLE001 — includes HF network/hub errors
+            _logger.error("enrich_pipeline_load_failed", model=_MODEL_NAME, error=str(exc))
+            self._ml_unavailable = True
+            return False
+        _logger.info("enrich_pipeline_loaded", model=_MODEL_NAME)
+        return True
+
+    def _load_batch(self, payload: bytes) -> tuple[list[str], list[str]]:
+        """Read the input Parquet and return (ids, texts), dropping too-short matn rows."""
+        table = pq.read_table(io.BytesIO(payload), columns=["source_id", "matn_en"])
+        ids: list[str] = []
+        texts: list[str] = []
+        for i in range(table.num_rows):
+            matn = table.column("matn_en")[i].as_py()
+            if not matn or len(matn) < _MIN_TEXT_LENGTH:
+                continue
+            ids.append(table.column("source_id")[i].as_py())
+            texts.append(matn)
+        return ids, texts
+
+    def _classify_rows(self, ids: list[str], texts: list[str]) -> list[dict[str, Any]]:
+        assert self._classifier is not None
+        rows: list[dict[str, Any]] = []
+        for start in range(0, len(texts), self.batch_size):
+            end = min(start + self.batch_size, len(texts))
+            chunk_texts = texts[start:end]
+            chunk_ids = ids[start:end]
+            try:
+                results = self._classifier(
+                    chunk_texts, candidate_labels=self.labels, multi_label=False
+                )
+            except Exception as exc:  # noqa: BLE001
+                _logger.error("enrich_batch_failed", offset=start, error=str(exc))
+                continue
+            if isinstance(results, dict):
+                results = [results]
+            for hid, result in zip(chunk_ids, results):
+                labels = result["labels"]
+                scores = result["scores"]
+                rows.append(
+                    {
+                        "source_id": hid,
+                        "topic_1": labels[0],
+                        "topic_1_score": round(float(scores[0]), 4),
+                        "topic_2": labels[1] if len(labels) > 1 else None,
+                        "topic_2_score": (round(float(scores[1]), 4) if len(scores) > 1 else None),
+                        "topic_3": labels[2] if len(labels) > 2 else None,
+                        "topic_3_score": (round(float(scores[2]), 4) if len(scores) > 2 else None),
+                    }
+                )
+        return rows
+
+    def _build_topics_table(self, rows: list[dict[str, Any]]) -> pa.Table:
+        if not rows:
+            return HADITH_TOPICS_SCHEMA.empty_table()
+        return pa.table(
+            {
+                "source_id": pa.array([r["source_id"] for r in rows], type=pa.string()),
+                "topic_1": pa.array([r["topic_1"] for r in rows], type=pa.string()),
+                "topic_1_score": pa.array([r["topic_1_score"] for r in rows], type=pa.float32()),
+                "topic_2": pa.array([r["topic_2"] for r in rows], type=pa.string()),
+                "topic_2_score": pa.array([r["topic_2_score"] for r in rows], type=pa.float32()),
+                "topic_3": pa.array([r["topic_3"] for r in rows], type=pa.string()),
+                "topic_3_score": pa.array([r["topic_3_score"] for r in rows], type=pa.float32()),
+            },
+            schema=HADITH_TOPICS_SCHEMA,
+        )
 
     def __call__(self, msg: PipelineMessage) -> PipelineMessage:
         payload = self.store.get_object(msg.b2_path)
 
-        # TODO: invoke graph metrics (PageRank / Louvain via GDS), topic
-        # classifier (transformer 14-label), and historical event linker.
-        enriched = payload
+        out_prefix = f"enriched/{msg.source}/{msg.batch_id}"
+        hadiths_key = f"{out_prefix}/hadiths.parquet"
+        topics_key = f"{out_prefix}/hadith_topics.parquet"
 
-        out_key = f"enriched/{msg.source}/{msg.batch_id}/hadiths.parquet"
-        self.store.put_object(out_key, enriched)
+        # Always pass-through the hadith payload so downstream stages
+        # see the full set of rows regardless of classifier availability.
+        self.store.put_object(hadiths_key, payload)
 
-        return msg.to_next_stage(b2_path=out_key)
+        if not self._ensure_classifier():
+            self.store.put_object(topics_key, _empty_topics_bytes())
+            return msg.to_next_stage(b2_path=hadiths_key)
+
+        try:
+            ids, texts = self._load_batch(payload)
+        except pa.ArrowInvalid as exc:
+            _logger.error("enrich_bad_parquet", batch_id=msg.batch_id, error=str(exc))
+            raise
+
+        if not texts:
+            _logger.info("enrich_no_texts", batch_id=msg.batch_id)
+            self.store.put_object(topics_key, _empty_topics_bytes())
+            return msg.to_next_stage(b2_path=hadiths_key)
+
+        rows = self._classify_rows(ids, texts)
+        topics_table = self._build_topics_table(rows)
+
+        buf = io.BytesIO()
+        pq.write_table(topics_table, buf)
+        self.store.put_object(topics_key, buf.getvalue())
+
+        _logger.info(
+            "enrich_complete",
+            batch_id=msg.batch_id,
+            hadiths=len(ids),
+            classified=topics_table.num_rows,
+        )
+        return msg.to_next_stage(b2_path=hadiths_key)

--- a/workers/lib/dlq.py
+++ b/workers/lib/dlq.py
@@ -14,10 +14,13 @@ from datetime import UTC, datetime
 from typing import Any
 
 from workers.lib.message import PipelineMessage
+from workers.lib.topics import PIPELINE_DLQ
 
-__all__ = ["DLQRecord", "build_dlq_record"]
+__all__ = ["DLQ_TOPIC", "DLQRecord", "build_dlq_record"]
 
-DLQ_TOPIC = "pipeline.dlq"
+# Backwards-compatible alias — runner.py and tests still import DLQ_TOPIC.
+# The canonical name is workers.lib.topics.PIPELINE_DLQ.
+DLQ_TOPIC = PIPELINE_DLQ
 
 
 class DLQRecord:

--- a/workers/lib/log.py
+++ b/workers/lib/log.py
@@ -64,4 +64,5 @@ def get_logger(name: str) -> structlog.stdlib.BoundLogger:
     """Fetch a bound logger. Auto-configures on first call."""
     if not _configured:
         configure_logging()
-    return structlog.get_logger(name)
+    logger: structlog.stdlib.BoundLogger = structlog.get_logger(name)
+    return logger

--- a/workers/lib/message.py
+++ b/workers/lib/message.py
@@ -36,7 +36,14 @@ class PipelineMessage(BaseModel):
     batch_id: str = Field(..., description="UUID identifying this processing batch")
     source: str = Field(..., description="Data source identifier, e.g. 'sunnah-api'")
     b2_path: str = Field(
-        ..., description="S3 object key, e.g. 'raw/sunnah-api/2026-04-13/x.parquet'"
+        ...,
+        description=(
+            "S3 path. Two forms (both valid — the consumer stage dictates which): "
+            "(1) a single object key, e.g. 'raw/sunnah-api/2026-04-13/x.parquet'; "
+            "(2) a folder prefix with a trailing slash, e.g. 'normalized/<batch_id>/', "
+            "used by the normalize→ingest hand-off (#192 D-ii) where ingest reads "
+            "'_MANIFEST.json' under the prefix to discover the per-label Parquets."
+        ),
     )
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(UTC),

--- a/workers/lib/object_store.py
+++ b/workers/lib/object_store.py
@@ -58,3 +58,19 @@ class ObjectStore:
     ) -> None:
         """Upload ``data`` to ``key`` in the configured bucket."""
         self.client.put_object(Bucket=self.bucket, Key=key, Body=data, ContentType=content_type)
+
+    def rename_object(self, src_key: str, dst_key: str) -> None:
+        """Atomically rename ``src_key`` to ``dst_key`` within the bucket.
+
+        Implemented as server-side copy + delete: ``CopyObject`` is atomic
+        from the reader's perspective (the destination either exists fully
+        or not at all), and the subsequent delete reclaims the source key.
+        Used by normalize (#192 D-ii) to stage per-label Parquets as
+        ``.part`` files and promote them once the write succeeds.
+        """
+        self.client.copy_object(
+            Bucket=self.bucket,
+            Key=dst_key,
+            CopySource={"Bucket": self.bucket, "Key": src_key},
+        )
+        self.client.delete_object(Bucket=self.bucket, Key=src_key)

--- a/workers/lib/topics.py
+++ b/workers/lib/topics.py
@@ -1,0 +1,52 @@
+"""Pipeline Kafka topic constants and node-label vocabulary.
+
+Single source of truth for topic names across every worker and every
+upstream producer (e.g. ``noorinalabs-data-acquisition``'s
+``kafka_producer.py``). All pipeline constants live here so a rename
+requires exactly one edit.
+
+Naming convention (locked in #192):
+
+    pipeline.<stage>.<past-tense-event>
+
+``<past-tense-event>`` describes the state of the batch after the stage
+finishes (``.landed``, ``.done``). ``.dlq`` is the terminal failure
+sink, one topic shared by all workers.
+
+The node-label vocabulary (``ALLOWED_NODE_LABELS``) lives here rather
+than in ``workers/ingest/processor.py`` so the normalize stage can
+validate its fan-out output against the same set ingest will MERGE with,
+without creating a normalize→ingest import cycle.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "ALLOWED_NODE_LABELS",
+    "PIPELINE_DEDUP_DONE",
+    "PIPELINE_DLQ",
+    "PIPELINE_ENRICH_DONE",
+    "PIPELINE_NORMALIZE_DONE",
+    "PIPELINE_RAW_LANDED",
+]
+
+PIPELINE_RAW_LANDED: str = "pipeline.raw.landed"
+PIPELINE_DEDUP_DONE: str = "pipeline.dedup.done"
+PIPELINE_ENRICH_DONE: str = "pipeline.enrich.done"
+PIPELINE_NORMALIZE_DONE: str = "pipeline.normalize.done"
+PIPELINE_DLQ: str = "pipeline.dlq"
+
+# Node labels the normalize stage may emit and the ingest stage may MERGE.
+# Kept explicit to prevent Cypher-label injection and to document the
+# unified entity vocabulary shared by the pipeline.
+ALLOWED_NODE_LABELS: frozenset[str] = frozenset(
+    {
+        "Narrator",
+        "Hadith",
+        "Collection",
+        "Chain",
+        "Grading",
+        "HistoricalEvent",
+        "Location",
+    }
+)

--- a/workers/normalize/main.py
+++ b/workers/normalize/main.py
@@ -7,6 +7,7 @@ import os
 from workers.lib.log import configure_logging, get_logger
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
+from workers.lib.topics import PIPELINE_ENRICH_DONE, PIPELINE_NORMALIZE_DONE
 from workers.normalize.processor import NormalizeProcessor
 
 _logger = get_logger("workers.normalize")
@@ -21,8 +22,8 @@ def build_runner() -> WorkerRunner:
 
     settings = WorkerSettings(
         worker_name="normalize-worker",
-        consume_topic="pipeline.enrich.done",
-        produce_topic="pipeline.norm.done",
+        consume_topic=PIPELINE_ENRICH_DONE,
+        produce_topic=PIPELINE_NORMALIZE_DONE,
         consumer_group="normalize-worker",
     )
     consumer = KafkaConsumer(

--- a/workers/normalize/processor.py
+++ b/workers/normalize/processor.py
@@ -1,35 +1,111 @@
-"""normalize-worker processor.
+"""normalize-worker processor — unify per-source schemas.
 
-Goal: map every per-source schema onto a single unified schema so
-ingest-worker can write Neo4j nodes/edges without source-specific
-branches.
+Goal
+----
+Produce a single unified hadith Parquet that the ingest worker can MERGE
+into Neo4j without per-source branches. Each source parser in
+``src/parse/*`` already emits rows that roughly follow
+``HADITH_SCHEMA``, but:
 
-TODO (follow-up issue): define the unified schema (anchor on
-``HADITH_SCHEMA`` + ``NARRATOR_MENTION_SCHEMA`` from
-``src/resolve/schemas.py``) and implement per-source field mapping.
-Current scaffold writes the input Parquet unchanged but to the
-normalized prefix so pointers flow through.
+* column order and nullability can drift between sources
+* required non-null fields (``source_id``, ``source_corpus``,
+  ``collection_name``, ``sect``) may occasionally be missing from a
+  malformed batch
+* extra columns produced by earlier stages (e.g. dedup side data) need
+  to be stripped before graph load
+
+This processor anchors on ``HADITH_SCHEMA`` from ``src/parse/schemas.py``
+and performs:
+
+1. Schema validation — every column required by the target schema must
+   be present in the input.
+2. Row filtering — rows missing any non-nullable target field are
+   dropped and counted.
+3. Column selection + cast — output is exactly ``HADITH_SCHEMA`` order /
+   types, dropping any unexpected columns.
+
+A rich cross-source mapping (e.g. flattening alternate isnad
+representations) is deliberately out of scope — it will arrive in a
+follow-up issue once ingest's Neo4j writes stabilise.
 """
 
 from __future__ import annotations
 
+import io
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.parse.schemas import HADITH_SCHEMA
+from workers.lib.log import get_logger
 from workers.lib.message import PipelineMessage
 from workers.lib.object_store import ObjectStore
 
 __all__ = ["NormalizeProcessor"]
 
+_logger = get_logger("workers.normalize")
+
+
+def _required_fields(schema: pa.Schema) -> list[str]:
+    return [f.name for f in schema if not f.nullable]
+
 
 class NormalizeProcessor:
-    def __init__(self, store: ObjectStore) -> None:
+    """Callable processor: coerce a batch to ``HADITH_SCHEMA`` shape."""
+
+    def __init__(self, store: ObjectStore, target_schema: pa.Schema = HADITH_SCHEMA) -> None:
         self.store = store
+        self.target_schema = target_schema
+        self._required = _required_fields(target_schema)
+
+    def _normalize(self, payload: bytes) -> tuple[pa.Table, int]:
+        """Return (normalized_table, dropped_row_count). Raises on unusable input."""
+        table = pq.read_table(io.BytesIO(payload))
+
+        missing = [f.name for f in self.target_schema if f.name not in table.column_names]
+        if missing:
+            raise ValueError(f"input parquet missing required columns: {missing}")
+
+        projected = table.select([f.name for f in self.target_schema])
+
+        # Drop rows with a null in any required-non-nullable field.
+        dropped = 0
+        if self._required:
+            mask = pa.array([True] * projected.num_rows, type=pa.bool_())
+            import pyarrow.compute as pc
+
+            for name in self._required:
+                not_null = pc.is_valid(projected.column(name))
+                mask = pc.and_(mask, not_null)
+            kept = projected.filter(mask)
+            dropped = projected.num_rows - kept.num_rows
+            projected = kept
+
+        try:
+            normalized = projected.cast(self.target_schema, safe=False)
+        except pa.ArrowInvalid as exc:
+            raise ValueError(f"cannot cast batch to HADITH_SCHEMA: {exc}") from exc
+
+        return normalized, dropped
 
     def __call__(self, msg: PipelineMessage) -> PipelineMessage:
         payload = self.store.get_object(msg.b2_path)
 
-        # TODO: apply unified-schema mapping per source.
-        normalized = payload
+        try:
+            normalized, dropped = self._normalize(payload)
+        except (pa.ArrowInvalid, ValueError) as exc:
+            _logger.error("normalize_invalid_batch", batch_id=msg.batch_id, error=str(exc))
+            raise
 
         out_key = f"normalized/{msg.batch_id}/hadiths.parquet"
-        self.store.put_object(out_key, normalized)
+        buf = io.BytesIO()
+        pq.write_table(normalized, buf)
+        self.store.put_object(out_key, buf.getvalue())
 
-        return msg.to_next_stage(b2_path=out_key)
+        _logger.info(
+            "normalize_complete",
+            batch_id=msg.batch_id,
+            rows=normalized.num_rows,
+            dropped=dropped,
+        )
+        return msg.to_next_stage(b2_path=out_key, record_count=normalized.num_rows)

--- a/workers/normalize/processor.py
+++ b/workers/normalize/processor.py
@@ -1,49 +1,413 @@
-"""normalize-worker processor — unify per-source schemas.
+"""normalize-worker processor — fan out hadith rows into graph entities.
 
-Goal
-----
-Produce a single unified hadith Parquet that the ingest worker can MERGE
-into Neo4j without per-source branches. Each source parser in
-``src/parse/*`` already emits rows that roughly follow
-``HADITH_SCHEMA``, but:
+Per #192 Option D-ii the normalize stage writes *per-label* Parquet
+files plus a ``_MANIFEST.json`` into a folder prefix keyed by
+``batch_id``. Ingest (#18) reads the manifest to MERGE nodes in
+node-first-then-edges order in a single Neo4j session.
 
-* column order and nullability can drift between sources
-* required non-null fields (``source_id``, ``source_corpus``,
-  ``collection_name``, ``sect``) may occasionally be missing from a
-  malformed batch
-* extra columns produced by earlier stages (e.g. dedup side data) need
-  to be stripped before graph load
+Output layout::
 
-This processor anchors on ``HADITH_SCHEMA`` from ``src/parse/schemas.py``
-and performs:
+    normalized/<batch_id>/
+        narrators.parquet         # Narrator nodes
+        hadiths.parquet           # Hadith nodes
+        collections.parquet       # Collection nodes (deduped within batch)
+        chains.parquet            # Chain nodes (one per hadith)
+        gradings.parquet          # Grading nodes (only if grade present)
+        edges.parquet             # all relationships
+        _MANIFEST.json            # written LAST
 
-1. Schema validation — every column required by the target schema must
-   be present in the input.
-2. Row filtering — rows missing any non-nullable target field are
-   dropped and counted.
-3. Column selection + cast — output is exactly ``HADITH_SCHEMA`` order /
-   types, dropping any unexpected columns.
+Every per-label Parquet row has the shape ``{label, id, props}`` where
+``props`` is a free-form dict carried through to Neo4j properties. The
+edge Parquet has ``{label, src_id, src_label, dst_id, dst_label,
+props}``. That shape is what ingest's ``_group_rows_by_label``
+expects and matches the upstream batch loaders in
+``src/graph/load_{nodes,edges}.py``.
 
-A rich cross-source mapping (e.g. flattening alternate isnad
-representations) is deliberately out of scope — it will arrive in a
-follow-up issue once ingest's Neo4j writes stabilise.
+Stable-ID generation
+--------------------
+IDs are deterministic so re-processing the same batch produces the same
+node identities (idempotent ingest MERGE). Hash inputs:
+
+* ``Hadith``   — ``hdt:<source_corpus>:<source_id>`` (already canonical
+  from the source parser; no hashing required).
+* ``Narrator`` — ``nar:<sha1-24>`` of
+  ``<lower(name_en)>|<normalize_arabic(name_ar)>``. Blank sides are
+  represented as the empty string so pure-English and pure-Arabic
+  mentions still produce stable IDs.
+* ``Chain``    — ``chn:<sha1-24>`` of
+  ``<hadith_id>|<|-joined narrator_ids in chain order>``.
+* ``Collection`` — ``col:<normalized_collection_name>`` (lowercase,
+  spaces→underscores). Not hashed so the ID is human-readable and
+  matches ``src/graph/load_nodes.py``.
+* ``Grading`` — ``grd:<hadith_id>``; one grading node per hadith.
+
+Phase-4 safety note (ingest side)
+---------------------------------
+Rows carry their properties inside a ``props`` dict rather than as
+individual columns. Ingest's Cypher MUST translate this into enumerated
+``SET n.key = row.props.key`` stanzas rather than ``SET n += row.props``
+— Farhan flagged ``SET +=`` as unsafe because it lets an attacker-
+controlled property name (``id``, ``:label``) subvert the node. See
+#192 comment thread for the decision.
 """
 
 from __future__ import annotations
 
+import hashlib
 import io
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
 
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.parquet as pq
 
+from src.parse.narrator_extraction import extract_narrator_mentions
 from src.parse.schemas import HADITH_SCHEMA
 from workers.lib.log import get_logger
 from workers.lib.message import PipelineMessage
 from workers.lib.object_store import ObjectStore
+from workers.lib.topics import ALLOWED_NODE_LABELS
 
 __all__ = ["NormalizeProcessor"]
 
 _logger = get_logger("workers.normalize")
+
+# Parquet filename for each node label. Labels absent from this map are
+# not emitted by normalize; ingest will simply skip them (manifest lists
+# only the files that were written).
+_NODE_FILENAMES: dict[str, str] = {
+    "Narrator": "narrators.parquet",
+    "Hadith": "hadiths.parquet",
+    "Collection": "collections.parquet",
+    "Chain": "chains.parquet",
+    "Grading": "gradings.parquet",
+    # HistoricalEvent and Location are curated (YAML-sourced) rather than
+    # extracted from hadith rows, so normalize doesn't emit them today.
+    # They stay in ALLOWED_NODE_LABELS for the vocabulary contract with
+    # ingest.
+}
+
+_EDGES_FILENAME = "edges.parquet"
+_MANIFEST_FILENAME = "_MANIFEST.json"
+
+# --------------------------------------------------------------------------
+# Node + edge row shapes. Flat Arrow schemas let each per-label Parquet
+# roundtrip cleanly through pyarrow without relying on struct/map types.
+# --------------------------------------------------------------------------
+
+_NODE_SCHEMA: pa.Schema = pa.schema(
+    [
+        pa.field("label", pa.string(), nullable=False),
+        pa.field("id", pa.string(), nullable=False),
+        # props is JSON-encoded so ingest can json.loads() it regardless
+        # of which downstream props are present. Avoids an exhaustive
+        # per-label Arrow schema for this early phase.
+        pa.field("props", pa.string(), nullable=False),
+    ]
+)
+
+_EDGE_SCHEMA: pa.Schema = pa.schema(
+    [
+        pa.field("label", pa.string(), nullable=False),
+        pa.field("src_id", pa.string(), nullable=False),
+        pa.field("src_label", pa.string(), nullable=False),
+        pa.field("dst_id", pa.string(), nullable=False),
+        pa.field("dst_label", pa.string(), nullable=False),
+        pa.field("props", pa.string(), nullable=False),
+    ]
+)
+
+
+@dataclass(frozen=True)
+class _NodeRow:
+    label: str
+    id: str
+    props: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _EdgeRow:
+    label: str
+    src_id: str
+    src_label: str
+    dst_id: str
+    dst_label: str
+    props: dict[str, Any]
+
+
+# --------------------------------------------------------------------------
+# ID + name helpers
+# --------------------------------------------------------------------------
+
+
+def _sha1_24(canonical: str) -> str:
+    """24-hex-char truncation of SHA-1. Enough entropy for node identity,
+    short enough for readable Neo4j ids. Matches the convention in
+    ``src/resolve/`` for narrator canonical ids.
+    """
+    return hashlib.sha1(canonical.encode("utf-8"), usedforsecurity=False).hexdigest()[:24]
+
+
+def _normalize_collection_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", name.strip().lower()).strip("_")
+
+
+def _narrator_id(name_en: str | None, name_ar: str | None) -> str:
+    """Stable narrator id from name fields.
+
+    Either side may be missing; the hash input keeps both in canonical
+    order so a later pass that fills in the Arabic side still produces
+    the same id from an identical English input when no Arabic was known.
+    """
+    en = (name_en or "").strip().lower()
+    ar_norm = _normalize_arabic_safe(name_ar) if name_ar else ""
+    return f"nar:{_sha1_24(f'en:{en}|ar:{ar_norm}')}"
+
+
+def _normalize_arabic_safe(text: str) -> str:
+    """Wrap ``src.utils.arabic.normalize_arabic`` but fall back cleanly."""
+    try:
+        from src.utils.arabic import normalize_arabic
+
+        return normalize_arabic(text).strip()
+    except Exception:  # noqa: BLE001 — normalization is best-effort for hashing
+        return text.strip()
+
+
+def _hadith_id(source_corpus: str, source_id: str) -> str:
+    key = f"{source_corpus}:{source_id}"
+    return key if key.startswith("hdt:") else f"hdt:{key}"
+
+
+def _collection_id(collection_name: str) -> str:
+    return f"col:{_normalize_collection_name(collection_name)}"
+
+
+def _chain_id(hadith_id: str, narrator_ids: list[str]) -> str:
+    return f"chn:{_sha1_24(hadith_id + '|' + '|'.join(narrator_ids))}"
+
+
+def _grading_id(hadith_id: str) -> str:
+    return f"grd:{hadith_id}"
+
+
+# --------------------------------------------------------------------------
+# Fan-out core
+# --------------------------------------------------------------------------
+
+
+def _fan_out_row(row: dict[str, Any]) -> tuple[list[_NodeRow], list[_EdgeRow]]:
+    """Expand a single HADITH_SCHEMA row into nodes + edges."""
+    source_id = row["source_id"]
+    source_corpus = row["source_corpus"]
+    collection_name = row["collection_name"]
+    sect = row["sect"]
+
+    hid = _hadith_id(source_corpus, source_id)
+    cid = _collection_id(collection_name)
+
+    nodes: list[_NodeRow] = [
+        _NodeRow(
+            label="Hadith",
+            id=hid,
+            props={
+                "matn_ar": row.get("matn_ar"),
+                "matn_en": row.get("matn_en"),
+                "isnad_raw_ar": row.get("isnad_raw_ar"),
+                "isnad_raw_en": row.get("isnad_raw_en"),
+                "grade": row.get("grade"),
+                "source_corpus": source_corpus,
+                "sect": sect,
+                "collection_name": collection_name,
+                "book_number": row.get("book_number"),
+                "chapter_number": row.get("chapter_number"),
+                "hadith_number": row.get("hadith_number"),
+                "chapter_name_ar": row.get("chapter_name_ar"),
+                "chapter_name_en": row.get("chapter_name_en"),
+            },
+        ),
+        _NodeRow(
+            label="Collection",
+            id=cid,
+            props={
+                "name_en": collection_name,
+                "sect": sect,
+                "source_corpus": source_corpus,
+            },
+        ),
+    ]
+
+    edges: list[_EdgeRow] = [
+        _EdgeRow(
+            label="APPEARS_IN",
+            src_id=hid,
+            src_label="Hadith",
+            dst_id=cid,
+            dst_label="Collection",
+            props={
+                "book_number": row.get("book_number"),
+                "chapter_number": row.get("chapter_number"),
+                "hadith_number": row.get("hadith_number"),
+            },
+        ),
+    ]
+
+    # ---- Narrators + Chain + TRANSMITTED_TO + NARRATED ----
+    isnad = row.get("isnad_raw_en") or row.get("isnad_raw_ar") or ""
+    language = "en" if row.get("isnad_raw_en") else "ar"
+    narrator_ids: list[str] = []
+
+    if isnad:
+        mentions = extract_narrator_mentions(isnad, language)
+        for mention in mentions:
+            if language == "en":
+                nid = _narrator_id(mention.name, None)
+                name_en: str | None = mention.name
+                name_ar: str | None = None
+            else:
+                nid = _narrator_id(None, mention.name)
+                name_en = None
+                name_ar = mention.name
+            nodes.append(
+                _NodeRow(
+                    label="Narrator",
+                    id=nid,
+                    props={
+                        "name_en": name_en,
+                        "name_ar": name_ar,
+                        "name_ar_normalized": (
+                            _normalize_arabic_safe(name_ar) if name_ar else None
+                        ),
+                        "transmission_method": mention.transmission_method,
+                    },
+                )
+            )
+            narrator_ids.append(nid)
+
+        # TRANSMITTED_TO chain pairs — matches src/graph/load_edges.py
+        for idx in range(len(narrator_ids) - 1):
+            edges.append(
+                _EdgeRow(
+                    label="TRANSMITTED_TO",
+                    src_id=narrator_ids[idx],
+                    src_label="Narrator",
+                    dst_id=narrator_ids[idx + 1],
+                    dst_label="Narrator",
+                    props={
+                        "position_in_chain": idx,
+                        "hadith_id": hid,
+                    },
+                )
+            )
+
+        # NARRATED: first (earliest) narrator -> hadith
+        if narrator_ids:
+            edges.append(
+                _EdgeRow(
+                    label="NARRATED",
+                    src_id=narrator_ids[0],
+                    src_label="Narrator",
+                    dst_id=hid,
+                    dst_label="Hadith",
+                    props={},
+                )
+            )
+
+    # ---- Chain node (always, even for empty isnad — matches load_nodes) ----
+    chn_id = _chain_id(hid, narrator_ids)
+    nodes.append(
+        _NodeRow(
+            label="Chain",
+            id=chn_id,
+            props={
+                "hadith_id": hid,
+                "chain_index": 0,
+                "chain_length": len(narrator_ids),
+                "is_complete": len(narrator_ids) > 0,
+                "narrator_ids": narrator_ids,
+            },
+        )
+    )
+
+    # ---- Grading + GRADED_BY (iff grade present) ----
+    grade = row.get("grade")
+    if grade:
+        grading_id = _grading_id(hid)
+        nodes.append(
+            _NodeRow(
+                label="Grading",
+                id=grading_id,
+                props={
+                    "hadith_id": hid,
+                    "grade": grade,
+                    "scholar_name": collection_name,
+                },
+            )
+        )
+        edges.append(
+            _EdgeRow(
+                label="GRADED_BY",
+                src_id=hid,
+                src_label="Hadith",
+                dst_id=grading_id,
+                dst_label="Grading",
+                props={},
+            )
+        )
+
+    return nodes, edges
+
+
+# --------------------------------------------------------------------------
+# Parquet serialisation
+# --------------------------------------------------------------------------
+
+
+def _nodes_to_parquet(label: str, nodes: list[_NodeRow]) -> bytes:
+    if not nodes:
+        table = _NODE_SCHEMA.empty_table()
+    else:
+        table = pa.table(
+            {
+                "label": [label] * len(nodes),
+                "id": [n.id for n in nodes],
+                "props": [json.dumps(n.props, ensure_ascii=False, default=str) for n in nodes],
+            },
+            schema=_NODE_SCHEMA,
+        )
+    buf = io.BytesIO()
+    pq.write_table(table, buf)
+    return buf.getvalue()
+
+
+def _edges_to_parquet(edges: list[_EdgeRow]) -> bytes:
+    if not edges:
+        table = _EDGE_SCHEMA.empty_table()
+    else:
+        table = pa.table(
+            {
+                "label": [e.label for e in edges],
+                "src_id": [e.src_id for e in edges],
+                "src_label": [e.src_label for e in edges],
+                "dst_id": [e.dst_id for e in edges],
+                "dst_label": [e.dst_label for e in edges],
+                "props": [json.dumps(e.props, ensure_ascii=False, default=str) for e in edges],
+            },
+            schema=_EDGE_SCHEMA,
+        )
+    buf = io.BytesIO()
+    pq.write_table(table, buf)
+    return buf.getvalue()
+
+
+# --------------------------------------------------------------------------
+# Normalize + fan-out processor
+# --------------------------------------------------------------------------
 
 
 def _required_fields(schema: pa.Schema) -> list[str]:
@@ -51,14 +415,16 @@ def _required_fields(schema: pa.Schema) -> list[str]:
 
 
 class NormalizeProcessor:
-    """Callable processor: coerce a batch to ``HADITH_SCHEMA`` shape."""
+    """Fan out a hadith-batch Parquet into per-label node + edge Parquets."""
 
     def __init__(self, store: ObjectStore, target_schema: pa.Schema = HADITH_SCHEMA) -> None:
         self.store = store
         self.target_schema = target_schema
         self._required = _required_fields(target_schema)
 
-    def _normalize(self, payload: bytes) -> tuple[pa.Table, int]:
+    # ---- shape coercion (unchanged behaviour, reused from the prior impl) ----
+
+    def _coerce_to_target_schema(self, payload: bytes) -> tuple[pa.Table, int]:
         """Return (normalized_table, dropped_row_count). Raises on unusable input."""
         table = pq.read_table(io.BytesIO(payload))
 
@@ -68,15 +434,11 @@ class NormalizeProcessor:
 
         projected = table.select([f.name for f in self.target_schema])
 
-        # Drop rows with a null in any required-non-nullable field.
         dropped = 0
         if self._required:
             mask = pa.array([True] * projected.num_rows, type=pa.bool_())
-            import pyarrow.compute as pc
-
             for name in self._required:
-                not_null = pc.is_valid(projected.column(name))
-                mask = pc.and_(mask, not_null)
+                mask = pc.and_(mask, pc.is_valid(projected.column(name)))
             kept = projected.filter(mask)
             dropped = projected.num_rows - kept.num_rows
             projected = kept
@@ -88,24 +450,108 @@ class NormalizeProcessor:
 
         return normalized, dropped
 
+    # ---- atomic write helpers ----
+
+    def _write_atomic(self, key: str, data: bytes, content_type: str) -> None:
+        """Write ``data`` to a ``.part`` suffix then rename to ``key``.
+
+        The suffix is randomised so two concurrent retries for the same
+        key can't clobber each other's staging object. Rename is atomic
+        server-side (S3 ``CopyObject`` + ``DeleteObject``), so readers
+        never see a half-written final key.
+        """
+        part_key = f"{key}.part.{uuid.uuid4().hex[:12]}"
+        self.store.put_object(part_key, data, content_type=content_type)
+        self.store.rename_object(part_key, key)
+
+    # ---- the main entry point ----
+
     def __call__(self, msg: PipelineMessage) -> PipelineMessage:
         payload = self.store.get_object(msg.b2_path)
 
         try:
-            normalized, dropped = self._normalize(payload)
+            normalized, dropped = self._coerce_to_target_schema(payload)
         except (pa.ArrowInvalid, ValueError) as exc:
             _logger.error("normalize_invalid_batch", batch_id=msg.batch_id, error=str(exc))
             raise
 
-        out_key = f"normalized/{msg.batch_id}/hadiths.parquet"
-        buf = io.BytesIO()
-        pq.write_table(normalized, buf)
-        self.store.put_object(out_key, buf.getvalue())
+        # Fan-out every surviving row into graph entities.
+        nodes_by_label: dict[str, list[_NodeRow]] = {}
+        all_edges: list[_EdgeRow] = []
+        for row in normalized.to_pylist():
+            nodes, edges = _fan_out_row(row)
+            for node in nodes:
+                if node.label not in ALLOWED_NODE_LABELS:
+                    raise ValueError(f"fan-out produced unknown node label {node.label!r}")
+                nodes_by_label.setdefault(node.label, []).append(node)
+            all_edges.extend(edges)
+
+        # Dedupe nodes within the batch by id — collections, narrators,
+        # and chains can repeat across hadith rows and ingest is already
+        # idempotent via MERGE, but shipping duplicates bloats the Parquet
+        # and wastes Cypher round-trips.
+        for label, rows in nodes_by_label.items():
+            seen: dict[str, _NodeRow] = {}
+            for node in rows:
+                # First-writer-wins; later duplicates are expected to
+                # carry the same props, so dropping them is safe.
+                seen.setdefault(node.id, node)
+            nodes_by_label[label] = list(seen.values())
+
+        # ---- write per-label Parquets under a .part suffix, then rename ----
+        prefix = f"normalized/{msg.batch_id}/"
+        manifest_entries: list[dict[str, Any]] = []
+        total_row_count = 0
+
+        for label, rows in nodes_by_label.items():
+            if not rows:
+                continue
+            filename = _NODE_FILENAMES[label]
+            key = f"{prefix}{filename}"
+            data = _nodes_to_parquet(label, rows)
+            self._write_atomic(key, data, content_type="application/octet-stream")
+            manifest_entries.append(
+                {
+                    "path": filename,
+                    "label": label,
+                    "row_count": len(rows),
+                }
+            )
+            total_row_count += len(rows)
+
+        # edges parquet — always written (may be empty)
+        edges_key = f"{prefix}{_EDGES_FILENAME}"
+        edges_data = _edges_to_parquet(all_edges)
+        self._write_atomic(edges_key, edges_data, content_type="application/octet-stream")
+        manifest_entries.append(
+            {
+                "path": _EDGES_FILENAME,
+                "row_count": len(all_edges),
+            }
+        )
+        total_row_count += len(all_edges)
+
+        # ---- manifest LAST (ingest uses this as the ready signal) ----
+        manifest = {
+            "batch_id": msg.batch_id,
+            "source": msg.source,
+            "created_at": datetime.now(UTC).isoformat(),
+            "parquets": manifest_entries,
+            "total_row_count": total_row_count,
+        }
+        self.store.put_object(
+            f"{prefix}{_MANIFEST_FILENAME}",
+            json.dumps(manifest, ensure_ascii=False).encode("utf-8"),
+            content_type="application/json",
+        )
 
         _logger.info(
             "normalize_complete",
             batch_id=msg.batch_id,
-            rows=normalized.num_rows,
-            dropped=dropped,
+            rows_in=normalized.num_rows,
+            rows_dropped=dropped,
+            nodes_by_label={k: len(v) for k, v in nodes_by_label.items()},
+            edges=len(all_edges),
         )
-        return msg.to_next_stage(b2_path=out_key, record_count=normalized.num_rows)
+
+        return msg.to_next_stage(b2_path=prefix, record_count=total_row_count)


### PR DESCRIPTION
## Summary

Ports real processor logic into three of the four pipeline worker shells
(dedup, enrich, normalize). `workers/ingest/processor.py` (Neo4j
MERGE / graph-load) stays on scope for #13 and is untouched.

- **Dedup** — in-batch FAISS top-K with variant tiering, ported from
  `src/resolve/dedup.py`. Emits `PARALLEL_LINKS_SCHEMA` Parquet
  alongside a pass-through `hadiths.parquet`. Lazy-inits the
  sentence-transformer + FAISS index on the processor instance.
- **Enrich** — per-batch zero-shot topic classification ported from
  `src/enrich/topics.py`. Emits `hadith_topics.parquet` side table.
  Graph-metric + historical-overlay enrichments remain Neo4j-post-load
  and are tracked as a follow-up stage.
- **Normalize** — new stage; validates against `HADITH_SCHEMA`,
  drops rows missing required fields, strips extras, casts to target
  schema. Invalid input raises so the runner DLQs.

Graceful ML-dep degradation (missing `faiss` / `sentence-transformers` /
`transformers` -> empty side table + pass-through payload) mirrors the
upstream's behaviour so containers that don't need the `ml` group stay
lightweight.

## Scope boundary

- `workers/ingest/processor.py` (Neo4j MERGE) is **not** modified —
  owned by #13, concurrent branch `W.Zielinska/0013-neo4j-merge`.
- `workers/lib/{dlq,message,runner,object_store}.py` unchanged for the
  same reason. Only `workers/lib/log.py:67` narrowed a return type to
  satisfy mypy on a pre-existing shipped issue.

## Port details

| Worker | Upstream | Adaptation |
|---|---|---|
| dedup | `src/resolve/dedup.py::run_dedup` | multi-file staging dir -> single-batch Parquet; lazy-init model on instance; intra-batch pairs only |
| enrich | `src/enrich/topics.py::run_topics` | Neo4j read/write -> Parquet read + side-table write |
| normalize | (new) | anchor on `src/parse/schemas.HADITH_SCHEMA`; filter-then-cast; missing columns -> DLQ |
| graph-load | `src/graph/load_{nodes,edges}.py` | **out of scope** — see #13 |

## New dependencies

None.  `faiss-cpu`, `sentence-transformers`, `transformers` were already
declared in the `ml` optional group (pyproject.toml).  `uv.lock` picks
up previously-declared `boto3` / `kafka-python` transitive deps that
scaffold PR #8 left unlocked.

## DLQ behaviour

- Malformed Parquet at the input pointer -> `ArrowInvalid` -> runner
  routes to `pipeline.dlq` (covered by
  `test_dedup_failure_propagates_to_dlq_via_runner`).
- Missing required column in normalize input -> `ValueError` -> DLQ
  (covered by `test_missing_required_column_raises`).
- Missing ML deps does **not** DLQ — logs + emits empty side table.
- No new retry layers added; runner's existing DLQ routing handles all.

## Test plan

- [x] `pytest tests/workers/` — 26 passed, 1 skipped (`@pytest.mark.ml`)
- [x] Full unit suite — 516 passed, 4 skipped, 13 deselected integration
- [x] `ruff check workers/ tests/workers/`
- [x] `ruff format --check workers/ tests/workers/`
- [x] `mypy workers/` — clean (no errors)
- [ ] Integration: local docker-compose end-to-end with MinIO + Kafka (deferred to main#136 per #10 AC)
- [ ] Verify port faithfulness vs upstream (Farhan Malik review)
- [ ] Architectural fit review (Weronika Zielinska)

Closes #10.

TechDebt: none for this PR. Pre-existing debt (InMemoryCheckpoint, cross-batch dedup) carried forward.
