### PR TITLE
infra(auto-close): add auto-close-issues workflow (propagation from isnad-graph per main#402)

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,35 @@
+name: Auto-close issues
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Close referenced issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const matches = body.matchAll(/[Cc]loses?\s+#(\d+)/g);
+            for (const match of matches) {
+              const issue_number = parseInt(match[1]);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: 'closed',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body: `Closed by PR #${context.payload.pull_request.number} merged into \`${context.payload.pull_request.base.ref}\`.`,
+              });
+            }


### PR DESCRIPTION
Propagates `auto-close-issues.yml` from noorinalabs-isnad-graph (canonical) per noorinalabs-main#402.

35-line literal copy (parameter-free: uses `context.repo.*` only). The workflow fires on `pull_request.closed && merged == true`, parses `[Cc]loses?\s+#(\d+)` from PR body, calls `github.rest.issues.update({state:'closed'})` + creates a "Closed by PR #N merged into <base>" comment.

**Wave-scope note**: this repo is deliberately not in P3W10 scope per `cross-repo-status.json deliberately_not_in_w10` (deploy work partitioned to W11 per 2026-05-12 directive; ingest-platform not yet active in Phase 3). The workflow file itself is wave-agnostic infra — filing now to keep the auto-close-issues cluster atomic across all 7 target repos. **Not labeled `p3-wave-10`**; tracking issue remains noorinalabs-main#402.

Related:
- noorinalabs-main#402 (tracking issue — propagation to 7 org repos)
- noorinalabs-main#221 (origin proposal — audit identifying gap)

Reviewers: Aisha Idrissi + Bereket Tadesse
