### PR TITLE
audit(reset): record dry_run, confirmation_method, scope fields explicitly (#16)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -407,7 +407,7 @@ def _cmd_reset(
     from pathlib import Path
 
     from src.config import get_settings
-    from src.pipeline.reset import PipelineResetter, ResetScope
+    from src.pipeline.reset import PipelineResetter, ResetScope, write_dry_run_audit
 
     # Build the scope first — validates inputs before any confirmation.
     provided = sum(1 for f in (stage, source, full) if f)
@@ -424,17 +424,37 @@ def _cmd_reset(
 
     print(f"=== Pipeline Reset ===\n{scope.describe()}\n")
 
-    if scope.level == "full" and not assume_yes:
-        confirm = input("Type 'OBLITERATE' to proceed: ").strip()
-        if confirm != "OBLITERATE":
-            print("Aborted.")
-            sys.exit(1)
-
-    if dry_run:
-        print("Dry run — no changes were made. Scope validated.")
-        return
+    # Track how the operator authorized the run. Only the full reset
+    # requires explicit confirmation today; stage/source scopes are
+    # recorded as "not-required" so SIEM queries can still filter
+    # by method without special-casing scope.
+    if scope.level == "full":
+        if assume_yes:
+            confirmation_method = "yes-flag"
+        else:
+            confirm = input("Type 'OBLITERATE' to proceed: ").strip()
+            if confirm != "OBLITERATE":
+                print("Aborted.")
+                sys.exit(1)
+            confirmation_method = "interactive"
+    else:
+        confirmation_method = "not-required"
 
     settings = get_settings()
+    data_dir = Path(settings.data_raw_dir).parent
+
+    if dry_run:
+        # Dry-run skips adapter construction (no boto3/kafka/neo4j/pg
+        # imports needed) but still writes an audit entry per issue #16.
+        _report, _entry, audit_path = write_dry_run_audit(
+            scope, confirmation_method=confirmation_method, data_dir=data_dir
+        )
+        print("\n=== Dry Run Complete (no changes made) ===")
+        print(f"  Level              : {scope.level}")
+        print(f"  Confirmation method: {confirmation_method}")
+        print(f"  Audit entry        : {audit_path}")
+        return
+
     object_store, kafka_admin, neo4j, pg = _build_reset_clients(settings)
 
     resetter = PipelineResetter(
@@ -442,9 +462,9 @@ def _cmd_reset(
         kafka_admin=kafka_admin,  # type: ignore[arg-type]
         neo4j=neo4j,  # type: ignore[arg-type]
         pg=pg,  # type: ignore[arg-type]
-        data_dir=Path(settings.data_raw_dir).parent,
+        data_dir=data_dir,
     )
-    report, _entry, audit_path = resetter.reset(scope)
+    report, _entry, audit_path = resetter.reset(scope, confirmation_method=confirmation_method)
 
     print("\n=== Reset Complete ===")
     print(f"  Level              : {report.level}")

--- a/src/pipeline/audit.py
+++ b/src/pipeline/audit.py
@@ -8,14 +8,29 @@ from __future__ import annotations
 
 import getpass
 import json
+import os
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-__all__ = ["AuditEntry", "list_recent_entries", "write_audit_entry"]
+__all__ = ["AuditEntry", "create_audit_entry", "list_recent_entries", "write_audit_entry"]
 
 AUDIT_DIR_NAME = "audit"
+
+# Env vars worth capturing alongside ``getpass.getuser()`` so SIEM can
+# attribute actions to a human even when running as root, a service
+# account, or inside a container. Only set keys whose env var is present
+# (never empty placeholders) — see issue #16 bonus item.
+_CALLER_HINT_ENV_VARS: tuple[str, ...] = (
+    "SUDO_USER",
+    "GITHUB_ACTOR",
+    "KUBERNETES_SERVICE_ACCOUNT",
+)
+
+
+def _collect_caller_hints() -> dict[str, str]:
+    return {var: os.environ[var] for var in _CALLER_HINT_ENV_VARS if os.environ.get(var)}
 
 
 @dataclass(frozen=True)
@@ -55,7 +70,19 @@ def create_audit_entry(
     rows_affected: int = 0,
     summary: dict[str, Any] | None = None,
 ) -> AuditEntry:
-    """Build an AuditEntry with auto-populated timestamp and operator."""
+    """Build an AuditEntry with auto-populated timestamp and operator.
+
+    Env-derived caller hints (``SUDO_USER``, ``GITHUB_ACTOR``,
+    ``KUBERNETES_SERVICE_ACCOUNT``) are merged into ``summary["caller_hints"]``
+    when present, so SIEM can attribute actions to a human on shared boxes,
+    container runtimes, or CI runners where ``getpass.getuser()`` returns
+    ``root`` or a service account.
+    """
+    merged_summary: dict[str, Any] = dict(summary or {})
+    hints = _collect_caller_hints()
+    if hints:
+        merged_summary["caller_hints"] = hints
+
     return AuditEntry(
         stage=stage,
         timestamp=datetime.now(tz=UTC).isoformat(),
@@ -63,7 +90,7 @@ def create_audit_entry(
         operator=getpass.getuser(),
         files_changed=files_changed or [],
         rows_affected=rows_affected,
-        summary=summary or {},
+        summary=merged_summary,
     )
 
 

--- a/src/pipeline/reset.py
+++ b/src/pipeline/reset.py
@@ -30,6 +30,7 @@ from typing import Any, Protocol
 from src.pipeline.audit import AuditEntry, create_audit_entry, write_audit_entry
 
 __all__ = [
+    "CONFIRMATION_METHODS",
     "KafkaAdmin",
     "Neo4jResetter",
     "PgResetter",
@@ -38,6 +39,7 @@ __all__ = [
     "ResetScope",
     "StageName",
     "S3Prefix",
+    "write_dry_run_audit",
 ]
 
 # Canonical stage → B2 prefix mapping. Matches issue #105 layout.
@@ -195,6 +197,10 @@ class ResetReport:
     neo4j_rows_deleted: int = 0
     pg_rows_deleted: int = 0
     duration_seconds: float = 0.0
+    dry_run: bool = False
+    confirmation_method: str = "not-required"
+    scope_stage: str | None = None
+    scope_source: str | None = None
 
     def to_summary(self) -> dict[str, Any]:
         return {
@@ -204,7 +210,15 @@ class ResetReport:
             "kafka_topics_reset": self.kafka_topics_reset,
             "neo4j_rows_deleted": self.neo4j_rows_deleted,
             "pg_rows_deleted": self.pg_rows_deleted,
+            "dry_run": self.dry_run,
+            "confirmation_method": self.confirmation_method,
+            "scope_stage": self.scope_stage,
+            "scope_source": self.scope_source,
         }
+
+
+# Allowed values for ``confirmation_method`` — keep in sync with CLI flag mapping.
+CONFIRMATION_METHODS: frozenset[str] = frozenset({"interactive", "yes-flag", "not-required"})
 
 
 class PipelineResetter:
@@ -229,12 +243,23 @@ class PipelineResetter:
         self.pg = pg
         self.data_dir = data_dir
 
-    def reset(self, scope: ResetScope) -> tuple[ResetReport, AuditEntry, Path]:
+    def reset(
+        self,
+        scope: ResetScope,
+        *,
+        confirmation_method: str = "not-required",
+    ) -> tuple[ResetReport, AuditEntry, Path]:
         """Execute a reset and persist an audit entry.
+
+        ``confirmation_method`` records how the operator authorized the run
+        (``"interactive"``, ``"yes-flag"``, or ``"not-required"``) so SIEM
+        can distinguish runbook automation from a typed OBLITERATE confirm.
 
         Returns the report, the audit entry, and the path where the
         audit entry was written.
         """
+        _validate_confirmation_method(confirmation_method)
+
         start = time.monotonic()
 
         if scope.level == "stage":
@@ -247,6 +272,9 @@ class PipelineResetter:
             raise ValueError(f"unknown reset level: {scope.level!r}")
 
         report.duration_seconds = round(time.monotonic() - start, 3)
+        report.confirmation_method = confirmation_method
+        report.scope_stage = scope.stage
+        report.scope_source = scope.source
 
         entry = create_audit_entry(
             stage=f"reset-{scope.level}",
@@ -315,6 +343,47 @@ class PipelineResetter:
             kafka_topics_reset=topics_reset,
             neo4j_rows_deleted=neo4j_rows,
             pg_rows_deleted=pg_rows,
+        )
+
+
+def write_dry_run_audit(
+    scope: ResetScope,
+    *,
+    confirmation_method: str,
+    data_dir: Path,
+) -> tuple[ResetReport, AuditEntry, Path]:
+    """Record a dry-run as an audit entry without performing any work.
+
+    Issue #16: dry-runs are operationally meaningful ("operator practiced
+    first"), and should appear in SIEM alongside real runs with
+    ``dry_run=True`` and zeroed deletion counters. Kept module-level
+    (rather than on ``PipelineResetter``) so the CLI dry-run path doesn't
+    have to construct the four heavyweight reset adapters.
+    """
+    _validate_confirmation_method(confirmation_method)
+
+    report = ResetReport(
+        level=scope.level,
+        dry_run=True,
+        confirmation_method=confirmation_method,
+        scope_stage=scope.stage,
+        scope_source=scope.source,
+    )
+    entry = create_audit_entry(
+        stage=f"reset-{scope.level}",
+        duration_seconds=0.0,
+        rows_affected=0,
+        summary=report.to_summary(),
+    )
+    path = write_audit_entry(data_dir, entry)
+    return report, entry, path
+
+
+def _validate_confirmation_method(method: str) -> None:
+    if method not in CONFIRMATION_METHODS:
+        raise ValueError(
+            f"invalid confirmation_method: {method!r}. "
+            f"Expected one of {sorted(CONFIRMATION_METHODS)}"
         )
 
 

--- a/tests/test_pipeline/test_audit.py
+++ b/tests/test_pipeline/test_audit.py
@@ -92,3 +92,78 @@ class TestWriteAndRead:
         assert len(e.files_changed) == 1
         assert e.files_changed[0]["md5_before"] == "aaa"
         assert e.summary["incremental"] is True
+
+
+class TestCallerHints:
+    """Issue #16 bonus: SIEM needs to attribute audit entries to a human
+    even when ``getpass.getuser()`` returns ``root`` (sudo), a service
+    account (k8s), or a CI bot account (GitHub Actions). Env-derived
+    hints are collected into ``summary["caller_hints"]``."""
+
+    _ALL_HINT_VARS = ("SUDO_USER", "GITHUB_ACTOR", "KUBERNETES_SERVICE_ACCOUNT")
+
+    def _clear_hint_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in self._ALL_HINT_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_no_hints_when_env_vars_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_hint_env(monkeypatch)
+
+        entry = create_audit_entry("sync", duration_seconds=1.0)
+
+        assert "caller_hints" not in entry.summary
+
+    def test_sudo_user_recorded_when_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_hint_env(monkeypatch)
+        monkeypatch.setenv("SUDO_USER", "alice")
+
+        entry = create_audit_entry("sync", duration_seconds=1.0)
+
+        assert entry.summary["caller_hints"] == {"SUDO_USER": "alice"}
+
+    def test_github_actor_and_k8s_sa_both_recorded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_hint_env(monkeypatch)
+        monkeypatch.setenv("GITHUB_ACTOR", "bob-bot")
+        monkeypatch.setenv("KUBERNETES_SERVICE_ACCOUNT", "audit-runner")
+
+        entry = create_audit_entry("reset-full", duration_seconds=1.0)
+
+        assert entry.summary["caller_hints"] == {
+            "GITHUB_ACTOR": "bob-bot",
+            "KUBERNETES_SERVICE_ACCOUNT": "audit-runner",
+        }
+
+    def test_empty_env_var_value_treated_as_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_hint_env(monkeypatch)
+        monkeypatch.setenv("SUDO_USER", "")
+
+        entry = create_audit_entry("sync", duration_seconds=1.0)
+
+        assert "caller_hints" not in entry.summary
+
+    def test_caller_hints_merge_with_existing_summary(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_hint_env(monkeypatch)
+        monkeypatch.setenv("SUDO_USER", "alice")
+
+        entry = create_audit_entry(
+            "reset-full",
+            duration_seconds=1.0,
+            summary={"level": "full", "s3_objects_deleted": 0},
+        )
+
+        assert entry.summary["level"] == "full"
+        assert entry.summary["s3_objects_deleted"] == 0
+        assert entry.summary["caller_hints"] == {"SUDO_USER": "alice"}
+
+    def test_caller_hints_does_not_mutate_input_summary(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_hint_env(monkeypatch)
+        monkeypatch.setenv("SUDO_USER", "alice")
+        input_summary: dict[str, object] = {"level": "stage"}
+
+        create_audit_entry("reset-stage", duration_seconds=1.0, summary=input_summary)
+
+        assert "caller_hints" not in input_summary

--- a/tests/test_pipeline/test_reset.py
+++ b/tests/test_pipeline/test_reset.py
@@ -15,10 +15,12 @@ import pytest
 
 from src.pipeline.reset import (
     ALL_PIPELINE_TOPICS,
+    CONFIRMATION_METHODS,
     STAGE_PREFIXES,
     STAGE_TOPICS,
     PipelineResetter,
     ResetScope,
+    write_dry_run_audit,
 )
 
 
@@ -354,3 +356,141 @@ class TestResetScopeDescribe:
         out = ResetScope.full_scope().describe()
 
         assert "PRESERVED" in out
+
+
+class TestAuditSummaryFieldsExplicit:
+    """Issue #16: audit summary must record dry_run, confirmation_method,
+    and scope_stage/scope_source as discrete fields (not substring-inferable).
+
+    SIEM and Grafana querying needs field-equality filters like
+    ``summary.scope_source == "sunnah-api"`` without regex-scanning
+    JSON-serialized ``s3_prefixes_deleted`` lists."""
+
+    def test_stage_summary_records_scope_stage_and_null_source(
+        self, resetter: PipelineResetter, tmp_path: Path
+    ) -> None:
+        _report, _entry, audit_path = resetter.reset(ResetScope.stage_scope("dedup"))
+
+        summary = json.loads(audit_path.read_text())["summary"]
+        assert summary["scope_stage"] == "dedup"
+        assert summary["scope_source"] is None
+        assert summary["dry_run"] is False
+        assert summary["confirmation_method"] == "not-required"
+
+    def test_source_summary_records_scope_source_and_null_stage(
+        self, resetter: PipelineResetter, tmp_path: Path
+    ) -> None:
+        _report, _entry, audit_path = resetter.reset(ResetScope.source_scope("sunnah-api"))
+
+        summary = json.loads(audit_path.read_text())["summary"]
+        assert summary["scope_source"] == "sunnah-api"
+        assert summary["scope_stage"] is None
+        assert summary["dry_run"] is False
+
+    def test_full_summary_records_null_stage_and_source(
+        self, resetter: PipelineResetter, tmp_path: Path
+    ) -> None:
+        _report, _entry, audit_path = resetter.reset(
+            ResetScope.full_scope(), confirmation_method="yes-flag"
+        )
+
+        summary = json.loads(audit_path.read_text())["summary"]
+        assert summary["scope_stage"] is None
+        assert summary["scope_source"] is None
+        assert summary["confirmation_method"] == "yes-flag"
+        assert summary["dry_run"] is False
+
+    def test_confirmation_method_interactive_recorded(
+        self, resetter: PipelineResetter, tmp_path: Path
+    ) -> None:
+        _report, _entry, audit_path = resetter.reset(
+            ResetScope.full_scope(), confirmation_method="interactive"
+        )
+
+        summary = json.loads(audit_path.read_text())["summary"]
+        assert summary["confirmation_method"] == "interactive"
+
+    def test_confirmation_method_rejects_unknown_value(self, resetter: PipelineResetter) -> None:
+        with pytest.raises(ValueError, match="invalid confirmation_method"):
+            resetter.reset(ResetScope.stage_scope("raw"), confirmation_method="approved")
+
+    def test_confirmation_methods_enum_locked(self) -> None:
+        """Guard test — adding/removing a confirmation method is a contract
+        change for downstream SIEM dashboards. Bump intentionally."""
+        assert CONFIRMATION_METHODS == frozenset({"interactive", "yes-flag", "not-required"})
+
+    def test_report_carries_new_fields_for_caller_inspection(
+        self, resetter: PipelineResetter
+    ) -> None:
+        report, _entry, _path = resetter.reset(
+            ResetScope.source_scope("thaqalayn"), confirmation_method="not-required"
+        )
+
+        assert report.dry_run is False
+        assert report.confirmation_method == "not-required"
+        assert report.scope_source == "thaqalayn"
+        assert report.scope_stage is None
+
+
+class TestDryRunAudit:
+    """Issue #16: dry-runs must write an audit entry tagged ``dry_run=True``
+    (today, dry-run skips audit entirely). ``write_dry_run_audit`` is a
+    module-level helper so the CLI dry-run path can call it without
+    constructing the four heavyweight reset adapters."""
+
+    def test_dry_run_writes_audit_entry_with_dry_run_true(self, tmp_path: Path) -> None:
+        report, _entry, audit_path = write_dry_run_audit(
+            ResetScope.full_scope(),
+            confirmation_method="interactive",
+            data_dir=tmp_path,
+        )
+
+        assert audit_path.exists()
+        assert report.dry_run is True
+
+        data = json.loads(audit_path.read_text())
+        assert data["stage"] == "reset-full"
+        assert data["summary"]["dry_run"] is True
+        assert data["summary"]["confirmation_method"] == "interactive"
+
+    def test_dry_run_zeroes_all_deletion_counters(self, tmp_path: Path) -> None:
+        _report, _entry, audit_path = write_dry_run_audit(
+            ResetScope.full_scope(),
+            confirmation_method="yes-flag",
+            data_dir=tmp_path,
+        )
+
+        summary = json.loads(audit_path.read_text())["summary"]
+        assert summary["s3_objects_deleted"] == 0
+        assert summary["s3_prefixes_deleted"] == []
+        assert summary["kafka_topics_reset"] == []
+        assert summary["neo4j_rows_deleted"] == 0
+        assert summary["pg_rows_deleted"] == 0
+
+    def test_dry_run_carries_scope_fields(self, tmp_path: Path) -> None:
+        _report, _entry, stage_path = write_dry_run_audit(
+            ResetScope.stage_scope("enriched"),
+            confirmation_method="not-required",
+            data_dir=tmp_path,
+        )
+        _r2, _e2, source_path = write_dry_run_audit(
+            ResetScope.source_scope("sunnah-api"),
+            confirmation_method="not-required",
+            data_dir=tmp_path,
+        )
+
+        stage_summary = json.loads(stage_path.read_text())["summary"]
+        assert stage_summary["scope_stage"] == "enriched"
+        assert stage_summary["scope_source"] is None
+
+        source_summary = json.loads(source_path.read_text())["summary"]
+        assert source_summary["scope_source"] == "sunnah-api"
+        assert source_summary["scope_stage"] is None
+
+    def test_dry_run_rejects_unknown_confirmation_method(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="invalid confirmation_method"):
+            write_dry_run_audit(
+                ResetScope.full_scope(),
+                confirmation_method="rubber-stamp",
+                data_dir=tmp_path,
+            )


### PR DESCRIPTION
Closes #16.

## Summary

The reset audit summary now records `dry_run`, `confirmation_method`,
`scope_stage`, and `scope_source` as discrete, field-equality-queryable
fields so SIEM / Grafana / Loki queries no longer require substring
scans over `s3_prefixes_deleted`. Dry-runs (previously skipped entirely)
now write an audit entry tagged `dry_run=True`. Env-derived caller hints
(`SUDO_USER`, `GITHUB_ACTOR`, `KUBERNETES_SERVICE_ACCOUNT`) are merged
into `summary["caller_hints"]` when present so SIEM can attribute to a
human even on shared/CI/container boxes.

## Changes

- `src/pipeline/reset.py`:
  - `ResetReport` gains `dry_run`, `confirmation_method`,
    `scope_stage`, `scope_source` fields, all surfaced in `to_summary()`.
  - `PipelineResetter.reset()` gains a `confirmation_method` keyword
    arg (default `"not-required"`), validated against a new
    `CONFIRMATION_METHODS` frozenset (`{"interactive", "yes-flag", "not-required"}`).
  - New module-level `write_dry_run_audit(scope, confirmation_method, data_dir)`
    helper writes an audit entry without constructing the four
    heavyweight reset adapters — keeps the CLI dry-run path import-cheap
    (boto3 / kafka / neo4j / psycopg stay deferred).
- `src/pipeline/audit.py`:
  - `create_audit_entry()` merges env-derived caller hints into
    `summary["caller_hints"]` when any of `SUDO_USER`, `GITHUB_ACTOR`,
    `KUBERNETES_SERVICE_ACCOUNT` is set and non-empty. Empty-string env
    vars treated as absent. Caller's input `summary` dict is never mutated.
  - `create_audit_entry` added to `__all__`.
- `src/cli.py`:
  - `_cmd_reset` now derives `confirmation_method` from CLI flags
    (`--yes` → `"yes-flag"`, interactive prompt → `"interactive"`,
    stage/source → `"not-required"`) and threads it into both real
    reset and dry-run audit paths.
  - Dry-run path now calls `write_dry_run_audit()` before adapter
    construction, preserving the lightweight dry-run semantics.

**`AuditEntry` dataclass shape is unchanged** — all new fields live
inside `summary` to avoid breaking `AuditEntry(**data)` round-trip
loading of pre-existing audit files. The issue explicitly left this
decision open ("Extend `ResetReport.to_summary` OR pass extra context
through `create_audit_entry`"); summary-only keeps the diff smaller and
backwards-compatible.

**No adapter changes** — `src/pipeline/reset_adapters.py` untouched,
per issue scope discipline.

## Tech Debt

None introduced. The `confirmation_method` enum is a small contract
addition with a guard test (`test_confirmation_methods_enum_locked`) so
any future addition is intentional and visible to SIEM dashboards.

## Test Plan

- `tests/test_pipeline/test_reset.py` — added two new test classes:
  - `TestAuditSummaryFieldsExplicit` (7 tests): stage/source/full scope
    populate `scope_stage`/`scope_source` correctly with nulls where
    inapplicable; `confirmation_method` recorded for `interactive` /
    `yes-flag` / `not-required`; unknown method rejected with
    `ValueError`; `CONFIRMATION_METHODS` enum lock guard; report
    object carries the new fields for in-process inspection.
  - `TestDryRunAudit` (4 tests): dry-run writes audit entry with
    `dry_run=True`; all deletion counters zeroed; scope fields
    propagate for stage/source/full; unknown confirmation method
    rejected.
- `tests/test_pipeline/test_audit.py` — added `TestCallerHints` (6 tests):
  no hints when env vars absent; `SUDO_USER` recorded; `GITHUB_ACTOR` +
  `KUBERNETES_SERVICE_ACCOUNT` both recorded; empty env value treated
  as absent; hints merge with existing summary; input summary dict
  never mutated.
- Local validation gates all pass:
  - `uvx ruff@latest check src/ tests/` — clean
  - `uvx ruff@latest format --check src/ tests/` — clean (124 files
    formatted)
  - `ENVIRONMENT=test uv run pytest tests/test_pipeline/test_reset.py tests/test_pipeline/test_audit.py -v`
    — **39 passed** (was 22 baseline, +17 new)
  - Full repo suite: **576 passed, 4 skipped, 12 errors** — all 12
    errors are pre-existing testcontainers/docker integration tests
    requiring a Docker daemon (unrelated to this change).

## Acceptance criteria from issue #16

> 1. **`dry_run` flag not recorded** — Recording dry-runs as audit gives
>    us "operator practiced first" telemetry.

**Done** — `ResetReport.dry_run` field, surfaced in `to_summary()`.
Dry-runs now write an audit entry via `write_dry_run_audit()` tagged
`dry_run=True` with zeroed deletion counters.

> 2. **`confirmation_method` not recorded** — Field:
>    `"interactive" | "yes-flag" | "not-required"`.

**Done** — `ResetReport.confirmation_method` field with exactly those
three allowed values; CLI maps `--yes` → `"yes-flag"`, typed
`OBLITERATE` → `"interactive"`, stage/source scopes → `"not-required"`.
Validated against `CONFIRMATION_METHODS` frozenset; unknown values
raise `ValueError`.

> 3. **`scope.stage` and `scope.source` not surfaced as discrete fields**
>    — Add `scope_stage` and `scope_source` to summary (null where not
>    applicable).

**Done** — `ResetReport.scope_stage` and `scope_source` fields, populated
from `ResetScope.stage` / `ResetScope.source`; both `None` for full
resets, one populated and the other `None` for stage/source resets.

> ## Bonus consideration
> `AuditEntry.operator` uses `getpass.getuser()` ... Worth also recording
> env-derived caller hints (`SUDO_USER`, `GITHUB_ACTOR`,
> `KUBERNETES_SERVICE_ACCOUNT`) when present.

**Done in scope** — `create_audit_entry()` merges these into
`summary["caller_hints"]` when present and non-empty. Kept in this PR
rather than split because it's a contained ~10-line change with full
test coverage; the diff stays narrow and the SIEM attribution win lands
together with the other fields.
