### PR TITLE
docs(ingest): document coalesce-clear contract on builders + schema (#23)

### DIFF
--- a/workers/ingest/processor.py
+++ b/workers/ingest/processor.py
@@ -274,6 +274,18 @@ def _build_node_cypher(label: str) -> str:
     curated ``text_ar`` on a hadith survives an ingest batch that only
     carries ``text_en``. This is the core of Farhan's Phase-4 fix
     (#192 comment thread).
+
+    Coalesce-clear contract (per-field, applies to every SET line)
+    --------------------------------------------------------------
+    - field omitted from ``row.props``  → preserve existing value
+    - field present with explicit null  → preserve existing value (silent no-op)
+    - field present with a new value    → overwrite
+
+    The explicit-null branch is asymmetric on purpose: ingest batches
+    cannot clear node properties. A correction that needs to null a
+    field must reach Neo4j through a separate path (issue #23 / future
+    corrections topic). The same contract applies to
+    ``_build_edge_cypher``.
     """
     fields = NODE_PROPERTY_MAP.get(label, [])
     set_lines = ",\n    ".join(f"n.{f} = coalesce(row.props.{f}, n.{f})" for f in fields)
@@ -287,7 +299,16 @@ def _build_node_cypher(label: str) -> str:
 
 
 def _build_edge_cypher(label: str) -> str:
-    """Per-edge-label MERGE Cypher with enumerated, null-safe SET stanzas."""
+    """Per-edge-label MERGE Cypher with enumerated, null-safe SET stanzas.
+
+    Same coalesce-clear contract as ``_build_node_cypher``:
+
+    - field omitted from ``row.props``  → preserve existing value
+    - field present with explicit null  → preserve existing value (silent no-op)
+    - field present with a new value    → overwrite
+
+    Edge properties cannot be cleared via an ingest batch (see #23).
+    """
     fields = EDGE_PROPERTY_MAP.get(label, [])
     set_lines = ",\n    ".join(f"r.{f} = coalesce(row.props.{f}, r.{f})" for f in fields)
     set_clause = f"SET {set_lines}\n" if fields else ""

--- a/workers/ingest/schema.py
+++ b/workers/ingest/schema.py
@@ -55,8 +55,7 @@ remove a ``sect_affiliation`` that a later source disavowed — emitting
 ``{"grade": null}`` is a no-op against the live node. This is the
 intended Phase-4 default (scholar curation must survive ingest churn);
 field-clearing, if needed, will arrive on a separate corrections path
-rather than through this allow-list. See #23 and the #192 design
-thread.
+rather than through this allow-list. See #23.
 """
 
 from __future__ import annotations

--- a/workers/ingest/schema.py
+++ b/workers/ingest/schema.py
@@ -38,6 +38,25 @@ Fields intentionally omitted
 fields that are exclusively populated by post-ingest enrichment (e.g.
 narrator centrality / pagerank) are excluded so an unenriched batch
 doesn't wipe them out.
+
+Contract: ingest batches cannot clear fields
+--------------------------------------------
+The allow-listed properties are written with
+``n.<f> = coalesce(row.props.<f>, n.<f>)`` in ``_build_node_cypher`` /
+``_build_edge_cypher``. The coalesce is asymmetric on the explicit-null
+branch:
+
+- field omitted from ``row.props``  → preserve existing value
+- field present with explicit null  → preserve existing value (silent no-op)
+- field present with a new value    → overwrite
+
+A normalize-stage batch therefore cannot null out a stale ``grade`` or
+remove a ``sect_affiliation`` that a later source disavowed — emitting
+``{"grade": null}`` is a no-op against the live node. This is the
+intended Phase-4 default (scholar curation must survive ingest churn);
+field-clearing, if needed, will arrive on a separate corrections path
+rather than through this allow-list. See #23 and the #192 design
+thread.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #23.

## Summary

PR #18 replaced `SET n += row.props` with per-field
`n.<f> = coalesce(row.props.<f>, n.<f>)` to satisfy Farhan's Phase-4
safety flag. The semantics make ingest batches incapable of clearing
fields — an explicit `{"grade": null}` is a silent no-op against the
live node, distinct from omitting the field entirely (also a no-op)
and from sending a new value (overwrite). The three-branch table is
correct behaviour for Phase-4 scholar curation but is undocumented,
so a future normalize / correction author can walk into the
silent-null trap without warning.

Per the issue's Option 1 (preferred for W8/W11): document the contract,
do not introduce a sentinel mechanism. Mechanism work is deferred until
a real corrections-topic use case surfaces.

## Diff confirmation — docstrings + module docstring only

- `workers/ingest/processor.py`
  - `_build_node_cypher` (line 251) — appends a "Coalesce-clear
    contract" subsection enumerating omit / explicit-null / new-value
    branches and pointing at #23.
  - `_build_edge_cypher` (line 277) — promoted from a one-line
    docstring to the same three-branch contract scoped to edges.
- `workers/ingest/schema.py`
  - Module docstring — adds a "Contract: ingest batches cannot clear
    fields" subsection naming `grade` / `sect_affiliation` as the
    worked example from the issue.

No runtime code changed. `tests/workers/test_ingest_neo4j.py` (19
tests) pass unchanged. `ruff check` + `ruff format --check` clean.

## Acceptance — 4/4

- [x] `_build_node_cypher` docstring states: omitted → preserve;
      explicit null → preserve (silent); new value → overwrite
- [x] Same three-line contract on `_build_edge_cypher`
- [x] `schema.py` module docstring gains "Contract: ingest batches
      cannot clear fields" subsection
- [x] Zero behavior change — only docstring / module-docstring diffs;
      19/19 ingest tests pass; ruff lint + format clean

## Note on the original `#192` cross-ref AC

The spawn brief and the issue body both referenced `#192` ("Phase-4
design thread" / "Farhan's comment thread") as the cross-ref target.
That reference is stale: `noorinalabs-isnad-ingest-platform#192` does
not exist (verified via `gh issue view 192 --repo …` returning GraphQL
`Could not resolve`), and `noorinalabs/noorinalabs-isnad-graph#192` is
an unrelated rate-limiting issue — the slot was reused after the
original Phase-4 flag was closed.

The codegen-tracking concern this AC was meant to forward-link to is
now fully covered by **#24** (Sayed's cross-repo codegen + CI gate,
landed as PRs #919 + #37). The cross-ref AC is therefore dropped as
superseded rather than chased to a stale or fabricated target.

Pre-existing `#192` references in `processor.py` and `schema.py`
(3 inherited sites in surrounding docstrings) are out of scope for
this PR per "tight scope" management call — they will be swept by
the W12 dedicated phantom-cleanup follow-up that Adaeze filed, which
captures the inherited-3 sites with proper provenance.

## Fixup log

- `1650fc5` → `7356c1e` — dropped `and the #192 design thread` from
  the new `schema.py` contract subsection per Petra's CR; the diff
  no longer adds any `#192` phantom even though pre-existing ones
  remain (W12 cleanup scope).

## Reviewers

- Primary: @petra-novak (tech lead) — Approved literal required for
  Hook 4
- Secondary: @bjorn-henriksen — Approved literal

## Tech Debt

None introduced. Doc-only clarification of the coalesce-clear
asymmetry already present in the implementation. No mechanism change;
existing tests unchanged.
