### PR TITLE
docs(workers): remove phantom #192 references in ingest schema/processor (Refs #40)

### DIFF
--- a/workers/ingest/processor.py
+++ b/workers/ingest/processor.py
@@ -1,12 +1,12 @@
 """ingest-worker processor — manifest-gated MERGE into Neo4j.
 
 Terminal stage. Consumes a pointer to a folder prefix written by the
-normalize worker (see ``workers/normalize/processor.py`` and #192
+normalize worker (see ``workers/normalize/processor.py``,
 Option D-ii) and MERGEs the per-label Parquets into Neo4j in a single
 retryable transaction: all node labels first, edges last.
 
-Design (issue #18, #192 D-ii)
------------------------------
+Design (issue #18, Option D-ii)
+-------------------------------
 * ``msg.b2_path`` is a folder prefix (e.g. ``normalized/<batch_id>/``).
   Ingest reads ``_MANIFEST.json`` from that prefix as the ready signal;
   normalize writes the manifest LAST so its presence implies every
@@ -20,7 +20,7 @@ Design (issue #18, #192 D-ii)
 * Per-field enumerated SET. Each label has an allow-list in
   ``workers.ingest.schema.NODE_PROPERTY_MAP``; the generated Cypher
   SETs exactly those fields as ``n.field = row.props.field``. Closes
-  Farhan's #192 Phase-4 flag: ``SET n += row.props`` let an
+  Farhan's Phase-4 flag: ``SET n += row.props`` let an
   attacker-controlled property overwrite the node, and also wiped
   scholar-curated fields not present in the current batch.
 * Error taxonomy:
@@ -283,8 +283,8 @@ def _build_node_cypher(label: str) -> str:
     Each SET uses ``coalesce(row.props.<f>, n.<f>)`` so a row that omits
     a field does NOT wipe the existing node property — the scholar-
     curated ``text_ar`` on a hadith survives an ingest batch that only
-    carries ``text_en``. This is the core of Farhan's Phase-4 fix
-    (#192 comment thread).
+    carries ``text_en``. This is the core of Farhan's Phase-4 fix; see
+    #23 for the coalesce-clear contract this establishes.
 
     Coalesce-clear contract (per-field, applies to every SET line)
     --------------------------------------------------------------

--- a/workers/ingest/schema.py
+++ b/workers/ingest/schema.py
@@ -1,6 +1,6 @@
 """Per-label property allow-lists for ingest MERGE.
 
-Closes Farhan's Phase-4 safety flag (#192): the old ingest implementation
+Closes Farhan's Phase-4 safety flag: the old ingest implementation
 used ``SET n += row.props`` which lets an attacker-controlled property
 key (``:label``, ``id``, a future scholar-curated field not present in
 this batch) overwrite or subvert the node. This module enumerates the


### PR DESCRIPTION
## Summary

`workers/ingest/schema.py` and `workers/ingest/processor.py` cited `#192` in 5 places (introduced by PR #18 as historical-context pointers). `#192` does not resolve in this repo — `gh issue view 192` returns GraphQL "Could not resolve to an issue". It was an un-backfilled placeholder or a renumbered/closed parent-repo ref. Dead, and post-PR #37 actively misleading.

## Sites cleared (5, all in `workers/ingest/`)

| File:line | Before | After |
|---|---|---|
| `schema.py:3` | `Farhan's Phase-4 safety flag (#192)` | drop `(#192)` — live codegen ref `#24` already cited at `schema.py:26` |
| `processor.py:4` | `... and #192 Option D-ii` | drop `#192`, keep `Option D-ii` (repo-wide design label) |
| `processor.py:8` | `Design (issue #18, #192 D-ii)` | `Design (issue #18, Option D-ii)` — `#18` is the real merged PR |
| `processor.py:23` | `Farhan's #192 Phase-4 flag` | drop `#192` |
| `processor.py:287` | `(#192 comment thread)` | point at live coalesce-clear contract `#23` (already cited at `processor.py:297`) |

## Verification

```
git grep '#192' workers/ingest/   # → nothing
```

- Docstring text only; no behavior code touched (diff is comments/docstrings exclusively).
- Local: ruff check + ruff format --check clean; `uv run pytest -m "not integration"` → 581 passed.

## Scope

Per the issue, scoped to `workers/ingest/` only. Out-of-scope `#192` references elsewhere (RUNBOOK.md, tests, `workers/lib/`, `workers/normalize/`) are left for a separately-filed wave-wide audit.

Refs #40