### PR TITLE
reset CLI: dry-run prints resolved scope via ResetScope.describe() (#15)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -417,19 +417,12 @@ def _cmd_reset(
 
     if stage:
         scope = ResetScope.stage_scope(stage)
-        summary_line = f"STAGE reset: prefix '{stage}/' and consumer offsets"
     elif source:
         scope = ResetScope.source_scope(source)
-        summary_line = f"SOURCE reset: all stage prefixes for source '{source}'"
     else:
         scope = ResetScope.full_scope()
-        summary_line = (
-            "FULL reset: every pipeline B2 prefix, every pipeline Kafka topic, "
-            "Neo4j hadith graph, PG hadith metadata. "
-            "Users/roles/sessions are PRESERVED."
-        )
 
-    print(f"=== Pipeline Reset ===\n  {summary_line}\n")
+    print(f"=== Pipeline Reset ===\n{scope.describe()}\n")
 
     if scope.level == "full" and not assume_yes:
         confirm = input("Type 'OBLITERATE' to proceed: ").strip()

--- a/src/pipeline/reset.py
+++ b/src/pipeline/reset.py
@@ -135,6 +135,54 @@ class ResetScope:
     def full_scope(cls) -> ResetScope:
         return cls(level="full")
 
+    def describe(self, *, indent: str = "  ") -> str:
+        """Render the resolved scope as a multi-line plan.
+
+        Single source of truth shared by the dry-run path and the
+        post-execution report header so operators see the exact same
+        prefixes / topics / tables / labels in both places. Pulls from
+        the same module-level constants the resetter and adapters use,
+        so the plan can never diverge from what gets executed.
+        """
+        from src.pipeline.reset_adapters import HADITH_METADATA_TABLES, HADITH_NODE_LABELS
+
+        if self.level == "stage":
+            assert self.stage is not None
+            prefix = STAGE_PREFIXES[self.stage]
+            topic = STAGE_TOPICS.get(self.stage, "(none — no Kafka topic for this stage)")
+            return (
+                f"STAGE reset — '{self.stage}':\n"
+                f"{indent}B2 prefix      : {prefix}\n"
+                f"{indent}Kafka topic    : {topic}\n"
+                f"{indent}Consumer group : {self.consumer_group}"
+            )
+
+        if self.level == "source":
+            assert self.source is not None
+            source_prefixes = [f"{p}{self.source}/" for p in STAGE_PREFIXES.values()]
+            lines = [f"SOURCE reset — '{self.source}':", f"{indent}B2 prefixes to wipe:"]
+            lines.extend(f"{indent}  - {sp}" for sp in source_prefixes)
+            return "\n".join(lines)
+
+        if self.level == "full":
+            lines = [
+                "FULL reset — every pipeline B2 prefix, every pipeline Kafka topic,",
+                f"{indent}Neo4j hadith graph, PG hadith metadata.",
+                f"{indent}Users/roles/sessions are PRESERVED.",
+                "",
+                f"{indent}B2 prefixes:",
+            ]
+            lines.extend(f"{indent}  - {p}" for p in STAGE_PREFIXES.values())
+            lines.append(f"{indent}Kafka topics:")
+            lines.extend(f"{indent}  - {t}" for t in ALL_PIPELINE_TOPICS)
+            lines.append(f"{indent}Neo4j node labels (HADITH_NODE_LABELS):")
+            lines.extend(f"{indent}  - {label}" for label in HADITH_NODE_LABELS)
+            lines.append(f"{indent}PG tables (HADITH_METADATA_TABLES):")
+            lines.extend(f"{indent}  - {table}" for table in HADITH_METADATA_TABLES)
+            return "\n".join(lines)
+
+        raise ValueError(f"unknown reset level: {self.level!r}")
+
 
 @dataclass
 class ResetReport:

--- a/tests/test_pipeline/test_reset.py
+++ b/tests/test_pipeline/test_reset.py
@@ -306,3 +306,51 @@ def test_paginated_s3_deletion(bucket_name: str, tmp_path: Path) -> None:
 
     assert report.s3_objects_deleted == 3
     assert store._client.objects == {}
+
+
+class TestResetScopeDescribe:
+    """``ResetScope.describe()`` is the resolved-plan helper shared by the
+    dry-run path and the post-execution report. Operators rely on it to
+    sanity-check intent before re-running without ``--dry-run``, so every
+    prefix / topic / table / label that the resetter will actually touch
+    MUST appear by literal string match. See issue #15."""
+
+    def test_stage_describes_prefix_topic_and_consumer_group(self) -> None:
+        out = ResetScope.stage_scope("dedup").describe()
+
+        assert STAGE_PREFIXES["dedup"] in out
+        assert STAGE_TOPICS["dedup"] in out
+        assert "dedup-worker" in out  # default consumer group
+
+    def test_stage_describes_custom_consumer_group(self) -> None:
+        out = ResetScope.stage_scope("enriched", consumer_group="custom-group").describe()
+
+        assert "custom-group" in out
+        assert "enriched-worker" not in out
+
+    def test_source_describes_every_stage_prefix(self) -> None:
+        out = ResetScope.source_scope("sunnah-api").describe()
+
+        for stage_prefix in STAGE_PREFIXES.values():
+            assert f"{stage_prefix}sunnah-api/" in out, (
+                f"source describe missing {stage_prefix}sunnah-api/"
+            )
+
+    def test_full_describes_every_prefix_topic_label_and_table(self) -> None:
+        from src.pipeline.reset_adapters import HADITH_METADATA_TABLES, HADITH_NODE_LABELS
+
+        out = ResetScope.full_scope().describe()
+
+        for prefix in STAGE_PREFIXES.values():
+            assert prefix in out, f"full describe missing B2 prefix {prefix}"
+        for topic in ALL_PIPELINE_TOPICS:
+            assert topic in out, f"full describe missing Kafka topic {topic}"
+        for label in HADITH_NODE_LABELS:
+            assert label in out, f"full describe missing Neo4j label {label}"
+        for table in HADITH_METADATA_TABLES:
+            assert table in out, f"full describe missing PG table {table}"
+
+    def test_full_describe_announces_user_data_preserved(self) -> None:
+        out = ResetScope.full_scope().describe()
+
+        assert "PRESERVED" in out


### PR DESCRIPTION
## Summary

`--dry-run` for `reset` previously printed only `"Dry run — no changes were made. Scope validated."` — operators couldn't sanity-check *what* the resolved scope was before re-running without the flag, which trains them to skip dry-run entirely (Nurul's call-out from PR #9 review).

This PR adds `ResetScope.describe()` as the single resolved-plan source of truth, used by both the pre-confirm header and the `--dry-run` path. The helper pulls from the same module-level constants the resetter and adapters already use (`STAGE_PREFIXES`, `STAGE_TOPICS`, `ALL_PIPELINE_TOPICS`, `HADITH_NODE_LABELS`, `HADITH_METADATA_TABLES`), so the plan operators see can never drift from what gets executed.

Adapter behaviour is unchanged. CLI + one method on the existing `ResetScope` dataclass.

### Output examples

`--stage dedup --dry-run`:
```
STAGE reset — 'dedup':
  B2 prefix      : dedup/
  Kafka topic    : pipeline.dedup.done
  Consumer group : dedup-worker
```

`--source sunnah-api --dry-run`:
```
SOURCE reset — 'sunnah-api':
  B2 prefixes to wipe:
    - raw/sunnah-api/
    - dedup/sunnah-api/
    - enriched/sunnah-api/
    - normalized/sunnah-api/
    - staged/sunnah-api/
```

`--all --dry-run` lists every prefix, every topic, every Neo4j label, and every PG table that would be touched (full plan).

## Tests

5 new in `tests/test_pipeline/test_reset.py::TestResetScopeDescribe` — 15/15 pass total (10 existing untouched). The `--all` test iterates every constant by literal string match per the issue acceptance criteria.

## Tech Debt

None introduced. Helper extraction reduces duplication between dry-run and post-execution report paths. Adapter behavior unchanged.

## Test plan

- [x] `uvx ruff@0.15.9 format --check src/pipeline/reset.py src/cli.py tests/test_pipeline/test_reset.py` — clean
- [x] `uvx ruff@0.15.9 check src/pipeline/reset.py src/cli.py tests/test_pipeline/test_reset.py` — clean
- [x] `ENVIRONMENT=test uv run --frozen pytest tests/test_pipeline/test_reset.py -v` — 15/15 pass
- [x] `mypy --strict` on touched files — 4 errors all pre-existing at `_build_reset_clients` tuple-unpack on wave-11 HEAD (verified by stashing this PR's diff and re-running; not introduced here)
- [ ] Reviewer: spot-read the `--all` describe() output against `STAGE_PREFIXES` / `ALL_PIPELINE_TOPICS` / `HADITH_NODE_LABELS` / `HADITH_METADATA_TABLES` to confirm coverage
- [ ] Reviewer: confirm `_cmd_reset` pre-confirm header and `--dry-run` print the same plan text (single source of truth)

## Coordination

Camila Vasquez's #16 (audit-fields sibling) is sequenced after this PR opens — same-file serialization on `src/cli.py` and `src/pipeline/reset.py`.

Closes #15
