### PR TITLE
tech-debt(P3W5 T3 #14): drop Dockerfile workaround, install via uv export+pip from authoritative lock

### DIFF
--- a/workers/dedup/Dockerfile
+++ b/workers/dedup/Dockerfile
@@ -17,9 +17,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-# TODO: add kafka-python and boto3 to pyproject.toml so uv sync installs them here.
-RUN uv sync --frozen --no-dev \
- && uv pip install --system kafka-python boto3
+RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+ && rm /tmp/requirements.txt
 
 COPY src ./src
 COPY workers ./workers

--- a/workers/enrich/Dockerfile
+++ b/workers/enrich/Dockerfile
@@ -17,8 +17,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev \
- && uv pip install --system kafka-python boto3
+RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+ && rm /tmp/requirements.txt
 
 COPY src ./src
 COPY workers ./workers

--- a/workers/ingest/Dockerfile
+++ b/workers/ingest/Dockerfile
@@ -17,8 +17,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev \
- && uv pip install --system kafka-python boto3
+RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+ && rm /tmp/requirements.txt
 
 COPY src ./src
 COPY workers ./workers

--- a/workers/normalize/Dockerfile
+++ b/workers/normalize/Dockerfile
@@ -17,8 +17,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev \
- && uv pip install --system kafka-python boto3
+RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+ && rm /tmp/requirements.txt
 
 COPY src ./src
 COPY workers ./workers


### PR DESCRIPTION
## Summary

Discharges `noorinalabs-isnad-ingest-platform#14` (P3W5 T3 — direct W4 silent-drop correction per `noorinalabs-main#272`).

The issue body claimed `uv.lock` was stale and needed regeneration. **It wasn't.** PR #8 had already added `kafka-python==2.3.1` and `boto3==1.42.93` to the lock with full hashes. `uv lock --check` is clean; a fresh `uv lock` is byte-identical. The only real debt to discharge was the four Dockerfiles' fallback `uv pip install --system kafka-python boto3` step (no pins, no hashes, hits PyPI on every build).

## Invariant

After this change every worker image installs deps **only** from `uv.lock`:
- no PyPI-wildcard install of unpinned packages
- no version drift between rebuilds
- `--require-hashes` enforced for every package

## Why the fix is `uv export → uv pip install`, not bare `uv sync`

The pre-existing Dockerfiles set `UV_SYSTEM_PYTHON=1` and the CMD invokes
`python -m workers.<stage>.main` from PATH (= `/usr/local/bin/python`,
the system python). `uv sync` ignores `UV_SYSTEM_PYTHON` and always
materializes the project into `/app/.venv/`. I empirically confirmed
that simply removing the `uv pip install --system` line broke the
runtime path with `ModuleNotFoundError: No module named 'kafka'`,
even though the build succeeded.

The replacement pattern preserves both invariants:
1. lock-as-only-source-of-truth (via `uv export --frozen`)
2. system-python install matching the existing CMD contract (via `--system`)

## Diff

`workers/{dedup,enrich,ingest,normalize}/Dockerfile` — replace
`uv sync --frozen --no-dev && uv pip install --system kafka-python boto3`
with
`uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt && uv pip install --system --require-hashes -r /tmp/requirements.txt && rm /tmp/requirements.txt`.

Identical change in all four files. `pyproject.toml` and `uv.lock` not touched (already correct).

## Closes

Closes #14

## Test plan

- [x] `uv lock --check` passes before and after (confirms lock is canonical)
- [x] Fresh `uv lock` is byte-identical to current (no regeneration drift)
- [x] `docker build` for `dedup` worker succeeds end-to-end
- [x] `docker build` for `normalize` worker succeeds end-to-end
- [x] Built `dedup` image: `python -c "import kafka, boto3"` resolves to
      `kafka-python 2.3.1` / `boto3 1.42.93` (matches lock pins)
- [x] Built `normalize` image: multi-import smoke (`kafka, boto3, pandas, neo4j, structlog`)
- [x] `uv sync --frozen` clean for project venv (dev workflow unchanged)
- [x] `pytest tests/ -m "not integration and not ml"` → 543 passed, 3 skipped
- [ ] CI green on PR (post-push)
- [ ] Rebuilt worker images deploy cleanly post-merge (release-coordinator gate;
      runtime acceptance distinct from PR acceptance per
      `feedback/pr_vs_runtime_acceptance_criteria.md`)

## Reviewers

cc @adaeze (manager — first review) @bjorn (DevOps Architect — second review)
