### PR TITLE
feat(workers): PgCheckpoint durable idempotency store — closes #11

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ DATA_CURATED_DIR=./data/curated
 # Logging
 LOG_LEVEL=INFO
 LOG_FORMAT=console
+
+# Worker checkpoint backend — `pg` (durable, prod default) | `in-memory` (local dev only) | `b2` (reserved, not implemented)
+# Local-only `make dev` may set this to `in-memory` to skip the PG dependency.
+INGEST_CHECKPOINT_BACKEND=pg

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
       S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-minio}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-minio12345}
+      INGEST_CHECKPOINT_BACKEND: ${INGEST_CHECKPOINT_BACKEND:-pg}
       LOG_LEVEL: INFO
       LOG_FORMAT: json
     restart: on-failure
@@ -36,6 +37,7 @@ services:
       S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-minio}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-minio12345}
+      INGEST_CHECKPOINT_BACKEND: ${INGEST_CHECKPOINT_BACKEND:-pg}
       LOG_LEVEL: INFO
       LOG_FORMAT: json
     restart: on-failure
@@ -50,6 +52,7 @@ services:
       S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-minio}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-minio12345}
+      INGEST_CHECKPOINT_BACKEND: ${INGEST_CHECKPOINT_BACKEND:-pg}
       LOG_LEVEL: INFO
       LOG_FORMAT: json
     restart: on-failure
@@ -64,6 +67,7 @@ services:
       S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-minio}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-minio12345}
+      INGEST_CHECKPOINT_BACKEND: ${INGEST_CHECKPOINT_BACKEND:-pg}
       NEO4J_URI: ${NEO4J_URI:-bolt://neo4j:7687}
       NEO4J_USER: ${NEO4J_USER:-neo4j}
       NEO4J_PASSWORD: ${NEO4J_PASSWORD:-changeme}

--- a/tests/integration/test_checkpoint_pg_restart.py
+++ b/tests/integration/test_checkpoint_pg_restart.py
@@ -1,0 +1,57 @@
+"""Restart-survival integration test for PgCheckpoint.
+
+Spins up a real PostgreSQL container via testcontainers, marks a batch,
+constructs a *fresh* PgCheckpoint against the same DSN (simulating a
+worker process restart), and asserts the mark survives.
+
+This is the W11 acceptance gate the issue cares about: in-memory state
+is lost on restart, PG state is not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg")
+
+from workers.lib.checkpoint_pg import PgCheckpoint  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+def _connect(dsn: str) -> psycopg.Connection:
+    return psycopg.connect(dsn)
+
+
+def test_checkpoint_survives_worker_restart(postgres_container) -> None:
+    dsn = postgres_container.get_connection_url().replace("postgresql+psycopg2://", "postgresql://")
+
+    # Worker process 1 — mark a batch, then exit (close connection).
+    conn1 = _connect(dsn)
+    cp1 = PgCheckpoint(conn=conn1, stage="dedup-worker")
+    assert cp1.seen("batch-restart-001") is False
+    cp1.mark("batch-restart-001")
+    assert cp1.seen("batch-restart-001") is True
+    cp1.close()
+
+    # Worker process 2 — fresh PgCheckpoint, fresh connection, same DSN.
+    # The DDL is idempotent so a second construction is harmless.
+    conn2 = _connect(dsn)
+    cp2 = PgCheckpoint(conn=conn2, stage="dedup-worker")
+    assert cp2.seen("batch-restart-001") is True, (
+        "checkpoint was lost across restart — durability regression"
+    )
+    # Another stage on the same DSN sees its own scope.
+    cp2_enrich = PgCheckpoint(conn=conn2, stage="enrich-worker")
+    assert cp2_enrich.seen("batch-restart-001") is False
+    cp2.close()
+
+
+def test_schema_creation_is_idempotent(postgres_container) -> None:
+    """Two back-to-back constructions on the same DSN must not error."""
+    dsn = postgres_container.get_connection_url().replace("postgresql+psycopg2://", "postgresql://")
+    conn = _connect(dsn)
+    PgCheckpoint(conn=conn, stage="dedup-worker")
+    # Second construction re-runs the DDL — must be a no-op, not an error.
+    PgCheckpoint(conn=conn, stage="dedup-worker")
+    conn.close()

--- a/tests/workers/test_checkpoint_pg.py
+++ b/tests/workers/test_checkpoint_pg.py
@@ -1,0 +1,130 @@
+"""Unit tests for PgCheckpoint with an in-memory psycopg-shaped fake.
+
+The fake covers only the surface PgCheckpoint actually exercises:
+``cursor()`` context manager yielding an object with ``execute`` and
+``fetchone``, ``commit()``, and ``close()``. This keeps the unit suite
+free of any real PostgreSQL dependency — the docker-backed restart
+drill lives in ``tests/integration/test_checkpoint_pg_restart.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from workers.lib.checkpoint_pg import PgCheckpoint
+
+
+class _FakeCursor:
+    def __init__(self, store: _FakePgConnection) -> None:
+        self._store = store
+        self._last_result: tuple[int] | None = None
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self._store.executed.append((sql, params))
+        normalized = re.sub(r"\s+", " ", sql).strip().upper()
+
+        if (
+            normalized.startswith("CREATE SCHEMA")
+            or "CREATE TABLE" in normalized
+            or "CREATE INDEX" in normalized
+        ):
+            self._last_result = None
+            return
+
+        if normalized.startswith("SELECT 1 FROM PIPELINE.WORKER_CHECKPOINT"):
+            assert params is not None
+            stage, batch_id = params
+            self._last_result = (1,) if (stage, batch_id) in self._store.rows else None
+            return
+
+        if normalized.startswith("INSERT INTO PIPELINE.WORKER_CHECKPOINT"):
+            assert params is not None
+            stage, batch_id = params
+            self._store.rows.add((stage, batch_id))
+            self._last_result = None
+            return
+
+        raise AssertionError(f"unexpected SQL in fake: {sql!r}")
+
+    def fetchone(self) -> tuple[int] | None:
+        return self._last_result
+
+
+class _FakePgConnection:
+    """Psycopg-shaped fake: cursor()-context-manager + commit() + close()."""
+
+    def __init__(self) -> None:
+        self.rows: set[tuple[str, str]] = set()
+        self.executed: list[tuple[str, tuple[Any, ...] | None]] = []
+        self.commits = 0
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def conn() -> _FakePgConnection:
+    return _FakePgConnection()
+
+
+def test_ddl_runs_at_construction(conn: _FakePgConnection) -> None:
+    PgCheckpoint(conn=conn, stage="dedup-worker")
+    # The DDL is one execute call; commit happens once during construction.
+    assert conn.commits == 1
+    assert any("CREATE SCHEMA" in sql.upper() for sql, _ in conn.executed)
+    assert any("CREATE TABLE" in sql.upper() for sql, _ in conn.executed)
+    assert any("CREATE INDEX" in sql.upper() for sql, _ in conn.executed)
+
+
+def test_empty_stage_rejected(conn: _FakePgConnection) -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        PgCheckpoint(conn=conn, stage="")
+
+
+def test_mark_then_seen_roundtrip(conn: _FakePgConnection) -> None:
+    cp = PgCheckpoint(conn=conn, stage="dedup-worker")
+    assert cp.seen("batch-001") is False
+    cp.mark("batch-001")
+    assert cp.seen("batch-001") is True
+
+
+def test_mark_is_idempotent_via_on_conflict(conn: _FakePgConnection) -> None:
+    cp = PgCheckpoint(conn=conn, stage="dedup-worker")
+    cp.mark("batch-001")
+    cp.mark("batch-001")  # second mark is a no-op via ON CONFLICT DO NOTHING
+    assert cp.seen("batch-001") is True
+    # Exactly one row landed.
+    assert sum(1 for r in conn.rows if r[1] == "batch-001") == 1
+
+
+def test_stage_scopes_seen_lookups(conn: _FakePgConnection) -> None:
+    """Same batch_id flowing through two stages gets two distinct rows."""
+    dedup = PgCheckpoint(conn=conn, stage="dedup-worker")
+    enrich = PgCheckpoint(conn=conn, stage="enrich-worker")
+    dedup.mark("batch-001")
+    assert dedup.seen("batch-001") is True
+    assert enrich.seen("batch-001") is False  # different stage, not yet marked
+    enrich.mark("batch-001")
+    assert enrich.seen("batch-001") is True
+
+
+def test_close_propagates_to_underlying_connection(conn: _FakePgConnection) -> None:
+    cp = PgCheckpoint(conn=conn, stage="dedup-worker")
+    cp.close()
+    assert conn.closed is True

--- a/workers/dedup/Dockerfile
+++ b/workers/dedup/Dockerfile
@@ -6,7 +6,8 @@ FROM python:3.14-slim
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy
+    UV_LINK_MODE=copy \
+    INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends build-essential curl \

--- a/workers/dedup/main.py
+++ b/workers/dedup/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 
 from workers.dedup.processor import DedupProcessor
+from workers.lib.checkpoint_factory import build_checkpoint
 from workers.lib.log import configure_logging, get_logger
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
@@ -42,6 +43,7 @@ def build_runner() -> WorkerRunner:
         consumer=consumer,
         producer=producer,
         process=DedupProcessor(store),
+        checkpoint=build_checkpoint(settings.worker_name),
     )
 
 

--- a/workers/enrich/Dockerfile
+++ b/workers/enrich/Dockerfile
@@ -6,7 +6,8 @@ FROM python:3.14-slim
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy
+    UV_LINK_MODE=copy \
+    INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends build-essential curl \

--- a/workers/enrich/main.py
+++ b/workers/enrich/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 
 from workers.enrich.processor import EnrichProcessor
+from workers.lib.checkpoint_factory import build_checkpoint
 from workers.lib.log import configure_logging, get_logger
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
@@ -40,6 +41,7 @@ def build_runner() -> WorkerRunner:
         consumer=consumer,
         producer=producer,
         process=EnrichProcessor(store),
+        checkpoint=build_checkpoint(settings.worker_name),
     )
 
 

--- a/workers/ingest/Dockerfile
+++ b/workers/ingest/Dockerfile
@@ -6,7 +6,8 @@ FROM python:3.14-slim
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy
+    UV_LINK_MODE=copy \
+    INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends build-essential curl \

--- a/workers/ingest/main.py
+++ b/workers/ingest/main.py
@@ -8,6 +8,7 @@ from types import FrameType
 from typing import TYPE_CHECKING
 
 from workers.ingest.processor import IngestProcessor
+from workers.lib.checkpoint_factory import build_checkpoint
 from workers.lib.log import configure_logging, get_logger
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
@@ -54,6 +55,7 @@ def build_runner() -> tuple[WorkerRunner, Driver]:
         consumer=consumer,
         producer=producer,
         process=IngestProcessor(store, neo4j_driver=driver),
+        checkpoint=build_checkpoint(settings.worker_name),
     )
     return runner, driver
 

--- a/workers/lib/checkpoint_factory.py
+++ b/workers/lib/checkpoint_factory.py
@@ -1,0 +1,49 @@
+"""Env-driven checkpoint backend selection for worker entrypoints.
+
+Reads ``INGEST_CHECKPOINT_BACKEND`` (``in-memory`` | ``pg``) and
+constructs the matching ``_Checkpoint`` implementation. ``b2`` is
+reserved for a future B2 marker-object backend; selecting it today
+raises ``NotImplementedError`` so callers can express the eventual
+shape without us silently degrading to in-memory.
+
+Production workers default to ``pg`` via the Dockerfile ENV; local
+``make dev`` keeps the in-memory default so no PG is required to
+exercise the consumer loop.
+"""
+
+from __future__ import annotations
+
+import os
+
+from workers.lib.runner import InMemoryCheckpoint, _Checkpoint
+
+__all__ = ["build_checkpoint"]
+
+_VALID = ("in-memory", "pg", "b2")
+
+
+def build_checkpoint(stage: str) -> _Checkpoint:
+    """Return a checkpoint for ``stage`` driven by ``INGEST_CHECKPOINT_BACKEND``."""
+    backend = os.environ.get("INGEST_CHECKPOINT_BACKEND", "in-memory").lower()
+
+    if backend == "in-memory":
+        return InMemoryCheckpoint()
+
+    if backend == "pg":
+        # Lazy import so unit-test workers don't require psycopg installed.
+        import psycopg
+
+        from src.config import get_settings
+        from workers.lib.checkpoint_pg import PgCheckpoint
+
+        dsn = get_settings().postgres.dsn
+        conn = psycopg.connect(dsn)
+        return PgCheckpoint(conn=conn, stage=stage)
+
+    if backend == "b2":
+        raise NotImplementedError(
+            "INGEST_CHECKPOINT_BACKEND=b2 is reserved for a future "
+            "B2 marker-object backend; use 'in-memory' or 'pg' today."
+        )
+
+    raise ValueError(f"INGEST_CHECKPOINT_BACKEND={backend!r} is invalid; expected one of {_VALID}.")

--- a/workers/lib/checkpoint_pg.py
+++ b/workers/lib/checkpoint_pg.py
@@ -1,0 +1,87 @@
+"""Durable PostgreSQL-backed worker checkpoint.
+
+Implements the ``_Checkpoint`` protocol in :mod:`workers.lib.runner`,
+backing the idempotency guard with a row per ``(stage, batch_id)`` in
+``pipeline.worker_checkpoint``.
+
+The schema is created idempotently at construction time, mirroring the
+no-Alembic pattern used by ``src.utils.pg_client.PgClient.ensure_schema``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+__all__ = ["PgCheckpoint", "_PgConnection"]
+
+
+class _PgConnection(Protocol):
+    """Minimal subset of ``psycopg.Connection`` we depend on.
+
+    Lets the unit tests pass a fake without importing psycopg.
+    """
+
+    def cursor(self) -> Any: ...
+    def commit(self) -> None: ...
+    def close(self) -> None: ...
+
+
+_DDL = """
+CREATE SCHEMA IF NOT EXISTS pipeline;
+
+CREATE TABLE IF NOT EXISTS pipeline.worker_checkpoint (
+    stage      text        NOT NULL,
+    batch_id   text        NOT NULL,
+    marked_at  timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (stage, batch_id)
+);
+
+CREATE INDEX IF NOT EXISTS worker_checkpoint_marked_at_idx
+    ON pipeline.worker_checkpoint (marked_at);
+"""
+
+
+class PgCheckpoint:
+    """Per-stage durable idempotency store.
+
+    Each ``(stage, batch_id)`` pair is one row. ``seen`` is a single
+    indexed lookup; ``mark`` is ``INSERT ... ON CONFLICT DO NOTHING``
+    so a redelivery after a partial failure is a no-op.
+
+    A TTL sweep is intentionally out of scope — at the expected rate
+    (~10k batches/day × 7-day Kafka retention ≈ 70k rows) the index
+    stays trivially small. See follow-up issue (filed post-#11) for
+    the explicit TTL job when scale warrants it.
+    """
+
+    def __init__(self, *, conn: _PgConnection, stage: str) -> None:
+        if not stage:
+            raise ValueError("stage must be a non-empty string")
+        self._conn = conn
+        self._stage = stage
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(_DDL)
+        self._conn.commit()
+
+    def seen(self, batch_id: str) -> bool:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM pipeline.worker_checkpoint WHERE stage = %s AND batch_id = %s",
+                (self._stage, batch_id),
+            )
+            return cur.fetchone() is not None
+
+    def mark(self, batch_id: str) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO pipeline.worker_checkpoint (stage, batch_id) "
+                "VALUES (%s, %s) ON CONFLICT (stage, batch_id) DO NOTHING",
+                (self._stage, batch_id),
+            )
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()

--- a/workers/lib/checkpoint_pg.py
+++ b/workers/lib/checkpoint_pg.py
@@ -50,8 +50,8 @@ class PgCheckpoint:
 
     A TTL sweep is intentionally out of scope — at the expected rate
     (~10k batches/day × 7-day Kafka retention ≈ 70k rows) the index
-    stays trivially small. See follow-up issue (filed post-#11) for
-    the explicit TTL job when scale warrants it.
+    stays trivially small. See #42 for the explicit TTL job when
+    scale warrants it.
     """
 
     def __init__(self, *, conn: _PgConnection, stage: str) -> None:

--- a/workers/normalize/Dockerfile
+++ b/workers/normalize/Dockerfile
@@ -6,7 +6,8 @@ FROM python:3.14-slim
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy
+    UV_LINK_MODE=copy \
+    INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends build-essential curl \

--- a/workers/normalize/main.py
+++ b/workers/normalize/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 
+from workers.lib.checkpoint_factory import build_checkpoint
 from workers.lib.log import configure_logging, get_logger
 from workers.lib.object_store import ObjectStore
 from workers.lib.runner import WorkerRunner, WorkerSettings
@@ -40,6 +41,7 @@ def build_runner() -> WorkerRunner:
         consumer=consumer,
         producer=producer,
         process=NormalizeProcessor(store),
+        checkpoint=build_checkpoint(settings.worker_name),
     )
 
 


### PR DESCRIPTION
Closes #11.

## Summary

Replace `InMemoryCheckpoint` as the production default for all four pipeline workers with `PgCheckpoint`, a PostgreSQL-backed durable idempotency store. Addresses the "required before any prod or shared-staging rollout" gate flagged in #11.

## Backend choice — PG over B2 / Kafka-transactional

| Option | Why rejected / chosen |
|--------|----------------------|
| B2 marker objects | B2 LIST consistency is NOT strongly consistent for new prefixes (PUT-then-LIST may not surface the new key). Wrong primitive for hot-path `seen()` lookups — a freshly-marked checkpoint could be missed on restart. |
| Kafka transactional + idempotent producer | `kafka-python>=2.0` (already pinned) does NOT support transactional producers — would require migration to `confluent-kafka`. Also requires rewriting worker `process()` semantics to put produce + mark in one transaction — violates the "no `processor.py` changes" acceptance gate. |
| **PostgreSQL table (chosen)** | `psycopg[binary]>=3.1` already pinned. `src/utils/pg_client.py` PgClient pattern established (sync, `dict_row`, context-managed, dsn from `get_settings().postgres.dsn`). `testcontainers[postgres]>=4.0` already pinned for integration test. INSERT with `ON CONFLICT DO NOTHING` is the textbook idempotency primitive. |

## Schema scope — new `pipeline` schema on existing shared PG instance

Team-lead pre-acked option (b) — new schema on the existing shared PG (`isnad_graph` database) rather than (a) reusing user-service's PG [cross-service coupling — rejected] or (c) provisioning a new ingest-only PG instance [overkill for a single small low-write table — rejected].

```sql
CREATE SCHEMA IF NOT EXISTS pipeline;

CREATE TABLE IF NOT EXISTS pipeline.worker_checkpoint (
    stage      text        NOT NULL,
    batch_id   text        NOT NULL,
    marked_at  timestamptz NOT NULL DEFAULT now(),
    PRIMARY KEY (stage, batch_id)
);

CREATE INDEX IF NOT EXISTS worker_checkpoint_marked_at_idx
    ON pipeline.worker_checkpoint (marked_at);
```

Follows the established no-Alembic pattern: schema management via idempotent `CREATE ... IF NOT EXISTS` invoked at worker startup, mirroring `src.utils.pg_client.PgClient.ensure_schema()`.

## Configuration

New env var `INGEST_CHECKPOINT_BACKEND={in-memory|pg|b2}`:

- **Prod default (Dockerfile/compose `ENV`)**: `pg`
- **Local/dev default (`make dev`)**: `in-memory` (no PG dependency for the consumer-loop happy-path)
- `b2` is reserved for a future marker-object backend; selecting it today raises `NotImplementedError` rather than silently degrading to in-memory

`PG_DSN` envvar (existing) is reused — no new connection config.

`InMemoryCheckpoint` is retained as an importable class (tests + local-dev import it directly); it just stops being the constructor default.

## Files

| File | Change | Purpose |
|------|--------|---------|
| `workers/lib/checkpoint_pg.py` | NEW (+87) | `PgCheckpoint` implements `_Checkpoint` protocol |
| `workers/lib/checkpoint_factory.py` | NEW (+49) | env-driven `build_checkpoint(stage)` |
| `workers/dedup/main.py` | MOD (+2) | wire `checkpoint=build_checkpoint(...)` in `build_runner()` |
| `workers/enrich/main.py` | MOD (+2) | same |
| `workers/normalize/main.py` | MOD (+2) | same |
| `workers/ingest/main.py` | MOD (+2) | same |
| `tests/workers/test_checkpoint_pg.py` | NEW (+130) | 6 unit tests with psycopg-shaped fake |
| `tests/integration/test_checkpoint_pg_restart.py` | NEW (+57) | testcontainers PG restart drill + DDL idempotency |

**`workers/lib/runner.py` UNCHANGED.** **All four `workers/*/processor.py` files UNCHANGED.** The `_Checkpoint` protocol seam already existed at `workers/lib/runner.py:55-58`; this PR only swaps the constructor default via the worker entrypoints. Acceptance gate preserved.

## Local verification at HEAD

```
ruff check src/ workers/ tests/         All checks passed
ruff format --check                     8 files already formatted
mypy --strict src/ workers/             Success: no issues found in 85 source files
pytest tests/workers/ -m "not integration"   61 passed, 1 skipped (ML), 0 failed
```

Integration restart drill (`tests/integration/test_checkpoint_pg_restart.py`) exercises a real PG via testcontainers — marks a batch on `PgCheckpoint` #1, closes the connection (simulating worker restart), constructs a fresh `PgCheckpoint` #2 on the same DSN, asserts the mark survives. Also verifies DDL is idempotent across re-construction.

## Acceptance — 6/6

- [x] PR description names chosen backend (PG) + rejection rationale for the other two (B2 LIST consistency, kafka-python lacking transactional producer)
- [x] New class implements `seen(batch_id) -> bool` + `mark(batch_id) -> None` matching `_Checkpoint` protocol at `workers/lib/runner.py:90`
- [x] Integration test: checkpoint survives worker restart (real backend per choice — testcontainers PG, `testcontainers[neo4j,postgres]>=4.0` pinned)
- [x] `InMemoryCheckpoint` STAYS for unit-tests/local-dev but no longer default
- [x] No `processor.py` changes in any of 4 workers
- [x] Configuration: `INGEST_CHECKPOINT_BACKEND={in-memory|pg|b2}` env var + sane prod default (`pg` via Dockerfile/compose); team-lead pre-ack on schema scope captured above

## Deferred to follow-ups (filed pre-merge, per Petra's blocker)

Per `multi-layer-gap-filing` discipline — these are real concerns adjacent to #11 but with distinct fix shapes that warrant their own review surface. Both filed and on project board before fixup commit so cites resolve at verdict time (Petra's `feedback_security_guard_inline_not_followup` sibling):

- **#42 — `pipeline.worker_checkpoint` TTL sweep** (W12 scope, `tech-debt`): periodic prune of rows older than ~7d (Kafka retention horizon). Not blocking at expected load (~70k rows/wk = trivial PG load). `workers/lib/checkpoint_pg.py:53` docstring updated to cite #42 in this fixup.
- **#43 — `WorkerRunner.handle_one()` mark-then-send ordering bug** (W12 scope, `tech-debt` + `bug`): `self.checkpoint.mark()` runs BEFORE `producer.send(produce_topic)`. If the producer fails post-mark, the downstream message is dropped permanently. Pre-existing — same behavior with InMemoryCheckpoint today. Body tags #11 + #36 (Petra's Neo4j retry PR) as prior-art for the broader checkpoint-correctness discussion.

## Fixup at `27009e3` (2026-05-17 — addresses ChangesRequested)

- **Tomás blocker (prod-default acceptance gate)**: applied Option C (belt-and-suspenders). All 4 worker `Dockerfile`s carry `ENV INGEST_CHECKPOINT_BACKEND=pg`; `docker-compose.yaml` adds `INGEST_CHECKPOINT_BACKEND: ${INGEST_CHECKPOINT_BACKEND:-pg}` to each of 4 worker services; `.env.example` documents the var with backend semantics + local-dev override hint.
- **Petra blocker 1 (real follow-up cites)**: #42 + #43 filed before commit, project board updated, `checkpoint_pg.py` docstring updated to cite #42, PR body cites real numbers (this section).
- **Petra blocker 2 (PR labels)**: `tech-debt` + `p3-wave-11` applied via REST (gh pr edit silent-no-op'd on Projects classic deprecation per `feedback_gh_pr_edit_silent_noop`).

Validation at new HEAD: `docker compose config` valid; `61 passed, 1 skipped` (matches pre-fix counts); ruff format + lint clean.

## Reviewers

- Primary: Petra Vidović (tech lead) — Approved literal required for Hook 4
- Secondary: Tomás Carvalho (QA engineer) — Approved literal

## Tech Debt

None introduced. Replaces a documented-as-temporary in-memory store with a durable backend, satisfying the "Required before any prod or shared-staging rollout" gate. InMemoryCheckpoint retained as opt-in for tests/local-dev only.

