### PR TITLE
ci(docs): pin actionlint to v1.7.12 + sha256 verification (Refs noorinalabs-main#578)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -152,10 +152,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Download and verify actionlint
+        env:
+          # Pinned: version + linux_amd64 tarball SHA256 from upstream's
+          # signed release manifest (actionlint_1.7.12_checksums.txt at
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+          # `sha256sum -c` aborts the job on mismatch — bytes-on-runner are
+          # exactly what was published at release time. Replaces the prior
+          # `curl|bash` of the unpinned download-actionlint.bash off `main`
+          # (#578): fetching+executing latest-of-main each run is a
+          # supply-chain gap and diverges from the pinned v1.7.12 the
+          # .pre-commit-config.yaml mirror already ships.
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          cd "$RUNNER_TEMP"
+          curl --fail --silent --show-error --location \
+            -o "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint -version
       - name: Run actionlint on workflows
         # shellcheck is preinstalled on ubuntu-latest, so actionlint's embedded
         # shellcheck integration runs (per the actionlint-needs-shellcheck
         # discipline) rather than silently skipping.
-        run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+        run: actionlint -color


### PR DESCRIPTION
## Summary

Pins the `docs.yml` actionlint installer to **v1.7.12 + SHA256 verification**, replacing the unpinned `bash <(curl ... download-actionlint.bash)` off `main`. This closes the child-repo slice of `noorinalabs-main#578` (rollout of the parent-canonical pin pattern, parent PR #579).

`Refs noorinalabs-main#578`

## What changed

`.github/workflows/docs.yml` `actionlint:` job — the single install+run step is replaced by two steps:

1. **Download and verify actionlint** — pinned `ACTIONLINT_VERSION=1.7.12`, downloads the `linux_amd64` tarball from the tagged release, `sha256sum -c` aborts the job on mismatch, installs to `/usr/local/bin/actionlint`, prints `actionlint -version`.
2. **Run actionlint on workflows** — `actionlint -color` (drops the `./` prefix; actionlint is now on PATH). This repo's job carries **no `-ignore` flags**, so none are preserved.

Why: fetching+executing latest-of-`main` each run is a supply-chain gap and diverges from the pinned v1.7.12 the `.pre-commit-config.yaml` mirror already ships.

## Verification

- **SHA256 independently re-verified** against upstream's published `actionlint_1.7.12_checksums.txt` (release tag v1.7.12) before committing — not trusted from the patch file. `linux_amd64` line: `8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8` ✓
- **Patch verified against origin HEAD first** — confirmed the wave-15 `docs.yml` checkout is `@v4` and the run line was plain `./actionlint -color` (no ignores), matching the canonical per-repo note.
- **`actionlint -color .github/workflows/docs.yml` runs clean locally** with shellcheck 0.10.0 on PATH (embedded shellcheck integration active, not skipped).

## Test plan

- [ ] `Config — Workflow actionlint` check-run green via `statusCheckRollup`
- [ ] 2 charter-format Approved verdicts (Petra Vidović, Bjørn Henriksen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
