### PR TITLE
docs(schema): point manual-mirror docstring at cross-repo CI gate (#24)

### DIFF
--- a/workers/ingest/schema.py
+++ b/workers/ingest/schema.py
@@ -10,11 +10,27 @@ is dropped before the Cypher statement is built.
 Source of truth
 ---------------
 The property names mirror the Pydantic models in
-``noorinalabs-isnad-graph/src/models/*``. Keeping the two in sync is a
-manual step today — when a model grows a new field the ingest allow-list
-must grow to match, otherwise normalize will emit a row whose prop
-silently drops. A future followup (tracked in #192) could codegen these
-maps from the shared models.
+``noorinalabs-isnad-graph/src/models/*``. This file is hand-authored
+canonical (developers grep against it), but mirror integrity is
+enforced by a CI gate in the isnad-graph repo:
+
+  noorinalabs-isnad-graph/.github/workflows/schema-drift.yml
+  noorinalabs-isnad-graph/scripts/emit_ingest_schema.py
+
+The gate runs on every isnad-graph PR. It fetches this file via
+sparse-checkout, derives the model-canonical allow-list from
+``model_fields``, and fails if either direction drifts (a model field
+ingest doesn't accept, OR a phantom ingest field not on the model).
+Rationalized asymmetry is declared in
+``noorinalabs-isnad-graph/scripts/{ingest,model}-extras.yaml`` with
+per-field tracking issue. See #24 for the design.
+
+When a model grows a new field, the isnad-graph PR will fail CI until
+EITHER (a) a sibling PR to this file lands adding the field to the
+appropriate allow-list, OR (b) the model field is excused via
+``model-extras.yaml`` with a category + tracking issue. The two PRs do
+not need to merge atomically — the workflow resolves to the matching
+wave-branch with main fallback so PRs in the same wave window converge.
 
 Fields intentionally omitted
 ----------------------------


### PR DESCRIPTION
## Summary

Updates the `Source of truth` paragraph in `workers/ingest/schema.py` docstring to point at the cross-repo CI drift-gate that just landed in `noorinalabs-isnad-graph` (companion PR opening in parallel under `A.Raghavan/0024-w11-schema-codegen`).

Three substantive prose changes, **no code change**:

1. Replaces the stale `#192` reference (Farhan's Phase-4 SET-injection flag, closed by PR #18) with `#24` (the actual codegen tracking issue, closed by the isnad-graph companion PR).
2. Documents the bidirectional drift-detection mechanism that now mechanically enforces the previously-manual mirror — both directions hard-fail unless declared in `noorinalabs-isnad-graph/scripts/{ingest,model}-extras.yaml`.
3. Documents the wave-aware sibling-checkout semantic so future readers understand sibling PRs don't have to merge atomically.

## Why a separate PR (not bundled into the isnad-graph PR)

- This file remains hand-authored canonical — developers grep `workers/ingest/schema.py` for the live allow-list. The CI gate validates equality; this file is the source-of-truth artifact for readers.
- The two PRs land independently. The isnad-graph workflow fetches `workers/ingest/schema.py` via sparse-checkout, NOT this PR's updated docstring text. Sequence-independence verified.
- The 1-line `#192` → `#24` ref-correction is a charter-required hygiene item — per [[feedback_drift_evidence_to_existing_rationalization_issue]] / /file-bug Pass B, a docstring cite must resolve to a live tracking issue.

## Bidirectional drift discovered during authoring (companion-PR context)

This isn't a regression introduced by this PR — it's the pre-existing baseline state. Captured here for reviewer context; the isnad-graph PR ships the codegen that catches future occurrences AND the `ingest-extras.yaml` + `model-extras.yaml` that rationalize the existing asymmetry. Followup-issue noorinalabs/noorinalabs-isnad-ingest-platform#35 (filed during #24 authoring, tech-debt + phase-3, on board) tracks the data-team rationalization decision for the 11 ingest-only legacy fields.

### Hadith (NODE_PROPERTY_MAP["Hadith"] vs `src/models/hadith.py`)

| Field | On model | In ingest map |
|---|---|---|
| `matn_ar`, `matn_en`, `isnad_raw_ar`, `isnad_raw_en`, `grade_composite`, `source_corpus` | ✓ | ✓ |
| `topic_tags` | ✓ | ✗ (excused as `todo-rationalize` in model-extras.yaml) |
| `has_shia_parallel`, `has_sunni_parallel` | ✓ | ✗ (excused as `todo-rationalize`) |
| `grade`, `sect`, `collection_name`, `book_number`, `chapter_number`, `hadith_number`, `chapter_name_ar`, `chapter_name_en` | ✗ | ✓ (excused as `phase-3-legacy` in ingest-extras.yaml → #35) |

### Narrator

- Model has `aliases` (todo-rationalize); ingest has `name_ar_normalized`, `transmission_method` (phase-3-legacy → #35).
- 5 Phase-4 enrichment-only fields on the model (`betweenness_centrality`, `in_degree`, `out_degree`, `pagerank`, `community_id`) — excluded from ingest per **this file's own** "Fields intentionally omitted" docstring section (PR #18 rationale, captured verbatim into `model-extras.yaml`).

### Collection / Chain / Grading / HistoricalEvent / Location

Collection has 1 ingest-only field (`source_corpus`, phase-3-legacy → #35). Rest converge clean.

### APPEARS_IN edge

Edge map has both `hadith_number` (phase-3-legacy → #35) AND `hadith_number_in_book` (on `AppearsIn` model); model only has the latter.

## Verification

`uvx ruff@0.15.11 check workers/ingest/schema.py` — clean (no code change, docstring-only).

## Tech Debt

None introduced. This PR mechanizes a previously-manual cross-repo mirror, eliminating a class of silent-drift bug. Option 2 (runtime validation via shared schema package) and option 3 (scheduled cross-repo issue-opener job) remain as future evolutions but require infrastructure (shared package, scheduled job) out of scope for this wave.

## Refs

- Closes noorinalabs/noorinalabs-isnad-ingest-platform#24 (jointly with the companion isnad-graph PR — both must merge for the gate to activate end-to-end)
- Companion PR: noorinalabs/noorinalabs-isnad-graph#919 (opened 2026-05-17 at head_sha e7fc5f2 by Arjun Raghavan per cross-repo identity-hook pivot, Co-Authored-By: Sayed Reza — see #919 commit message for the authorship-rationale prose)
- Followup issue: noorinalabs/noorinalabs-isnad-ingest-platform#35 (data-team rationalization, no wave label)

