### PR TITLE
tech-debt(workers): worker_checkpoint TTL sweep (Refs #42)

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -22,9 +22,10 @@ relevant.
 4. [Deploy procedure](#deploy-procedure)
 5. [Rollback](#rollback)
 6. [Common-failure triage](#common-failure-triage)
-7. [On-call escalation](#on-call-escalation)
-8. [References](#references)
-9. [Known gaps and carry-forwards](#known-gaps-and-carry-forwards)
+7. [Maintenance](#maintenance)
+8. [On-call escalation](#on-call-escalation)
+9. [References](#references)
+10. [Known gaps and carry-forwards](#known-gaps-and-carry-forwards)
 
 ---
 
@@ -448,6 +449,54 @@ If MinIO is responsive but `403`s:
 - `S3_ENDPOINT_URL` pointing at the wrong host (MinIO is HTTP not
   HTTPS in local dev).
 - Bucket policy missing — should be unrestricted for the dev creds.
+
+---
+
+## Maintenance
+
+### worker_checkpoint TTL sweep
+
+`PgCheckpoint` (the `pg` checkpoint backend) writes one row per
+`(stage, batch_id)` into `pipeline.worker_checkpoint`. At the expected
+steady-state rate (~10k batches/day × 7-day Kafka retention ≈ 70k rows)
+the `worker_checkpoint_marked_at_idx` stays trivially small and **no
+sweep is needed**. The sweep exists for the cases that break that
+assumption:
+
+- sustained throughput rise (e.g. >100k batches/day),
+- Kafka retention extended beyond 7 days, or
+- a backfill/replay row spike that doesn't age out naturally.
+
+`PgCheckpoint.sweep()` is the mechanism. It is a **no-op until a stage's
+row count exceeds the threshold**; once over, it deletes rows older than
+the retention window and returns the number deleted. It is safe to call
+on every worker tick or from an external scheduler — below threshold it
+costs a single `count(*)`.
+
+**Ops surface:** the sweep is a method, not a deployed job — wiring it to
+a cron / k8s `CronJob` / scheduler tick is a deploy-side choice tracked
+in `noorinalabs-deploy` (it owns the Postgres runtime). Call
+`build_checkpoint(stage).sweep()` from whichever scheduler the cutover
+picks; the method has no scheduler assumptions baked in.
+
+**Tuning** (env, read at `PgCheckpoint` construction — change without a
+code edit):
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `INGEST_CHECKPOINT_RETENTION_DAYS` | `14` | Delete rows older than this. Default = 7-day Kafka retention + 1-week safety margin. Raise it if Kafka retention is extended. |
+| `INGEST_CHECKPOINT_SWEEP_THRESHOLD_ROWS` | `100000` | Per-stage row count below which the sweep is a no-op. Raise it to suppress sweeps at higher steady-state; lower it to sweep more eagerly. |
+
+A blank or unparseable value falls back to the default (logged as
+`checkpoint_env_int_invalid`) rather than crashing the worker.
+
+**Observability:** every `sweep()` emits a `checkpoint_sweep` structured
+log with `deleted`, the pre-sweep `row_count`, the active `threshold_rows`
+/ `retention_days`, and a `swept` boolean. Alert on **`swept=true` with
+`deleted=0`** (or a `row_count` that keeps climbing across ticks) — that
+means rows are accumulating faster than the retention window evicts them,
+i.e. retention is mis-tuned for the current throughput and the window or
+threshold needs revisiting per the table above.
 
 ---
 

--- a/tests/workers/test_checkpoint_pg.py
+++ b/tests/workers/test_checkpoint_pg.py
@@ -10,6 +10,7 @@ drill lives in ``tests/integration/test_checkpoint_pg_restart.py``.
 from __future__ import annotations
 
 import re
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -20,7 +21,8 @@ from workers.lib.checkpoint_pg import PgCheckpoint
 class _FakeCursor:
     def __init__(self, store: _FakePgConnection) -> None:
         self._store = store
-        self._last_result: tuple[int] | None = None
+        self._last_result: tuple[Any, ...] | None = None
+        self.rowcount: int | None = None
 
     def __enter__(self) -> _FakeCursor:
         return self
@@ -46,27 +48,61 @@ class _FakeCursor:
             self._last_result = (1,) if (stage, batch_id) in self._store.rows else None
             return
 
+        if normalized.startswith("SELECT COUNT(*) FROM PIPELINE.WORKER_CHECKPOINT"):
+            assert params is not None
+            (stage,) = params
+            self._last_result = (sum(1 for r in self._store.rows if r[0] == stage),)
+            return
+
         if normalized.startswith("INSERT INTO PIPELINE.WORKER_CHECKPOINT"):
             assert params is not None
             stage, batch_id = params
             self._store.rows.add((stage, batch_id))
+            self._store.marked_at.setdefault((stage, batch_id), self._store.now)
+            self._last_result = None
+            return
+
+        if normalized.startswith("DELETE FROM PIPELINE.WORKER_CHECKPOINT"):
+            assert params is not None
+            stage, retention_days = params
+            cutoff = self._store.now - timedelta(days=int(retention_days))
+            doomed = {
+                r
+                for r in self._store.rows
+                if r[0] == stage and self._store.marked_at.get(r, self._store.now) < cutoff
+            }
+            self._store.rows -= doomed
+            for r in doomed:
+                self._store.marked_at.pop(r, None)
+            self.rowcount = len(doomed)
             self._last_result = None
             return
 
         raise AssertionError(f"unexpected SQL in fake: {sql!r}")
 
-    def fetchone(self) -> tuple[int] | None:
+    def fetchone(self) -> tuple[Any, ...] | None:
         return self._last_result
 
 
 class _FakePgConnection:
-    """Psycopg-shaped fake: cursor()-context-manager + commit() + close()."""
+    """Psycopg-shaped fake: cursor()-context-manager + commit() + close().
+
+    Tracks a per-row ``marked_at`` so the TTL sweep DELETE can be modelled
+    against an injectable wall-clock (``now``).
+    """
 
     def __init__(self) -> None:
         self.rows: set[tuple[str, str]] = set()
+        self.marked_at: dict[tuple[str, str], datetime] = {}
+        self.now = datetime.now(UTC)
         self.executed: list[tuple[str, tuple[Any, ...] | None]] = []
         self.commits = 0
         self.closed = False
+
+    def insert_aged(self, stage: str, batch_id: str, *, age_days: float) -> None:
+        """Seed a row whose ``marked_at`` is ``age_days`` in the past."""
+        self.rows.add((stage, batch_id))
+        self.marked_at[(stage, batch_id)] = self.now - timedelta(days=age_days)
 
     def cursor(self) -> _FakeCursor:
         return _FakeCursor(self)
@@ -128,3 +164,82 @@ def test_close_propagates_to_underlying_connection(conn: _FakePgConnection) -> N
     cp = PgCheckpoint(conn=conn, stage="dedup-worker")
     cp.close()
     assert conn.closed is True
+
+
+# --- TTL sweep (#42) ---------------------------------------------------------
+
+
+def test_sweep_is_noop_below_threshold(conn: _FakePgConnection) -> None:
+    """At or below the row-count threshold the sweep deletes nothing."""
+    cp = PgCheckpoint(conn=conn, stage="dedup-worker", retention_days=14, threshold_rows=5)
+    # Two rows older than the window, but well under the 5-row threshold.
+    conn.insert_aged("dedup-worker", "batch-old-1", age_days=30)
+    conn.insert_aged("dedup-worker", "batch-old-2", age_days=30)
+    assert cp.sweep() == 0
+    assert conn.rows == {("dedup-worker", "batch-old-1"), ("dedup-worker", "batch-old-2")}
+    # No DELETE was issued.
+    assert not any("DELETE" in sql.upper() for sql, _ in conn.executed)
+
+
+def test_sweep_deletes_only_aged_rows_over_threshold(conn: _FakePgConnection) -> None:
+    cp = PgCheckpoint(conn=conn, stage="dedup-worker", retention_days=14, threshold_rows=2)
+    # Three rows trip the 2-row threshold; only the two older than 14d age out.
+    conn.insert_aged("dedup-worker", "batch-stale-1", age_days=20)
+    conn.insert_aged("dedup-worker", "batch-stale-2", age_days=15)
+    conn.insert_aged("dedup-worker", "batch-fresh", age_days=3)
+    deleted = cp.sweep()
+    assert deleted == 2
+    assert conn.rows == {("dedup-worker", "batch-fresh")}
+
+
+def test_sweep_is_stage_scoped(conn: _FakePgConnection) -> None:
+    """A sweep on one stage never touches another stage's rows."""
+    dedup = PgCheckpoint(conn=conn, stage="dedup-worker", retention_days=14, threshold_rows=0)
+    conn.insert_aged("dedup-worker", "batch-old", age_days=30)
+    conn.insert_aged("enrich-worker", "batch-old", age_days=30)
+    assert dedup.sweep() == 1
+    assert ("enrich-worker", "batch-old") in conn.rows
+    assert ("dedup-worker", "batch-old") not in conn.rows
+
+
+def test_sweep_over_threshold_with_only_fresh_rows_deletes_nothing(
+    conn: _FakePgConnection,
+) -> None:
+    """Over threshold but all rows inside the window — the alerting signal."""
+    cp = PgCheckpoint(conn=conn, stage="dedup-worker", retention_days=14, threshold_rows=1)
+    conn.insert_aged("dedup-worker", "batch-a", age_days=2)
+    conn.insert_aged("dedup-worker", "batch-b", age_days=5)
+    assert cp.sweep() == 0
+    assert len(conn.rows) == 2
+
+
+def test_retention_and_threshold_read_from_env(
+    conn: _FakePgConnection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("INGEST_CHECKPOINT_RETENTION_DAYS", "7")
+    monkeypatch.setenv("INGEST_CHECKPOINT_SWEEP_THRESHOLD_ROWS", "1")
+    cp = PgCheckpoint(conn=conn, stage="dedup-worker")
+    conn.insert_aged("dedup-worker", "batch-stale", age_days=10)  # > 7d window
+    conn.insert_aged("dedup-worker", "batch-fresh", age_days=4)  # < 7d window
+    assert cp.sweep() == 1
+    assert conn.rows == {("dedup-worker", "batch-fresh")}
+
+
+def test_invalid_env_falls_back_to_default(
+    conn: _FakePgConnection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("INGEST_CHECKPOINT_RETENTION_DAYS", "not-an-int")
+    # Falls back to the 14-day default rather than crashing construction.
+    cp = PgCheckpoint(conn=conn, stage="dedup-worker", threshold_rows=0)
+    conn.insert_aged("dedup-worker", "batch-stale", age_days=20)
+    assert cp.sweep() == 1
+
+
+def test_invalid_retention_argument_rejected(conn: _FakePgConnection) -> None:
+    with pytest.raises(ValueError, match="retention_days must be positive"):
+        PgCheckpoint(conn=conn, stage="dedup-worker", retention_days=0)
+
+
+def test_invalid_threshold_argument_rejected(conn: _FakePgConnection) -> None:
+    with pytest.raises(ValueError, match="threshold_rows must be non-negative"):
+        PgCheckpoint(conn=conn, stage="dedup-worker", threshold_rows=-1)

--- a/workers/lib/checkpoint_pg.py
+++ b/workers/lib/checkpoint_pg.py
@@ -10,9 +10,26 @@ no-Alembic pattern used by ``src.utils.pg_client.PgClient.ensure_schema``.
 
 from __future__ import annotations
 
+import os
 from typing import Any, Protocol
 
+from workers.lib.log import get_logger
+
 __all__ = ["PgCheckpoint", "_PgConnection"]
+
+_logger = get_logger("workers.checkpoint_pg")
+
+# TTL sweep defaults (#42). The sweep is a no-op until the row count for a
+# stage exceeds ``_SWEEP_THRESHOLD_ROWS``; below that the index stays trivially
+# small and a periodic DELETE is pure operational cost. Once over threshold,
+# rows older than ``_SWEEP_RETENTION_DAYS`` are deleted. The retention window
+# defaults to Kafka's 7-day retention plus a one-week safety margin, so a row
+# is only ever swept well after its batch could possibly be redelivered.
+#
+# Both are read at construction time from the environment so ops can tune them
+# without a code change (see RUNBOOK § "worker_checkpoint TTL sweep").
+_DEFAULT_RETENTION_DAYS = 14
+_DEFAULT_THRESHOLD_ROWS = 100_000
 
 
 class _PgConnection(Protocol):
@@ -41,6 +58,23 @@ CREATE INDEX IF NOT EXISTS worker_checkpoint_marked_at_idx
 """
 
 
+def _env_int(name: str, default: int) -> int:
+    """Read ``name`` from the environment as an int, falling back to ``default``.
+
+    A blank or unparseable value falls back to the default rather than
+    crashing a worker on a typo'd env var; the chosen value is observable
+    in the ``checkpoint_sweep`` metric.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        _logger.warning("checkpoint_env_int_invalid", name=name, value=raw, default=default)
+        return default
+
+
 class PgCheckpoint:
     """Per-stage durable idempotency store.
 
@@ -48,17 +82,40 @@ class PgCheckpoint:
     indexed lookup; ``mark`` is ``INSERT ... ON CONFLICT DO NOTHING``
     so a redelivery after a partial failure is a no-op.
 
-    A TTL sweep is intentionally out of scope — at the expected rate
-    (~10k batches/day × 7-day Kafka retention ≈ 70k rows) the index
-    stays trivially small. See #42 for the explicit TTL job when
-    scale warrants it.
+    At the expected rate (~10k batches/day × 7-day Kafka retention ≈
+    70k rows) the ``marked_at`` index stays trivially small, so the
+    TTL :meth:`sweep` is a no-op until a stage's row count crosses
+    ``threshold_rows``. A throughput rise, an extended Kafka retention,
+    or a backfill/replay spike trips the sweep, which then deletes rows
+    older than ``retention_days``. See #42.
     """
 
-    def __init__(self, *, conn: _PgConnection, stage: str) -> None:
+    def __init__(
+        self,
+        *,
+        conn: _PgConnection,
+        stage: str,
+        retention_days: int | None = None,
+        threshold_rows: int | None = None,
+    ) -> None:
         if not stage:
             raise ValueError("stage must be a non-empty string")
         self._conn = conn
         self._stage = stage
+        self._retention_days = (
+            retention_days
+            if retention_days is not None
+            else _env_int("INGEST_CHECKPOINT_RETENTION_DAYS", _DEFAULT_RETENTION_DAYS)
+        )
+        self._threshold_rows = (
+            threshold_rows
+            if threshold_rows is not None
+            else _env_int("INGEST_CHECKPOINT_SWEEP_THRESHOLD_ROWS", _DEFAULT_THRESHOLD_ROWS)
+        )
+        if self._retention_days <= 0:
+            raise ValueError("retention_days must be positive")
+        if self._threshold_rows < 0:
+            raise ValueError("threshold_rows must be non-negative")
         self._ensure_schema()
 
     def _ensure_schema(self) -> None:
@@ -82,6 +139,65 @@ class PgCheckpoint:
                 (self._stage, batch_id),
             )
         self._conn.commit()
+
+    def _row_count(self) -> int:
+        """Number of checkpoint rows for this stage."""
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM pipeline.worker_checkpoint WHERE stage = %s",
+                (self._stage,),
+            )
+            row = cur.fetchone()
+        return int(row[0]) if row is not None else 0
+
+    def sweep(self) -> int:
+        """Delete aged-out checkpoint rows once the stage exceeds its threshold.
+
+        No-op (returns ``0``) while the stage's row count is at or below
+        ``threshold_rows`` — below that the index stays trivially small and a
+        DELETE is pure operational cost. Once over threshold, deletes rows whose
+        ``marked_at`` is older than ``retention_days`` and returns the number
+        deleted.
+
+        Emits a ``checkpoint_sweep`` metric (rows deleted + pre-sweep row count +
+        the active thresholds) so an external scheduler can alert on a sweep that
+        deletes nothing despite a high row count — the signal that retention is
+        mis-tuned for the current throughput.
+        """
+        row_count = self._row_count()
+        if row_count <= self._threshold_rows:
+            _logger.info(
+                "checkpoint_sweep",
+                stage=self._stage,
+                deleted=0,
+                row_count=row_count,
+                threshold_rows=self._threshold_rows,
+                retention_days=self._retention_days,
+                swept=False,
+            )
+            return 0
+
+        with self._conn.cursor() as cur:
+            # make_interval keeps the retention window a bound parameter rather
+            # than string-interpolating into an INTERVAL literal.
+            cur.execute(
+                "DELETE FROM pipeline.worker_checkpoint "
+                "WHERE stage = %s AND marked_at < now() - make_interval(days => %s)",
+                (self._stage, self._retention_days),
+            )
+            deleted = int(cur.rowcount) if cur.rowcount is not None else 0
+        self._conn.commit()
+
+        _logger.info(
+            "checkpoint_sweep",
+            stage=self._stage,
+            deleted=deleted,
+            row_count=row_count,
+            threshold_rows=self._threshold_rows,
+            retention_days=self._retention_days,
+            swept=True,
+        )
+        return deleted
 
     def close(self) -> None:
         self._conn.close()


### PR DESCRIPTION
Adds a threshold-gated TTL sweep for `pipeline.worker_checkpoint` (`PgCheckpoint.sweep()`).

## What
- `sweep()` is a no-op (single `count(*)`) until a stage's row count exceeds a configurable threshold; once over, deletes rows older than a configurable retention window and returns the deletion count.
- Retention + threshold are env-configurable (`INGEST_CHECKPOINT_RETENTION_DAYS` default 14, `INGEST_CHECKPOINT_SWEEP_THRESHOLD_ROWS` default 100k); invalid env falls back to defaults instead of crashing a worker.
- DELETE uses `make_interval(days => %s)` (bound param, not interpolated INTERVAL literal).
- Observability: each sweep emits a `checkpoint_sweep` structured log (deleted / row_count / threshold_rows / retention_days / swept). Alert on `swept=true, deleted=0`.
- RUNBOOK § Maintenance documents the mechanism, ops-surface choice (method, not a deployed job — scheduler wiring is deploy-side), tuning env vars, and alerting signal.

## Acceptance (#42)
- [x] Sweep mechanism implemented + documented (ops-surface choice captured in RUNBOOK)
- [x] Retention window configurable via env
- [x] Observability: deletion-count metric exposed (`checkpoint_sweep` log)
- [x] Runbook entry for tuning when throughput changes
- [x] PgCheckpoint docstring cites #42

## Out of scope (per #42)
Operational/observability only — no correctness change to mark/seen/close. Deployed scheduler wiring (cron / k8s CronJob) is a deploy-side choice tracked in `noorinalabs-deploy`.

## Tests
8 new unit tests against the existing psycopg-shaped fake (extended to model per-row `marked_at` + DELETE): below/over threshold, age cutoff, stage scoping, env-driven config, invalid-env fallback, constructor validation. Full `tests/workers/` suite: 77 passed, 1 skipped. mypy + ruff (check + format) clean.

TechDebt: none

Refs #42
