### PR TITLE
fix(workers): send-before-mark in WorkerRunner.handle_one (Refs #43)

### DIFF
--- a/tests/workers/test_runner.py
+++ b/tests/workers/test_runner.py
@@ -4,10 +4,32 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from tests.workers.conftest import FakeConsumer, FakeProducer
+from tests.workers.test_checkpoint_pg import _FakePgConnection
+from workers.lib.checkpoint_pg import PgCheckpoint
 from workers.lib.dlq import DLQ_TOPIC
 from workers.lib.message import PipelineMessage, parse_message, serialize_message
-from workers.lib.runner import WorkerRunner, WorkerSettings
+from workers.lib.runner import InMemoryCheckpoint, WorkerRunner, WorkerSettings
+
+
+class _SendFailsProducer(FakeProducer):
+    """Producer whose downstream ``send`` raises, simulating broker
+    unavailability / queue-full in the mark/send window (#43).
+
+    DLQ sends still succeed so the failure is isolated to the
+    next-stage publish path.
+    """
+
+    def __init__(self, *, failing_topic: str) -> None:
+        super().__init__()
+        self._failing_topic = failing_topic
+
+    def send(self, topic: str, value: bytes) -> None:
+        if topic == self._failing_topic:
+            raise RuntimeError("broker unavailable")
+        super().send(topic, value)
 
 
 def _settings() -> WorkerSettings:
@@ -129,3 +151,90 @@ def test_no_produce_when_produce_topic_is_none(sample_message: PipelineMessage) 
     runner.handle_one(serialize_message(sample_message))
 
     assert producer.sent == []
+
+
+def test_send_failure_after_mark_does_not_record_checkpoint_inmemory(
+    sample_message: PipelineMessage,
+) -> None:
+    """Regression for #43: if ``producer.send`` raises, the batch must NOT
+    be marked, so a restart reprocesses and re-sends it instead of silently
+    skipping a lost downstream message.
+
+    Covers the default ``InMemoryCheckpoint`` path.
+    """
+    producer = _SendFailsProducer(failing_topic="out")
+    checkpoint = InMemoryCheckpoint()
+
+    def process(msg: PipelineMessage) -> PipelineMessage:
+        return msg.to_next_stage(b2_path="dedup/x.parquet")
+
+    runner = WorkerRunner(
+        settings=_settings(),
+        consumer=FakeConsumer([]),
+        producer=producer,
+        process=process,
+        checkpoint=checkpoint,
+    )
+
+    # The send raises out of handle_one — the batch was not successfully
+    # produced, so it must not be recorded as processed.
+    with pytest.raises(RuntimeError, match="broker unavailable"):
+        runner.handle_one(serialize_message(sample_message))
+
+    assert checkpoint.seen(sample_message.batch_id) is False
+    assert producer.sent == []  # nothing landed downstream
+
+
+def test_send_failure_after_mark_does_not_record_checkpoint_pg(
+    sample_message: PipelineMessage,
+) -> None:
+    """Regression for #43 on the durable ``PgCheckpoint`` path.
+
+    A mark-before-send ordering would leave a permanent row in
+    ``pipeline.worker_checkpoint`` for a batch that never produced its
+    downstream message — exactly the durable-loss this issue describes.
+    """
+    producer = _SendFailsProducer(failing_topic="out")
+    conn = _FakePgConnection()
+    checkpoint = PgCheckpoint(conn=conn, stage="dedup-worker")
+
+    def process(msg: PipelineMessage) -> PipelineMessage:
+        return msg.to_next_stage(b2_path="dedup/x.parquet")
+
+    runner = WorkerRunner(
+        settings=_settings(),
+        consumer=FakeConsumer([]),
+        producer=producer,
+        process=process,
+        checkpoint=checkpoint,
+    )
+
+    with pytest.raises(RuntimeError, match="broker unavailable"):
+        runner.handle_one(serialize_message(sample_message))
+
+    assert checkpoint.seen(sample_message.batch_id) is False
+    assert producer.sent == []
+
+
+def test_successful_send_then_marks_checkpoint(
+    sample_message: PipelineMessage,
+) -> None:
+    """The happy path still marks: send succeeds, then the batch is recorded
+    so a redelivery is correctly skipped."""
+    producer = FakeProducer()
+    checkpoint = InMemoryCheckpoint()
+
+    def process(msg: PipelineMessage) -> PipelineMessage:
+        return msg.to_next_stage(b2_path="dedup/x.parquet")
+
+    runner = WorkerRunner(
+        settings=_settings(),
+        consumer=FakeConsumer([]),
+        producer=producer,
+        process=process,
+        checkpoint=checkpoint,
+    )
+    runner.handle_one(serialize_message(sample_message))
+
+    assert checkpoint.seen(sample_message.batch_id) is True
+    assert len(producer.sent) == 1

--- a/workers/lib/runner.py
+++ b/workers/lib/runner.py
@@ -126,10 +126,19 @@ class WorkerRunner:
             return
 
         self.metrics.records_processed(msg.record_count, batch_id=msg.batch_id)
-        self.checkpoint.mark(msg.batch_id)
 
+        # Send-before-mark ordering (#43). The checkpoint must only record a
+        # batch as processed AFTER its downstream message has been handed to
+        # the producer. The reverse order loses the downstream message if
+        # ``producer.send`` raises after ``mark`` commits: on restart the
+        # batch_id reads as seen and the message is silently skipped forever.
+        # If ``send`` raises here, we do NOT mark — the batch is reprocessed
+        # and re-sent on restart, which downstream consumers absorb via their
+        # own idempotency scope (a re-send is safe; a lost message is not).
         if next_msg is not None and self.settings.produce_topic is not None:
             self.producer.send(self.settings.produce_topic, serialize_message(next_msg))
+
+        self.checkpoint.mark(msg.batch_id)
 
     def run_forever(self, *, stop: Callable[[], bool] | None = None) -> None:
         """Consume indefinitely. ``stop`` is a hook the tests use to break the loop."""


### PR DESCRIPTION
## Summary

`WorkerRunner.handle_one` marked the batch_id as processed (`checkpoint.mark`) **before** producing the downstream message (`producer.send`). If `producer.send` raised after the mark committed — broker unavailability, producer queue full, crash in the window — the batch was durably recorded as seen but its next-stage message was never produced. On restart the batch reads as seen and is silently skipped → permanent downstream loss.

## Fix (Option A — send-before-mark)

Reorder so the next-stage message is handed to the producer **first**, then `mark`. If `send` raises, the batch is not marked, so a restart reprocesses and re-sends it. A re-send is safe (downstream consumers absorb redelivery via their own idempotency scope); a lost message is not recoverable.

## Tests

Regression coverage for both checkpoint paths:
- `test_send_failure_after_mark_does_not_record_checkpoint_inmemory` — `InMemoryCheckpoint`
- `test_send_failure_after_mark_does_not_record_checkpoint_pg` — `PgCheckpoint` (via the unit pg-fake)
- `test_successful_send_then_marks_checkpoint` — happy path still marks

A producer that raises on the produce topic must leave the checkpoint unmarked and nothing landed downstream.

## Scope

Only `WorkerRunner.handle_one` ordering. No `processor.py` change, no `_Checkpoint` Protocol change (preserves #11's carve-outs).

Local: ruff check + ruff format --check + mypy src/ + full workers pytest all green.

Refs #43