### PR TITLE
fix(normalize): drop doubled corpus prefix from Hadith id (closes #63)

### DIFF
--- a/tests/workers/test_processors.py
+++ b/tests/workers/test_processors.py
@@ -348,6 +348,44 @@ class TestNormalizeProcessor:
         assert "NARRATED" in edge_labels
         assert "TRANSMITTED_TO" in edge_labels
 
+    def test_hadith_id_matches_batch_loader_no_doubled_corpus(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        hadith_row: Any,
+    ) -> None:
+        """Streaming normalize must emit the SAME Hadith id as the batch loader (#63).
+
+        ``source_id`` is already corpus-prefixed by the parsers
+        (``generate_source_id`` -> ``sunnah:bukhari:1:1``). The batch loader
+        keys the Hadith node as ``hdt:{source_id}`` (``src/graph/load_nodes.py``
+        line ``hid = f"hdt:{sid}"``). normalize previously prepended
+        ``source_corpus`` a second time, producing the doubled
+        ``hdt:sunnah:sunnah:bukhari:1:1`` and a duplicate node for the same
+        hadith. Assert the streaming id equals the batch id exactly so the two
+        paths MERGE one node, not two.
+        """
+        source_id = "sunnah:bukhari:1:1"
+        rows = [hadith_row(source_id=source_id, source_corpus="sunnah", matn_en="text")]
+        _seed(object_store, sample_message.b2_path, build_hadith_parquet(rows))
+
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        hadiths = self._read_nodes(object_store, nxt.b2_path, "hadiths.parquet")
+        assert len(hadiths) == 1
+        streaming_id = hadiths[0]["id"]
+
+        # The exact id the batch loader would MERGE on (load_nodes.py).
+        batch_id = f"hdt:{source_id}"
+        assert streaming_id == batch_id, (
+            f"streaming Hadith id {streaming_id!r} != batch id {batch_id!r} — "
+            "the corpus prefix is doubled (#63)"
+        )
+        # Defensively pin the exact value so a regression can't pass by
+        # coincidentally agreeing on a wrong-but-equal id.
+        assert streaming_id == "hdt:sunnah:bukhari:1:1"
+        assert "sunnah:sunnah" not in streaming_id
+
     def test_every_node_row_matches_allowed_label_vocabulary(
         self,
         object_store: ObjectStore,

--- a/workers/normalize/processor.py
+++ b/workers/normalize/processor.py
@@ -28,8 +28,9 @@ Stable-ID generation
 IDs are deterministic so re-processing the same batch produces the same
 node identities (idempotent ingest MERGE). Hash inputs:
 
-* ``Hadith``   — ``hdt:<source_corpus>:<source_id>`` (already canonical
-  from the source parser; no hashing required).
+* ``Hadith``   — ``hdt:<source_id>`` where ``source_id`` is already
+  corpus-prefixed by the parser (``sunnah:bukhari:1:1``); no hashing and
+  no extra corpus prepend (#63). Matches ``src/graph/load_nodes.py``.
 * ``Narrator`` — ``nar:<sha1-24>`` of
   ``<lower(name_en)>|<normalize_arabic(name_ar)>``. Blank sides are
   represented as the empty string so pure-English and pure-Arabic
@@ -179,9 +180,20 @@ def _normalize_arabic_safe(text: str) -> str:
         return text.strip()
 
 
-def _hadith_id(source_corpus: str, source_id: str) -> str:
-    key = f"{source_corpus}:{source_id}"
-    return key if key.startswith("hdt:") else f"hdt:{key}"
+def _hadith_id(source_id: str) -> str:
+    """Canonical Hadith id — ``hdt:<source_id>`` (matches the batch loaders).
+
+    ``source_id`` is already corpus-prefixed by the parsers
+    (``generate_source_id`` emits ``<corpus>:<collection>:<parts>``, e.g.
+    ``sunnah:bukhari:1:1``), so the corpus must NOT be prepended a second
+    time — that produced the doubled ``hdt:sunnah:sunnah:bukhari:1:1`` of
+    #63, which split one hadith into two Neo4j nodes against the batch
+    loader's ``hdt:sunnah:bukhari:1:1``. This now mirrors
+    ``src/graph/load_nodes.py`` (``f"hdt:{sid}"``) and
+    ``src/graph/load_edges.py`` exactly so streaming and batch MERGE the
+    same node.
+    """
+    return source_id if source_id.startswith("hdt:") else f"hdt:{source_id}"
 
 
 def _collection_id(collection_name: str) -> str:
@@ -208,7 +220,7 @@ def _fan_out_row(row: dict[str, Any]) -> tuple[list[_NodeRow], list[_EdgeRow]]:
     collection_name = row["collection_name"]
     sect = row["sect"]
 
-    hid = _hadith_id(source_corpus, source_id)
+    hid = _hadith_id(source_id)
     cid = _collection_id(collection_name)
 
     nodes: list[_NodeRow] = [


### PR DESCRIPTION
## Summary
Fixes #63 — streaming normalize doubled the corpus prefix in the Hadith id (`hdt:sunnah:sunnah:bukhari:1:1`) while the batch loader emits `hdt:sunnah:bukhari:1:1`, splitting one hadith into two Neo4j nodes.

`source_id` is already corpus-prefixed by the parsers (`generate_source_id` → `<corpus>:<collection>:<parts>`), so `_hadith_id` must NOT prepend `source_corpus` a second time. The fix makes normalize emit `hdt:{source_id}`, matching `src/graph/load_nodes.py` (`hid = f"hdt:{sid}"`) and `src/graph/load_edges.py` exactly so streaming and batch MERGE the same node.

## Changes
- `workers/normalize/processor.py`: `_hadith_id(source_id)` drops the `source_corpus` prepend; docstring updated.
- `tests/workers/test_processors.py`: new unit guard `test_hadith_id_matches_batch_loader_no_doubled_corpus` — asserts the streaming Hadith id equals the batch loader's `hdt:{source_id}` for a corpus-prefixed fixture and that the corpus is never doubled.

## Verification
- `tests/workers/test_processors.py`: 20 passed, 1 skipped.
- Full Docker-less suite: 597 passed, 4 skipped.
- ruff check + format-check + mypy clean on changed files.
- Confirmed the new guard FAILS on the pre-fix `_hadith_id` and PASSES on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)