### PR TITLE
fix(ingest #20): bound Neo4j retry — drop redundant SessionExpired reopen

### DIFF
--- a/tests/workers/test_ingest_neo4j.py
+++ b/tests/workers/test_ingest_neo4j.py
@@ -534,9 +534,30 @@ def test_ingest_drops_properties_outside_allowlist(
 # ---------------------------------------------------------------------------
 
 
-def test_ingest_retries_once_on_session_expired(
+def test_ingest_session_expired_propagates_to_dlq(
     object_store: ObjectStore, folder_prefix_message: PipelineMessage
 ) -> None:
+    """Issue #20: outer ``SessionExpired`` reopen was redundant.
+
+    The neo4j driver classifies ``SessionExpired`` as retryable
+    (``SessionExpired.is_retryable() -> True`` in ``neo4j.exceptions``)
+    and retries it inside ``session.execute_write``'s loop in
+    ``neo4j._sync.work.session._run_transaction``, bounded by
+    ``max_transaction_retry_time`` (default 30s). The processor's outer
+    try/except reopen ran the entire batch a *second* time on a fresh
+    session, doubling the per-message worst-case retry budget without
+    adding any fault tolerance the driver did not already provide.
+
+    With the outer reopen removed, a ``SessionExpired`` that surfaces
+    from ``execute_write`` means the driver's wall-clock retry budget
+    was exhausted — propagate so the runner DLQs.
+
+    *Test scope:* the ``_FakeSession`` here bypasses the real retry loop
+    by raising directly from ``execute_write``; this asserts the *wire
+    contract* (one session opened, exception propagates) but does NOT
+    exercise the driver's wall-clock bound. That requires a real Neo4j
+    (testcontainers, issue #136 integration suite).
+    """
     from neo4j.exceptions import SessionExpired
 
     _write_batch(
@@ -544,15 +565,52 @@ def test_ingest_retries_once_on_session_expired(
         folder_prefix_message.b2_path,
         nodes={"Narrator": [{"id": "nar:a", "props": {"name_en": "A"}}]},
     )
-    first = _FakeSession([], raise_on_execute=SessionExpired("token expired"))
-    second = _FakeSession([])
-    driver = _FakeDriver(session_factories=[first, second])
+    sess = _FakeSession([], raise_on_execute=SessionExpired("driver retry budget exhausted"))
+    driver = _FakeDriver(session_factories=[sess])
 
-    IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+    with pytest.raises(SessionExpired):
+        IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
 
-    # Reopened — the successful second session ran the full batch
-    assert driver._next_factory == 2
-    assert len(driver.sink) == 1  # one tx.run for the single Narrator label
+    # Exactly one session opened — no outer reopen
+    assert driver._next_factory == 1
+    assert driver.sink == []  # error fired before any tx.run captured
+
+
+def test_runner_routes_session_expired_to_dlq(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    """Issue #20: post-driver-bound SessionExpired routes to DLQ via runner."""
+    from neo4j.exceptions import SessionExpired
+
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Narrator": [{"id": "nar:a", "props": {"name_en": "A"}}]},
+    )
+    sess = _FakeSession([], raise_on_execute=SessionExpired("driver retry budget exhausted"))
+    driver = _FakeDriver(session_factories=[sess])
+    producer = FakeProducer()
+
+    runner = WorkerRunner(
+        settings=WorkerSettings(
+            worker_name="ingest-worker",
+            consume_topic=PIPELINE_NORMALIZE_DONE,
+            produce_topic=None,
+            consumer_group="ingest-worker",
+        ),
+        consumer=FakeConsumer([]),
+        producer=producer,
+        process=IngestProcessor(object_store, neo4j_driver=driver),
+    )
+    runner.handle_one(serialize_message(folder_prefix_message))
+
+    assert len(producer.sent) == 1
+    topic, value = producer.sent[0]
+    assert topic == DLQ_TOPIC
+    record = json.loads(value)
+    assert record["error_class"] == "SessionExpired"
+    # Single session opened — no outer reopen
+    assert driver._next_factory == 1
 
 
 def test_ingest_client_error_propagates_for_dlq(

--- a/tests/workers/test_ingest_neo4j.py
+++ b/tests/workers/test_ingest_neo4j.py
@@ -2,7 +2,7 @@
 
 The tests mock the neo4j driver/session so the suite runs without
 Docker or a live database. Integration coverage against a real Neo4j
-(testcontainers) is tracked separately in issue #136.
+(testcontainers) is tracked separately in issue #38.
 """
 
 from __future__ import annotations
@@ -556,7 +556,7 @@ def test_ingest_session_expired_propagates_to_dlq(
     by raising directly from ``execute_write``; this asserts the *wire
     contract* (one session opened, exception propagates) but does NOT
     exercise the driver's wall-clock bound. That requires a real Neo4j
-    (testcontainers, issue #136 integration suite).
+    (testcontainers, issue #38 integration suite).
     """
     from neo4j.exceptions import SessionExpired
 

--- a/workers/ingest/processor.py
+++ b/workers/ingest/processor.py
@@ -28,9 +28,21 @@ Design (issue #18, #192 D-ii)
       runner DLQs it.
     * ``UnknownSchemaError`` — manifest references an unknown label or
       an unknown edge type; runner DLQs.
-    * ``ServiceUnavailable`` — neo4j driver retries internally.
-    * ``SessionExpired`` — reopen session once and retry.
+    * Transient driver errors (``ServiceUnavailable``, ``TransientError``,
+      ``SessionExpired``) — the neo4j driver retries them internally
+      inside ``session.execute_write``, bounded by the driver-config
+      ``max_transaction_retry_time`` (default 30s). Once that wall-clock
+      bound is exhausted the last error propagates and the runner DLQs
+      it. Per-message Neo4j retry time is therefore capped at ~30s.
     * ``ClientError`` and everything else — propagate for DLQ.
+
+Issue #20 removed a redundant outer ``SessionExpired`` reopen that
+compounded with the driver-internal retry; ``SessionExpired.is_retryable()``
+returns True (verified in ``neo4j.exceptions`` and the ``_run_transaction``
+retry loop in ``neo4j._sync.work.session``), so the driver already
+retries the same call internally — re-running the batch on a fresh
+session doubled the worst-case retry budget without adding fault
+tolerance.
 """
 
 from __future__ import annotations
@@ -370,15 +382,18 @@ class IngestProcessor:
             )
             return None
 
-        from neo4j.exceptions import SessionExpired
-
         def _run_batch(tx: ManagedTransaction) -> dict[str, dict[str, int]]:
             """Single-transaction closure — all nodes first, then edges.
 
             Running both phases inside one ``execute_write`` means the
             driver's retry covers the whole batch, and edges always see
             their endpoints MATCH-able because the MERGE of nodes ran in
-            the same transaction scope.
+            the same transaction scope. The driver retries all transient
+            errors (``ServiceUnavailable``, ``TransientError``,
+            ``SessionExpired``) internally, bounded by
+            ``max_transaction_retry_time`` (default 30s); when the wall-
+            clock budget is exhausted the last error propagates and the
+            runner DLQs the message.
             """
             merged_nodes: dict[str, int] = {}
             for node_label, label_rows in nodes_by_label.items():
@@ -388,17 +403,8 @@ class IngestProcessor:
                 merged_edges[edge_label] = _merge_edges_tx(tx, label=edge_label, rows=edge_rows)
             return {"nodes": merged_nodes, "edges": merged_edges}
 
-        def _run(session: Any) -> dict[str, dict[str, int]]:
-            result: dict[str, dict[str, int]] = session.execute_write(_run_batch)
-            return result
-
-        try:
-            with self.neo4j_driver.session() as session:
-                merged = _run(session)
-        except SessionExpired:
-            _logger.warning("ingest_session_expired_retrying", batch_id=msg.batch_id)
-            with self.neo4j_driver.session() as session:
-                merged = _run(session)
+        with self.neo4j_driver.session() as session:
+            merged: dict[str, dict[str, int]] = session.execute_write(_run_batch)
 
         _logger.info(
             "ingest_merged",

--- a/workers/ingest/processor.py
+++ b/workers/ingest/processor.py
@@ -393,7 +393,11 @@ class IngestProcessor:
             ``SessionExpired``) internally, bounded by
             ``max_transaction_retry_time`` (default 30s); when the wall-
             clock budget is exhausted the last error propagates and the
-            runner DLQs the message.
+            runner DLQs the message. Each retry iteration releases the
+            connection back to the pool and reacquires a fresh one (see
+            ``neo4j._sync.work.session._run_transaction`` lines 557 / 532),
+            so a ``SessionExpired`` triggers a fresh-connection retry
+            which on a cluster can land on a different cluster member.
             """
             merged_nodes: dict[str, int] = {}
             for node_label, label_rows in nodes_by_label.items():


### PR DESCRIPTION
Closes #20.

## What changed

Removes the outer `try/except SessionExpired` reopen at the top of `IngestProcessor.__call__` (`workers/ingest/processor.py`). The neo4j driver already retries `SessionExpired` inside `session.execute_write`, bounded by `max_transaction_retry_time` (default 30s). The outer reopen ran the whole batch a second time on a fresh session, doubling the worst-case per-message retry budget without adding any fault tolerance the driver did not already provide.

## Chosen option

**Issue option 3 — drop the outer SessionExpired retry as redundant.** The issue called this "lowest risk if verified." Verified.

## Driver-source evidence (verified at HEAD, not training memory)

The neo4j driver is pinned `>=5.15` in `pyproject.toml`. Locally installed 6.1.0 (allowed by the pin) was inspected:

1. **`neo4j/exceptions.py:986-987`** — `SessionExpired(DriverError)` overrides `is_retryable()` to return `True`.
2. **`neo4j/_sync/work/session.py:494-586`** — `_run_transaction` (the engine behind `execute_write`):
   - Lines 556-559: catches `(DriverError, Neo4jError)`, calls `error.is_retryable()`, retries when true. `SessionExpired` IS a `DriverError` and IS retryable → caught and retried internally.
   - Lines 565-568: wall-clock bound enforced via `t1 - t0 > self._config.max_transaction_retry_time`.
3. **`neo4j/_conf.py:360`** — `max_transaction_retry_time = 30.0  # seconds` (default).

The `is_retryable` + bounded-retry contract has been the documented driver API since 5.x (verified above; not asserted from training memory).

## Documented retry budget

**Per-message Neo4j retry time: ~30s** (driver-default `max_transaction_retry_time`). Single bound, not compounded.

Behavior on sustained Neo4j degradation: driver retries `ServiceUnavailable` / `TransientError` / `SessionExpired` internally up to 30s wall-clock; once exhausted the last error propagates → runner DLQs the message → ops triage via the DLQ topic. Consumer lag no longer stalls under sustained transient failure.

## Test changes

Removes `test_ingest_retries_once_on_session_expired` (asserted the deleted outer reopen).

Replaces with:
- `test_ingest_session_expired_propagates_to_dlq` — fake `execute_write` raises `SessionExpired` (simulating post-driver-bound exhaustion); asserts single session opened, no outer reopen, exception propagates.
- `test_runner_routes_session_expired_to_dlq` — end-to-end via `WorkerRunner`; asserts DLQ topic emission with `error_class=SessionExpired`.

### Test-scope caveat ([[feedback_test_mock_injection_masks_production_failure]])

The `_FakeSession` fixtures bypass the real driver retry loop (they raise directly from `execute_write`). This is the right scope for asserting **removal of the outer reopen** (one session opened, exception propagates) but does NOT exercise the driver's wall-clock bound itself. That requires a real Neo4j (testcontainers, tracked in issue #38 integration suite — filed 2026-05-17 to replace the phantom #136 reference flagged by Tomas Carvalho at head_sha 29b5727). The test docstring states this explicitly so reviewers don't misread coverage scope.

## Local validation

- `uvx ruff check workers/ingest/processor.py tests/workers/test_ingest_neo4j.py` — passed
- `uvx ruff format --check ...` — already formatted
- `ENVIRONMENT=test python -m pytest tests/workers/test_ingest_neo4j.py` — 20 passed
- `ENVIRONMENT=test python -m pytest tests/workers/ tests/test_utils/ --ignore=tests/test_utils/test_arabic_fuzz.py` — 102 passed, 1 skipped (1 ignored module fails on host-pyenv missing `hypothesis` dep — pre-existing, unrelated to this change; CI venv has the dep)

## Scope guard

Deliberately NOT tuning driver `max_transaction_retry_time` (issue option 2). That is a separate decision — if 30s warrants tuning, it will be filed as a narrow follow-up issue, not bundled into this PR.

## Tech Debt

None introduced. This PR removes an unbounded retry path (or bounds it explicitly); the change is a net reduction in operational risk. The follow-up consideration for driver max_transaction_retry_time tune is intentionally out of scope (separate decision); if pursued, will be filed as a narrow follow-up issue.