### PR TITLE
hygiene(gitignore): add .claude/.consulted/ to ignore list (refs noorinalabs-main#465)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,5 @@ faiss_index/
 *.log
 logs/
 
+.claude/.consulted/
 .claude/.librarian-consulted/


### PR DESCRIPTION
Refs noorinalabs/noorinalabs-main#465 (parent meta-issue).

## Summary

Add `.claude/.consulted/` to `.gitignore` so consultation sentinels written by `/ontology-librarian` (and future transcript-reading skills under the namespaced sentinel root) don't show as untracked in `git status`.

## Background

The `/ontology-librarian` skill writes a sentinel to `.claude/.consulted/ontology-librarian/<sha1(pwd)[:16]>.marker` on every invocation as part of the Hook 15 (`enforce_librarian_consulted`) fallback path. The #176 namespace migration in `noorinalabs-main` moved the sentinel root from `.claude/.librarian-consulted/` to `.claude/.consulted/<skill_name>/` so multiple transcript-reading hooks could share the same directory without colliding.

That migration updated `noorinalabs-main/.gitignore` but did not sync the change to the 7 child repos. This PR closes the gap in this repo.

## State at origin/main (verified by parent meta-issue)

This repo is one of the 5 **STALE** repos — `.gitignore` covers only the legacy `.claude/.librarian-consulted/` path (line 64). This PR adds `.claude/.consulted/` immediately above the legacy entry (groups the two consultation-related rules visually; "current above legacy" reads as the namespace-migration semantics).

The legacy `.claude/.librarian-consulted/` rule stays in place for one wave (no harm — directory doesn't exist on disk anymore). It will be removed in W12 cleanup per the parent meta-issue's optional follow-up.

## Change

```diff
+.claude/.consulted/
 .claude/.librarian-consulted/
```

## Test plan

- [x] Mechanical 1-line `.gitignore` edit; no code touched
- [x] Verify post-merge with: `gh api repos/noorinalabs/noorinalabs-isnad-ingest-platform/contents/.gitignore?ref=main --jq '.content' | base64 -d | grep -n '.consulted'` → returns both rules
- [x] After this lands, `git status` in any worktree of this repo will no longer show `.claude/.consulted/ontology-librarian/<hash>.marker` as untracked

## Tech Debt

None introduced.

## Cross-repo context

Part of the 7-PR sweep tracked in `noorinalabs/noorinalabs-main#465`. The 6 sibling PRs follow the same shape. Reviewers (Aino Virtanen + Santiago Ferreira, parent-side org-level) approved a one-time charter carve-out from `feedback_child_repo_implementer_rule` for this mechanical cross-repo cleanup because the rule being inherited (`.claude/.consulted/`) was authored parent-side.
