### PR TITLE
refactor(ingest): rationalize per-appearance Hadith fields per #35 ruling (Refs #35)

### DIFF
--- a/tests/workers/test_processors.py
+++ b/tests/workers/test_processors.py
@@ -488,6 +488,52 @@ class TestNormalizeProcessor:
         assert len(hadiths) == 1
         assert hadiths[0]["props"]["collection_name"] == "bukhari"
 
+    def test_hadith_node_omits_per_appearance_fields_per_issue_35(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        hadith_row: Any,
+    ) -> None:
+        """#35 ruling: book/chapter/hadith number are per-appearance facts.
+
+        They are no longer emitted onto the Hadith node (removed from the
+        ingest NODE allow-list; no query/API/frontend consumer reads them
+        off the node). They live on the APPEARS_IN edge instead, and the
+        edge carries the modeled name ``hadith_number_in_book`` rather than
+        the bare legacy ``hadith_number``.
+        """
+        row = hadith_row(source_id="h1", matn_en="text", collection_name="bukhari")
+        row["book_number"] = 3
+        row["chapter_number"] = 7
+        row["hadith_number"] = 42
+        _seed(object_store, sample_message.b2_path, build_hadith_parquet([row]))
+
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        # Node side: none of the three per-appearance fields on the Hadith node.
+        hadiths = self._read_nodes(object_store, nxt.b2_path, "hadiths.parquet")
+        assert len(hadiths) == 1
+        node_props = hadiths[0]["props"]
+        for removed in ("book_number", "chapter_number", "hadith_number"):
+            assert removed not in node_props, f"{removed} must not be on the Hadith node"
+
+        # Edge side: APPEARS_IN keeps book/chapter and uses the canonical
+        # ``hadith_number_in_book`` key, not the bare ``hadith_number``.
+        edges_table = pq.read_table(object_store.get_object(f"{nxt.b2_path}edges.parquet"))
+        edge_rows = edges_table.to_pylist()
+        appears = [
+            {**e, "props": json.loads(e["props"])} for e in edge_rows if e["label"] == "APPEARS_IN"
+        ]
+        assert len(appears) == 1
+        edge_props = appears[0]["props"]
+        assert edge_props.get("book_number") == 3
+        assert edge_props.get("chapter_number") == 7
+        assert edge_props.get("hadith_number_in_book") == 42
+        assert "hadith_number" not in edge_props, (
+            "APPEARS_IN must use the canonical hadith_number_in_book, "
+            "not the bare legacy hadith_number"
+        )
+
     def test_missing_required_column_raises(
         self,
         object_store: ObjectStore,

--- a/workers/ingest/schema.py
+++ b/workers/ingest/schema.py
@@ -81,9 +81,12 @@ NODE_PROPERTY_MAP: dict[str, list[str]] = {
         "source_corpus",
         "sect",
         "collection_name",
-        "book_number",
-        "chapter_number",
-        "hadith_number",
+        # book_number / chapter_number / hadith_number removed from the
+        # Hadith node allow-list per the #35 data-team ruling: these are
+        # per-appearance facts the model carries on the APPEARS_IN edge,
+        # never read off the Hadith node by any query/API/frontend
+        # consumer (verified org-wide at #35 execution time). The edge
+        # keeps them (see EDGE_PROPERTY_MAP["APPEARS_IN"]).
         "chapter_name_ar",
         "chapter_name_en",
     ],
@@ -190,7 +193,10 @@ EDGE_PROPERTY_MAP: dict[str, list[str]] = {
     "APPEARS_IN": [
         "book_number",
         "chapter_number",
-        "hadith_number",
+        # Canonicalized to the modeled name per the #35 ruling: the
+        # AppearsIn Pydantic model exposes hadith_number_in_book, so the
+        # bare legacy hadith_number is dropped from the edge allow-list
+        # (and from normalize's edge payload). Use hadith_number_in_book.
         "hadith_number_in_book",
     ],
     "STUDIED_UNDER": [

--- a/workers/normalize/processor.py
+++ b/workers/normalize/processor.py
@@ -224,9 +224,12 @@ def _fan_out_row(row: dict[str, Any]) -> tuple[list[_NodeRow], list[_EdgeRow]]:
                 "source_corpus": source_corpus,
                 "sect": sect,
                 "collection_name": collection_name,
-                "book_number": row.get("book_number"),
-                "chapter_number": row.get("chapter_number"),
-                "hadith_number": row.get("hadith_number"),
+                # book_number / chapter_number / hadith_number are no longer
+                # emitted onto the Hadith node (#35 ruling): they are
+                # per-appearance facts carried on the APPEARS_IN edge below,
+                # and no consumer reads them off the node. The ingest
+                # allow-list also dropped them; stopping the emission here
+                # avoids a per-batch "dropped unknown prop" warning.
                 "chapter_name_ar": row.get("chapter_name_ar"),
                 "chapter_name_en": row.get("chapter_name_en"),
             },
@@ -252,7 +255,11 @@ def _fan_out_row(row: dict[str, Any]) -> tuple[list[_NodeRow], list[_EdgeRow]]:
             props={
                 "book_number": row.get("book_number"),
                 "chapter_number": row.get("chapter_number"),
-                "hadith_number": row.get("hadith_number"),
+                # Canonicalized to the modeled name (#35 ruling): the
+                # AppearsIn model field is hadith_number_in_book, so emit
+                # under that key and drop the bare legacy hadith_number.
+                # Source column stays hadith_number (feeds the edge).
+                "hadith_number_in_book": row.get("hadith_number"),
             },
         ),
     ]


### PR DESCRIPTION
## Summary

Lands the **ingest-platform-side** parts of the ratified #35 data-team ruling that do NOT depend on Farhan's isnad-graph model PR. (The four PROMOTE fields' `ingest-extras.yaml` drops wait on his model change — out of scope here.)

### REMOVE node-copy — `book_number` / `chapter_number` / `hadith_number`
Per-appearance facts the model carries on the `APPEARS_IN` edge, not Hadith-node properties.

**Owner-gated query-layer check (PASSED for all three):** verified org-wide that no query/API/frontend consumer reads these off the Hadith **node**:
- isnad-graph `src/api`, `queries/` (Cypher), `frontend/src` — zero references
- user-service / landing-page / deploy `src/` — zero references
- (data-acquisition `src/graph/load_nodes.py` still *writes* `n.book_number` etc. via a separate legacy Phase-3 loader, but nothing **reads** them back off the node — a writer, not a query-layer reader. Gate passes. Flagged separately to TPM as legacy-writer context.)

Removed from `NODE_PROPERTY_MAP["Hadith"]` and from normalize's Hadith-node payload (so no per-batch "dropped unknown prop" warning). The `APPEARS_IN` edge keeps all three.

### EDGE canonicalization — `APPEARS_IN.hadith_number` → `hadith_number_in_book`
The `AppearsIn` Pydantic model field is `hadith_number_in_book`; the bare legacy `hadith_number` is dropped from `EDGE_PROPERTY_MAP["APPEARS_IN"]` and normalize emits the value under the modeled key. Source column stays `hadith_number` (feeds the edge).

### Not in this PR (deliberate)
- **PROMOTE** (`chapter_name_ar`, `chapter_name_en`, `name_ar_normalized`, `source_corpus`): wait on Farhan's isnad-graph model PR; their ingest-extras drops land after.
- **KEEP→permanent** flips (`grade`, `sect`, `collection_name`, `transmission_method`) and the dead-entry drops for the removed fields: these edit `noorinalabs-isnad-graph/scripts/ingest-extras.yaml` — an **isnad-graph** file, so a separate isnad-graph PR (cross-repo boundary). The schema-drift gate stays green either way (verified).

## Verification
- `scripts/emit_ingest_schema.py check` against the modified ingest schema → **clean** (gate not broken).
- Regression test: Hadith node omits the three fields; `APPEARS_IN` carries `hadith_number_in_book` not bare `hadith_number`.
- Full non-integration suite: 596 passed, 4 skipped. ruff check + format clean.

TechDebt: none

Refs #35