### PR TITLE
fix(ingest): fail loud on edge MERGE with missing endpoint (Refs #33)

### DIFF
--- a/tests/workers/test_ingest_neo4j.py
+++ b/tests/workers/test_ingest_neo4j.py
@@ -17,6 +17,7 @@ import pytest
 
 from tests.workers.conftest import FakeConsumer, FakeProducer
 from workers.ingest.processor import (
+    EndpointMissingError,
     IngestProcessor,
     ManifestMissingError,
     UnknownSchemaError,
@@ -44,13 +45,47 @@ class _FakeResult:
 
 
 class _FakeTx:
-    def __init__(self, sink: list[tuple[str, dict[str, Any]]]) -> None:
+    """Records every ``tx.run`` and simulates the node/edge MERGE result shape.
+
+    Node MERGEs return ``{"merged": <row count>}``. Edge MERGEs use the
+    fail-loud ``OPTIONAL MATCH`` Cypher and return both ``merged`` and
+    ``skipped`` — the fake emulates the OPTIONAL MATCH by treating an
+    endpoint as present only if its id is in ``known_ids``. Node MERGEs
+    seen earlier in the same transaction add their ids to ``known_ids``,
+    mirroring the same-session "nodes first" ordering contract so the
+    happy path resolves every endpoint.
+    """
+
+    def __init__(
+        self,
+        sink: list[tuple[str, dict[str, Any]]],
+        *,
+        known_ids: set[str] | None = None,
+    ) -> None:
         self._sink = sink
+        # Endpoints resolvable by the simulated OPTIONAL MATCH. Seeded by
+        # the caller (cross-batch absent-endpoint tests) and grown by node
+        # MERGEs run earlier in this transaction (within-batch happy path).
+        self._known_ids: set[str] = set(known_ids or set())
 
     def run(self, query: str, **params: Any) -> _FakeResult:
         self._sink.append((query, params))
         rows = params.get("rows") or []
-        return _FakeResult({"merged": len(rows)})
+        is_edge = "MERGE (s)-[r:" in query
+        if not is_edge:
+            for row in rows:
+                row_id = row.get("id")
+                if isinstance(row_id, str):
+                    self._known_ids.add(row_id)
+            return _FakeResult({"merged": len(rows)})
+        merged = 0
+        skipped = 0
+        for row in rows:
+            if row.get("src_id") in self._known_ids and row.get("dst_id") in self._known_ids:
+                merged += 1
+            else:
+                skipped += 1
+        return _FakeResult({"merged": merged, "skipped": skipped})
 
 
 class _FakeSession:
@@ -59,9 +94,13 @@ class _FakeSession:
         sink: list[tuple[str, dict[str, Any]]],
         *,
         raise_on_execute: Exception | None = None,
+        known_ids: set[str] | None = None,
     ) -> None:
         self._sink = sink
         self._raise = raise_on_execute
+        # Pre-existing graph node ids the simulated OPTIONAL MATCH resolves
+        # for edge endpoints, on top of whatever nodes this batch MERGEs.
+        self._known_ids = known_ids
 
     def __enter__(self) -> _FakeSession:
         return self
@@ -74,16 +113,24 @@ class _FakeSession:
             err = self._raise
             self._raise = None  # one-shot: subsequent calls succeed
             raise err
-        tx = _FakeTx(self._sink)
+        tx = _FakeTx(self._sink, known_ids=self._known_ids)
         return fn(tx, **kwargs)
 
 
 class _FakeDriver:
-    def __init__(self, *, session_factories: list[_FakeSession] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        session_factories: list[_FakeSession] | None = None,
+        known_ids: set[str] | None = None,
+    ) -> None:
         self.sink: list[tuple[str, dict[str, Any]]] = []
         self.closed = False
         self._factories = session_factories or []
         self._next_factory = 0
+        # Graph node ids present before this batch (cross-batch endpoint
+        # tests seed pre-existing nodes here).
+        self._known_ids = known_ids
 
     def session(self) -> _FakeSession:
         if self._factories:
@@ -94,7 +141,7 @@ class _FakeDriver:
             self._next_factory += 1
             sess._sink = self.sink  # share recording sink
             return sess
-        return _FakeSession(self.sink)
+        return _FakeSession(self.sink, known_ids=self._known_ids)
 
     def close(self) -> None:
         self.closed = True
@@ -251,11 +298,23 @@ def test_node_cypher_for_empty_allowlist_has_no_set() -> None:
     assert "SET" not in query
 
 
-def test_edge_cypher_matches_endpoints_then_merges() -> None:
+def test_edge_cypher_optional_matches_endpoints_and_counts_skips() -> None:
+    """#33: edge Cypher OPTIONAL MATCHes endpoints and reports skips, not silent.
+
+    A bare ``MATCH`` would drop a row with a missing endpoint with zero
+    telemetry; the fail-loud contract requires OPTIONAL MATCH plus a
+    ``skipped`` count the caller can raise on.
+    """
     query = _build_edge_cypher("TRANSMITTED_TO")
-    assert "MATCH (s {id: row.src_id})" in query
-    assert "MATCH (t {id: row.dst_id})" in query
+    assert "OPTIONAL MATCH (s {id: row.src_id})" in query
+    assert "OPTIONAL MATCH (t {id: row.dst_id})" in query
     assert "MERGE (s)-[r:`TRANSMITTED_TO`]->(t)" in query
+    # The MERGE is guarded so it only fires when both endpoints resolved.
+    assert "FOREACH" in query
+    assert "WHEN s IS NOT NULL AND t IS NOT NULL" in query
+    # Both counts are returned so the caller can fail loud on a skip.
+    assert "AS merged" in query
+    assert "AS skipped" in query
     assert (
         "r.position_in_chain = coalesce(row.props.position_in_chain, r.position_in_chain)" in query
     )
@@ -456,6 +515,127 @@ def test_unknown_edge_label_in_batch_raises_schema_error(
     with pytest.raises(UnknownSchemaError, match="unknown label 'SUBVERT_GRAPH'"):
         IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
     assert driver.sink == []  # schema error surfaced before Neo4j
+
+
+# ---------------------------------------------------------------------------
+# #33 — edge endpoint missing must fail loud (per #22 acceptance)
+# ---------------------------------------------------------------------------
+
+
+def test_edge_with_missing_endpoint_in_batch_fails_loud(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    """An edge whose endpoint never lands in the graph must raise, not skip.
+
+    #22 acceptance: *"endpoint missing (both src_id and dst_id must exist
+    — MERGE on node first or fail loud)"*. Here ``nar:b`` is referenced by
+    the edge but is absent from both this batch's node MERGEs and the
+    pre-existing graph, so the OPTIONAL MATCH leaves ``t`` null and the
+    relationship MERGE cannot fire. Old behavior: silent skip, data lost.
+    New behavior: ``EndpointMissingError`` → DLQ.
+    """
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Narrator": [{"id": "nar:a", "props": {"name_en": "A"}}]},
+        edges=[
+            {
+                "label": "TRANSMITTED_TO",
+                "src_id": "nar:a",
+                "src_label": "Narrator",
+                "dst_id": "nar:b",  # never MERGEd as a node, not pre-existing
+                "dst_label": "Narrator",
+                "props": {"position_in_chain": 0},
+            }
+        ],
+    )
+    driver = _FakeDriver()
+
+    with pytest.raises(EndpointMissingError, match="endpoint absent from the graph"):
+        IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+    # EndpointMissingError is a subclass of UnknownSchemaError so the
+    # runner's existing schema-error branch DLQs it.
+    assert issubclass(EndpointMissingError, UnknownSchemaError)
+    # The missing endpoint id appears in the loud failure message.
+    with pytest.raises(EndpointMissingError, match="nar:b"):
+        IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+
+
+def test_edge_with_endpoint_in_prior_batch_present_merges_cleanly(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    """The cross-batch happy path: endpoint landed in a prior batch.
+
+    The destination node ``nar:b`` is NOT in this batch's node MERGEs but
+    IS pre-existing in the graph (seeded via the driver's ``known_ids``).
+    The OPTIONAL MATCH resolves both endpoints, so the edge MERGEs and no
+    EndpointMissingError fires — proving the fail-loud path keys on
+    *graph presence*, not *this-batch presence*.
+    """
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Narrator": [{"id": "nar:a", "props": {"name_en": "A"}}]},
+        edges=[
+            {
+                "label": "TRANSMITTED_TO",
+                "src_id": "nar:a",
+                "src_label": "Narrator",
+                "dst_id": "nar:b",
+                "dst_label": "Narrator",
+                "props": {"position_in_chain": 0},
+            }
+        ],
+    )
+    driver = _FakeDriver(known_ids={"nar:b"})  # nar:b landed in a prior batch
+
+    # No exception — the edge resolves both endpoints.
+    IngestProcessor(object_store, neo4j_driver=driver)(folder_prefix_message)
+
+    edge_calls = [(q, p) for q, p in driver.sink if "MERGE (s)-[r:" in q]
+    assert len(edge_calls) == 1
+
+
+def test_runner_routes_missing_endpoint_to_dlq(
+    object_store: ObjectStore, folder_prefix_message: PipelineMessage
+) -> None:
+    """#33: a missing-endpoint edge is DLQ'd, not silently dropped."""
+    _write_batch(
+        object_store,
+        folder_prefix_message.b2_path,
+        nodes={"Narrator": [{"id": "nar:a", "props": {"name_en": "A"}}]},
+        edges=[
+            {
+                "label": "TRANSMITTED_TO",
+                "src_id": "nar:a",
+                "src_label": "Narrator",
+                "dst_id": "nar:ghost",  # never lands
+                "dst_label": "Narrator",
+                "props": {},
+            }
+        ],
+    )
+    driver = _FakeDriver()
+    producer = FakeProducer()
+
+    runner = WorkerRunner(
+        settings=WorkerSettings(
+            worker_name="ingest-worker",
+            consume_topic=PIPELINE_NORMALIZE_DONE,
+            produce_topic=None,
+            consumer_group="ingest-worker",
+        ),
+        consumer=FakeConsumer([]),
+        producer=producer,
+        process=IngestProcessor(object_store, neo4j_driver=driver),
+    )
+    runner.handle_one(serialize_message(folder_prefix_message))
+
+    assert len(producer.sent) == 1
+    topic, value = producer.sent[0]
+    assert topic == DLQ_TOPIC
+    record = json.loads(value)
+    assert record["error_class"] == "EndpointMissingError"
 
 
 # ---------------------------------------------------------------------------

--- a/workers/ingest/processor.py
+++ b/workers/ingest/processor.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     from neo4j import Driver, ManagedTransaction
 
 __all__ = [
+    "EndpointMissingError",
     "IngestProcessor",
     "ManifestMissingError",
     "UnknownSchemaError",
@@ -80,6 +81,23 @@ class UnknownSchemaError(ValueError):
 
 class ManifestMissingError(UnknownSchemaError):
     """Raised when ``_MANIFEST.json`` is absent or cannot be parsed.
+
+    Subclass of ``UnknownSchemaError`` so the runner's existing DLQ
+    routing for schema errors catches this without a new branch.
+    """
+
+
+class EndpointMissingError(UnknownSchemaError):
+    """Raised when an edge MERGE references an endpoint absent from the graph.
+
+    #22 acceptance requires that a missing endpoint (``src_id`` or
+    ``dst_id`` that does not resolve to an existing node at MERGE time)
+    fail loud rather than silently skip. The old ``MATCH … MATCH … MERGE``
+    idiom dropped such rows with no error, no telemetry, no DLQ — an
+    undetectable data-loss class for the never-landing-endpoint case (see
+    #33). The edge Cypher now ``OPTIONAL MATCH``es both endpoints and
+    counts the rows where either side is null; a non-zero count raises
+    this error.
 
     Subclass of ``UnknownSchemaError`` so the runner's existing DLQ
     routing for schema errors catches this without a new branch.
@@ -310,9 +328,29 @@ def _build_node_cypher(label: str) -> str:
 
 
 def _build_edge_cypher(label: str) -> str:
-    """Per-edge-label MERGE Cypher with enumerated, null-safe SET stanzas.
+    """Per-edge-label MERGE Cypher with fail-loud missing-endpoint detection.
 
-    Same coalesce-clear contract as ``_build_node_cypher``:
+    #22 acceptance: *"endpoint missing (both src_id and dst_id must exist
+    — MERGE on node first or fail loud)"*. The original idiom
+
+        MATCH (s {id: row.src_id})
+        MATCH (t {id: row.dst_id})
+        MERGE (s)-[r:`label`]->(t)
+
+    silently dropped a row whose endpoint did not yet exist — the MATCH
+    returned 0 rows and the relationship MERGE never fired. Within a
+    single batch this is safe (node MERGE runs first in the same tx), but
+    a cross-batch edge whose endpoint was supposed to land earlier and
+    never did was lost with no error, no DLQ, no metric (#33).
+
+    This builder uses ``OPTIONAL MATCH`` on both endpoints and a
+    ``FOREACH`` guard that only MERGEs the relationship when both sides
+    resolved. It returns two counts — the number of relationships merged
+    and the number of rows whose endpoint was missing. The caller
+    (``_merge_edges_tx``) raises ``EndpointMissingError`` when the missing
+    count is non-zero, so the silent-skip becomes a loud DLQ.
+
+    Coalesce-clear contract (per SET line) — same as ``_build_node_cypher``:
 
     - field omitted from ``row.props``  → preserve existing value
     - field present with explicit null  → preserve existing value (silent no-op)
@@ -321,15 +359,24 @@ def _build_edge_cypher(label: str) -> str:
     Edge properties cannot be cleared via an ingest batch (see #23).
     """
     fields = EDGE_PROPERTY_MAP.get(label, [])
-    set_lines = ",\n    ".join(f"r.{f} = coalesce(row.props.{f}, r.{f})" for f in fields)
-    set_clause = f"SET {set_lines}\n" if fields else ""
+    # SET stanzas run inside the FOREACH guard, so they reference the
+    # relationship bound there (``r``) and the per-row ``row`` captured by
+    # the surrounding UNWIND.
+    set_lines = ",\n        ".join(f"r.{f} = coalesce(row.props.{f}, r.{f})" for f in fields)
+    set_clause = f"\n        SET {set_lines}" if fields else ""
     return (
         "UNWIND $rows AS row\n"
-        "MATCH (s {id: row.src_id})\n"
-        "MATCH (t {id: row.dst_id})\n"
-        f"MERGE (s)-[r:`{label}`]->(t)\n"
-        f"{set_clause}"
-        "RETURN count(r) AS merged"
+        "OPTIONAL MATCH (s {id: row.src_id})\n"
+        "OPTIONAL MATCH (t {id: row.dst_id})\n"
+        # FOREACH over a 1- or 0-element list: the relationship MERGE runs
+        # only when BOTH endpoints resolved. A missing endpoint leaves the
+        # list empty so nothing is created — and we count it below.
+        "FOREACH (_ IN CASE WHEN s IS NOT NULL AND t IS NOT NULL THEN [1] ELSE [] END |\n"
+        f"    MERGE (s)-[r:`{label}`]->(t){set_clause}\n"
+        ")\n"
+        "RETURN\n"
+        "  count(CASE WHEN s IS NOT NULL AND t IS NOT NULL THEN 1 END) AS merged,\n"
+        "  count(CASE WHEN s IS NULL OR t IS NULL THEN 1 END) AS skipped"
     )
 
 
@@ -341,10 +388,58 @@ def _merge_nodes_tx(tx: ManagedTransaction, *, label: str, rows: list[dict[str, 
 
 
 def _merge_edges_tx(tx: ManagedTransaction, *, label: str, rows: list[dict[str, Any]]) -> int:
+    """MERGE one edge label's rows; fail loud on any missing endpoint.
+
+    The edge Cypher (see ``_build_edge_cypher``) returns both the merged
+    count and a ``skipped`` count of rows whose ``src_id``/``dst_id`` did
+    not resolve to a node in the graph. Per #22 acceptance a missing
+    endpoint must fail loud, so any non-zero ``skipped`` raises
+    ``EndpointMissingError`` — the runner then DLQs the whole batch
+    rather than letting the edge data vanish silently (#33).
+    """
     query = _build_edge_cypher(label)
     result = tx.run(query, rows=rows)
     record = result.single()
-    return int(record["merged"]) if record else 0
+    if record is None:
+        return 0
+    skipped = int(record["skipped"]) if record["skipped"] is not None else 0
+    if skipped:
+        missing = _missing_endpoint_ids(rows)
+        _logger.error(
+            "ingest_edge_endpoint_missing",
+            edge_label=label,
+            skipped=skipped,
+            total=len(rows),
+            missing_endpoints=missing,
+        )
+        msg = (
+            f"{label}: {skipped} of {len(rows)} edge row(s) reference an "
+            f"endpoint absent from the graph at MERGE time "
+            f"(missing node ids: {missing}); failing loud per #22 acceptance"
+        )
+        raise EndpointMissingError(msg)
+    return int(record["merged"]) if record["merged"] is not None else 0
+
+
+def _missing_endpoint_ids(rows: list[dict[str, Any]]) -> list[str]:
+    """Collect the distinct endpoint ids referenced by the edge rows.
+
+    Used only to build the ``EndpointMissingError`` message / log line.
+    The Cypher already determined *that* an endpoint was missing; without
+    a second round-trip we cannot know exactly which ids were absent, so
+    we surface every endpoint id in the failing batch (capped) as the
+    operator's starting point for the bring-up audit. Bounded to keep the
+    DLQ record and log line from ballooning on a large batch.
+    """
+    seen: list[str] = []
+    for row in rows:
+        for key in ("src_id", "dst_id"):
+            value = row.get(key)
+            if isinstance(value, str) and value not in seen:
+                seen.append(value)
+                if len(seen) >= 20:  # noqa: PLR2004 — log/message cap, not a domain constant
+                    return seen
+    return seen
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Edge MERGE used `MATCH (s) MATCH (t) MERGE (s)-[r]->(t)`. When either endpoint did not exist at MERGE time, the `MATCH` returned 0 rows and the relationship MERGE silently never fired — no error, no DLQ, no metric. Cross-batch (an edge referencing an endpoint that should have landed in a prior batch but never did) this lost edge data silently — an undetectable data-loss class. It diverged from #22 acceptance: *"endpoint missing (both src_id and dst_id must exist — MERGE on node first or fail loud)"*.

## Change (issue option 1)

- `_build_edge_cypher`: `OPTIONAL MATCH` both endpoints; guard the relationship MERGE behind a `FOREACH` that fires only when both resolved; return both `merged` and `skipped` counts.
- `_merge_edges_tx`: raise new `EndpointMissingError` (subclass of `UnknownSchemaError` → runner's existing schema-error branch DLQs it) when `skipped > 0`; log `ingest_edge_endpoint_missing` with referenced endpoint ids for bring-up detection.
- Within-batch happy path unchanged (nodes MERGE first in the same session). Fail-loud keys on *graph presence*, not *this-batch presence*, so a legitimately prior-batch endpoint still merges cleanly.

## Acceptance (#33)

- [x] Missing endpoint = loud failure (EndpointMissingError → DLQ), not silent skip
- [x] Unit test: edge row referencing a node not present → schema error / DLQ
- [x] Docstring on `_build_edge_cypher` documents the chosen contract
- [x] Log line emitted on missing-endpoint event

## Tests

- OPTIONAL-MATCH / FOREACH / `skipped`-count Cypher shape
- missing endpoint → `EndpointMissingError` (message names the missing id)
- prior-batch endpoint present (graph-seeded) → clean merge, no error
- runner routes `EndpointMissingError` to DLQ with `error_class == "EndpointMissingError"`

Full unit suite: 587 passed, 4 skipped. 12 integration errors are pre-existing Docker/Neo4j-dependent (testcontainers, #38), unrelated. ruff check + format clean.

TechDebt: none

Refs #33
Refs #22