### PR TITLE
test(integration): full dedup→enrich→normalize→ingest worker-chain E2E (Refs noorinalabs-main#136)

### DIFF
--- a/tests/integration/test_worker_chain_e2e.py
+++ b/tests/integration/test_worker_chain_e2e.py
@@ -368,7 +368,7 @@ def test_streaming_hadith_id_matches_batch_loader_through_real_neo4j(
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "BUG (ig#TBD, reported to team lead): src/pipeline/reset._delete_prefix "
+        "BUG (#68): src/pipeline/reset._delete_prefix "
         "calls client.delete_objects() which a real S3-compatible store (MinIO, "
         "and B2) rejects with 'MissingContentMD5' under botocore>=1.36 — the bulk "
         "DeleteObjects op needs a Content-MD5/checksum header boto3 no longer adds "

--- a/tests/integration/test_worker_chain_e2e.py
+++ b/tests/integration/test_worker_chain_e2e.py
@@ -1,0 +1,452 @@
+"""Full four-stage worker-chain E2E through real Kafka + MinIO + Neo4j (main#136).
+
+What this adds over the existing integration suite
+--------------------------------------------------
+* ``test_kafka_worker_e2e.py`` (#55) drives **enrich → normalize → ingest**
+  through real Kafka, but *seeds at* ``pipeline.dedup.done`` — the dedup
+  worker itself never runs, and its raw → ``dedup/.../hadiths.parquet``
+  object hand-off is not exercised over real infra.
+* ``test_e2e_inprocess.py`` (ig#62 / main#139) runs the whole chain but
+  **in-process** — an in-memory broker and an emulator Neo4j sink — and
+  asserts node *counts*, not the exact node identities.
+* ``test_minio_dedup_object_store.py`` (#55) exercises the MinIO object-store
+  contract through ``DedupProcessor`` but with no Kafka chain.
+
+This module closes the remaining gap: the **complete**
+``dedup → enrich → normalize → ingest`` chain across FOUR real Kafka topics
+and a shared real MinIO bucket, terminating in a real Neo4j MERGE — with the
+dedup worker as the first hop consuming ``pipeline.raw.landed``. It also
+pins two contracts that the existing suite leaves unguarded end to end:
+
+1. **Hadith-id parity (#63).** The fixture's ``source_id`` is corpus-prefixed
+   exactly as the parsers emit it (``sunnah:bukhari:1:1``). The terminal
+   Neo4j node id must equal the batch loader's ``hdt:{source_id}`` — NOT the
+   doubled ``hdt:sunnah:sunnah:bukhari:1:1``. The #55 E2E uses a bare
+   ``source_id="h-1"`` that cannot surface the doubling; this one can.
+2. **Admin stage-reset (#108).** After the chain lands, a ``stage`` reset of
+   the ``normalized`` prefix wipes only that stage's MinIO objects (the raw
+   and dedup prefixes survive), proving the reset scope is honoured against a
+   real object store rather than the ``FakeS3Client`` the unit suite uses.
+
+Determinism note
+----------------
+Like the #55 E2E, each ``WorkerRunner`` here is the production
+``WorkerRunner`` + production processor, but built with a test-only consumer
+config (``auto_offset_reset="earliest"`` + a ``consumer_timeout_ms`` so
+``run_forever`` drains and returns instead of blocking like a long-lived
+worker). The topic topology and object hand-offs are unchanged.
+
+ML deps are NOT required: dedup and enrich both degrade gracefully (empty
+links / empty topics side-table + pass-through copy) without
+``sentence-transformers`` / ``faiss`` / ``transformers``, so the hadith
+payload reaches normalize and ingest on every hop.
+
+Runtime requirement
+-------------------
+``@pytest.mark.integration`` — needs Docker for THREE containers (Kafka,
+MinIO, Neo4j). Excluded from the default ``pytest -m "not integration"`` run;
+runs via ``make test-integration``. ``importorskip`` on
+``testcontainers.kafka`` / ``testcontainers.minio`` / ``boto3`` / ``kafka``
+keeps a Docker-less lane collecting cleanly.
+"""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Iterator
+from typing import Any
+
+import pyarrow.parquet as pq
+import pytest
+
+pytest.importorskip("testcontainers.kafka")
+pytest.importorskip("testcontainers.minio")
+pytest.importorskip("boto3")
+pytest.importorskip("kafka")
+
+import boto3  # noqa: E402
+from botocore.config import Config  # noqa: E402
+from kafka import KafkaProducer  # noqa: E402  # type: ignore[import-untyped]
+from testcontainers.kafka import KafkaContainer  # noqa: E402
+from testcontainers.minio import MinioContainer  # noqa: E402
+from testcontainers.neo4j import Neo4jContainer  # noqa: E402
+
+from tests.factories import build_hadith_table  # noqa: E402
+from workers.dedup.processor import DedupProcessor  # noqa: E402
+from workers.enrich.processor import EnrichProcessor  # noqa: E402
+from workers.ingest.processor import IngestProcessor  # noqa: E402
+from workers.lib.message import PipelineMessage, serialize_message  # noqa: E402
+from workers.lib.object_store import ObjectStore  # noqa: E402
+from workers.lib.runner import WorkerRunner, WorkerSettings  # noqa: E402
+from workers.lib.topics import (  # noqa: E402
+    PIPELINE_DEDUP_DONE,
+    PIPELINE_ENRICH_DONE,
+    PIPELINE_NORMALIZE_DONE,
+    PIPELINE_RAW_LANDED,
+)
+from workers.normalize.processor import NormalizeProcessor  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+TEST_BUCKET = "noorinalabs-pipeline"
+NEO4J_TEST_PASSWORD = "testpassword123"
+CONSUMER_TIMEOUT_MS = 20_000
+
+# A real, corpus-prefixed source_id — exactly the shape the parsers emit via
+# ``generate_source_id`` (``<corpus>:<collection>:<parts>``). This is what makes
+# the #63 doubling observable: a bare id like "h-1" cannot.
+SOURCE = "sunnah"
+SOURCE_ID = "sunnah:bukhari:1:1"
+# The id the batch loader (``src/graph/load_nodes.py``: ``hdt:{sid}``) MERGEs.
+EXPECTED_HADITH_ID = f"hdt:{SOURCE_ID}"
+
+
+# ---------------------------------------------------------------------------
+# Container fixtures (module-scoped so all tests share one stack)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def kafka_container() -> Iterator[KafkaContainer]:
+    with KafkaContainer() as kafka:
+        yield kafka
+
+
+@pytest.fixture(scope="module")
+def minio_container() -> Iterator[MinioContainer]:
+    with MinioContainer(access_key="minio", secret_key="minio12345") as minio:
+        yield minio
+
+
+@pytest.fixture(scope="module")
+def neo4j_container_module() -> Iterator[Neo4jContainer]:
+    with Neo4jContainer("neo4j:5-community", password=NEO4J_TEST_PASSWORD) as neo4j:
+        yield neo4j
+
+
+@pytest.fixture
+def bootstrap(kafka_container: KafkaContainer) -> str:
+    return kafka_container.get_bootstrap_server()
+
+
+@pytest.fixture
+def minio_store(minio_container: MinioContainer) -> ObjectStore:
+    """Real ``ObjectStore`` on the MinIO container, bucket pre-created."""
+    cfg = minio_container.get_config()
+    client = boto3.client(
+        "s3",
+        endpoint_url=f"http://{cfg['endpoint']}",
+        aws_access_key_id=cfg["access_key"],
+        aws_secret_access_key=cfg["secret_key"],
+        region_name="us-east-1",
+        config=Config(s3={"addressing_style": "path"}),
+    )
+    try:
+        client.create_bucket(Bucket=TEST_BUCKET)
+    except client.exceptions.BucketAlreadyOwnedByYou:
+        pass
+    return ObjectStore(bucket=TEST_BUCKET, client=client)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_stage_runner(
+    *,
+    bootstrap: str,
+    worker_name: str,
+    consume_topic: str,
+    produce_topic: str | None,
+    process: Any,
+) -> WorkerRunner:
+    """Production ``WorkerRunner`` + processor, bounded for a test drain.
+
+    Mirrors ``workers.<stage>.main.build_runner`` but with
+    ``auto_offset_reset="earliest"`` and a ``consumer_timeout_ms`` so
+    ``run_forever`` returns once the topic drains instead of blocking.
+    """
+    from kafka import KafkaConsumer  # type: ignore[import-untyped]
+
+    consumer = KafkaConsumer(
+        consume_topic,
+        bootstrap_servers=bootstrap,
+        group_id=worker_name,
+        enable_auto_commit=False,
+        auto_offset_reset="earliest",
+        consumer_timeout_ms=CONSUMER_TIMEOUT_MS,
+        value_deserializer=None,
+    )
+    producer = KafkaProducer(bootstrap_servers=bootstrap)
+    return WorkerRunner(
+        settings=WorkerSettings(
+            worker_name=worker_name,
+            consume_topic=consume_topic,
+            produce_topic=produce_topic,
+            consumer_group=worker_name,
+        ),
+        consumer=consumer,
+        producer=producer,
+        process=process,
+    )
+
+
+def _drain(runner: WorkerRunner) -> None:
+    try:
+        runner.run_forever()
+    finally:
+        runner.consumer.close()
+        runner.producer.close()
+
+
+def _seed_raw_input(store: ObjectStore, bootstrap: str, batch_id: str) -> str:
+    """Write a raw hadith batch to MinIO and produce its pointer to raw.landed.
+
+    The dedup worker is the first hop, so the seed message is published to
+    ``pipeline.raw.landed`` (dedup's upstream). ``source_id`` is corpus-prefixed
+    so the #63 doubling is observable end to end.
+    """
+    raw_key = f"raw/{SOURCE}/{batch_id}/hadiths.parquet"
+    table = build_hadith_table(
+        [
+            {
+                "source_id": SOURCE_ID,
+                "source_corpus": SOURCE,
+                "collection_name": "bukhari",
+                "matn_en": "Actions are judged by intentions",
+                "grade": "sahih",
+            },
+        ]
+    )
+    buf = io.BytesIO()
+    pq.write_table(table, buf)
+    store.put_object(raw_key, buf.getvalue())
+
+    msg = PipelineMessage(batch_id=batch_id, source=SOURCE, b2_path=raw_key, record_count=1)
+    producer = KafkaProducer(bootstrap_servers=bootstrap)
+    producer.send(PIPELINE_RAW_LANDED, serialize_message(msg))
+    producer.flush()
+    producer.close()
+    return raw_key
+
+
+def _run_full_chain(bootstrap: str, store: ObjectStore, neo4j: Neo4jContainer) -> None:
+    """Drive dedup → enrich → normalize → ingest across four real Kafka topics."""
+    from neo4j import GraphDatabase
+
+    driver = GraphDatabase.driver(neo4j.get_connection_url(), auth=("neo4j", NEO4J_TEST_PASSWORD))
+    try:
+        # Hop 1: dedup consumes pipeline.raw.landed → produces pipeline.dedup.done
+        _drain(
+            _make_stage_runner(
+                bootstrap=bootstrap,
+                worker_name="dedup-worker",
+                consume_topic=PIPELINE_RAW_LANDED,
+                produce_topic=PIPELINE_DEDUP_DONE,
+                process=DedupProcessor(store),
+            )
+        )
+        # Hop 2: enrich consumes pipeline.dedup.done → produces pipeline.enrich.done
+        _drain(
+            _make_stage_runner(
+                bootstrap=bootstrap,
+                worker_name="enrich-worker",
+                consume_topic=PIPELINE_DEDUP_DONE,
+                produce_topic=PIPELINE_ENRICH_DONE,
+                process=EnrichProcessor(store),
+            )
+        )
+        # Hop 3: normalize consumes pipeline.enrich.done → produces pipeline.normalize.done
+        _drain(
+            _make_stage_runner(
+                bootstrap=bootstrap,
+                worker_name="normalize-worker",
+                consume_topic=PIPELINE_ENRICH_DONE,
+                produce_topic=PIPELINE_NORMALIZE_DONE,
+                process=NormalizeProcessor(store),
+            )
+        )
+        # Hop 4: ingest (terminal) consumes pipeline.normalize.done → MERGE into Neo4j
+        _drain(
+            _make_stage_runner(
+                bootstrap=bootstrap,
+                worker_name="ingest-worker",
+                consume_topic=PIPELINE_NORMALIZE_DONE,
+                produce_topic=None,
+                process=IngestProcessor(store, neo4j_driver=driver),
+            )
+        )
+    finally:
+        driver.close()
+
+
+def _list_keys(store: ObjectStore, prefix: str) -> list[str]:
+    resp = store.client.list_objects_v2(Bucket=store.bucket, Prefix=prefix)
+    return [obj["Key"] for obj in resp.get("Contents", []) or []]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_full_dedup_to_ingest_chain_lands_hadith_in_neo4j(
+    bootstrap: str,
+    minio_store: ObjectStore,
+    neo4j_container_module: Neo4jContainer,
+) -> None:
+    """A raw batch traverses dedup → enrich → normalize → ingest across four
+    real Kafka topics and the Hadith node lands in Neo4j with the canonical id.
+    """
+    from neo4j import GraphDatabase
+
+    batch_id = "batch-chain-e2e-001"
+    _seed_raw_input(minio_store, bootstrap, batch_id)
+    _run_full_chain(bootstrap, minio_store, neo4j_container_module)
+
+    driver = GraphDatabase.driver(
+        neo4j_container_module.get_connection_url(),
+        auth=("neo4j", NEO4J_TEST_PASSWORD),
+    )
+    try:
+        with driver.session() as session:
+            record = session.run(
+                "MATCH (n:Hadith {id: $id}) RETURN n.matn_en AS matn_en",
+                id=EXPECTED_HADITH_ID,
+            ).single()
+            # Proof there is exactly ONE Hadith node — no doubled-id sibling.
+            count = session.run("MATCH (n:Hadith) RETURN count(n) AS c").single()["c"]
+    finally:
+        driver.close()
+
+    assert record is not None, (
+        f"Hadith {EXPECTED_HADITH_ID!r} not found — the message did not traverse "
+        "the full dedup→enrich→normalize→ingest Kafka chain"
+    )
+    assert "Actions are judged by intentions" in record["matn_en"]
+    assert count == 1, f"expected exactly one Hadith node, found {count}"
+
+
+def test_streaming_hadith_id_matches_batch_loader_through_real_neo4j(
+    bootstrap: str,
+    minio_store: ObjectStore,
+    neo4j_container_module: Neo4jContainer,
+) -> None:
+    """End-to-end #63 guard: the id the chain MERGEs equals the batch loader's.
+
+    The fixture ``source_id`` is corpus-prefixed (``sunnah:bukhari:1:1``).
+    The terminal Neo4j node id must be ``hdt:sunnah:bukhari:1:1`` — the batch
+    loader's ``hdt:{source_id}`` — and must NOT carry a doubled corpus
+    (``hdt:sunnah:sunnah:bukhari:1:1``). This is the live-infra counterpart to
+    the normalize unit guard, proving the contract holds all the way into the
+    graph, not just at the normalize Parquet.
+    """
+    from neo4j import GraphDatabase
+
+    batch_id = "batch-id-parity-001"
+    _seed_raw_input(minio_store, bootstrap, batch_id)
+    _run_full_chain(bootstrap, minio_store, neo4j_container_module)
+
+    driver = GraphDatabase.driver(
+        neo4j_container_module.get_connection_url(),
+        auth=("neo4j", NEO4J_TEST_PASSWORD),
+    )
+    try:
+        with driver.session() as session:
+            ids = [r["id"] for r in session.run("MATCH (n:Hadith) RETURN n.id AS id")]
+    finally:
+        driver.close()
+
+    assert ids == [EXPECTED_HADITH_ID], (
+        f"Hadith ids in graph {ids!r} != expected [{EXPECTED_HADITH_ID!r}] — "
+        "streaming and batch must MERGE the same node (#63)"
+    )
+    assert all("sunnah:sunnah" not in i for i in ids), "corpus prefix doubled (#63)"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "BUG (ig#TBD, reported to team lead): src/pipeline/reset._delete_prefix "
+        "calls client.delete_objects() which a real S3-compatible store (MinIO, "
+        "and B2) rejects with 'MissingContentMD5' under botocore>=1.36 — the bulk "
+        "DeleteObjects op needs a Content-MD5/checksum header boto3 no longer adds "
+        "by default. The unit suite never caught it because FakeS3Client.delete_"
+        "objects is an in-memory no-op. This integration scenario is the regression "
+        "guard; remove the xfail once reset uses per-object delete_object (which "
+        "ObjectStore already does) or sets the checksum header."
+    ),
+)
+def test_admin_stage_reset_wipes_only_normalized_prefix_on_real_minio(
+    bootstrap: str,
+    minio_store: ObjectStore,
+    neo4j_container_module: Neo4jContainer,
+) -> None:
+    """Admin ``stage`` reset (#108) honours scope against a real MinIO store.
+
+    After the chain lands objects under raw/, dedup/, and normalized/, a
+    ``stage`` reset of the ``normalized`` prefix must delete only that prefix's
+    objects — the upstream raw/ and dedup/ payloads survive, so the stage can be
+    re-run without re-acquiring or re-deduping. The unit suite proves the reset
+    *logic* against ``FakeS3Client``; this proves it against the real
+    ``list_objects_v2`` / ``delete_objects`` S3 surface the resetter calls — and
+    currently surfaces a real defect in that surface (see the ``xfail`` reason).
+    """
+    from src.pipeline.reset import (
+        STAGE_PREFIXES,
+        PipelineResetter,
+        ResetScope,
+    )
+
+    batch_id = "batch-reset-e2e-001"
+    _seed_raw_input(minio_store, bootstrap, batch_id)
+    _run_full_chain(bootstrap, minio_store, neo4j_container_module)
+
+    # Pre-condition: all three upstream prefixes carry objects.
+    assert _list_keys(minio_store, "raw/"), "raw prefix should be populated"
+    assert _list_keys(minio_store, "dedup/"), "dedup prefix should be populated"
+    normalized_before = _list_keys(minio_store, STAGE_PREFIXES["normalized"])
+    assert normalized_before, "normalized prefix should be populated by the chain"
+
+    # A stage reset only touches MinIO + Kafka offsets; the Kafka/Neo4j/PG
+    # adapters are not exercised by a ``stage`` scope, so simple no-op stand-ins
+    # keep the test focused on the real object-store deletion path.
+    class _NoOpKafkaAdmin:
+        def reset_consumer_offsets(self, topic: str, group_id: str) -> None:
+            pass
+
+        def delete_topic_data(self, topic: str) -> None:
+            pass
+
+    class _NoOpNeo4j:
+        def truncate_hadith_graph(self) -> int:
+            return 0
+
+    class _NoOpPg:
+        def truncate_hadith_metadata(self) -> int:
+            return 0
+
+    resetter = PipelineResetter(
+        object_store=minio_store,
+        kafka_admin=_NoOpKafkaAdmin(),
+        neo4j=_NoOpNeo4j(),
+        pg=_NoOpPg(),
+        data_dir=_tmp_audit_dir(),
+    )
+    report, _entry, _path = resetter.reset(ResetScope.stage_scope("normalized"))
+
+    # The normalized prefix is now empty; raw/ and dedup/ are untouched.
+    assert _list_keys(minio_store, STAGE_PREFIXES["normalized"]) == []
+    assert _list_keys(minio_store, "raw/"), "raw prefix must survive a normalized-stage reset"
+    assert _list_keys(minio_store, "dedup/"), "dedup prefix must survive a normalized-stage reset"
+    assert report.s3_objects_deleted == len(normalized_before)
+    assert report.s3_prefixes_deleted == [STAGE_PREFIXES["normalized"]]
+
+
+def _tmp_audit_dir() -> Any:
+    """A throwaway audit dir for the reset's audit write (real filesystem)."""
+    import tempfile
+    from pathlib import Path
+
+    return Path(tempfile.mkdtemp(prefix="reset-audit-"))

--- a/tests/integration/test_worker_chain_e2e.py
+++ b/tests/integration/test_worker_chain_e2e.py
@@ -368,7 +368,7 @@ def test_streaming_hadith_id_matches_batch_loader_through_real_neo4j(
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "BUG (#68): src/pipeline/reset._delete_prefix "
+        "BUG (#69): src/pipeline/reset._delete_prefix "
         "calls client.delete_objects() which a real S3-compatible store (MinIO, "
         "and B2) rejects with 'MissingContentMD5' under botocore>=1.36 — the bulk "
         "DeleteObjects op needs a Content-MD5/checksum header boto3 no longer adds "

--- a/tests/workers/test_processors.py
+++ b/tests/workers/test_processors.py
@@ -348,6 +348,44 @@ class TestNormalizeProcessor:
         assert "NARRATED" in edge_labels
         assert "TRANSMITTED_TO" in edge_labels
 
+    def test_hadith_id_matches_batch_loader_no_doubled_corpus(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        hadith_row: Any,
+    ) -> None:
+        """Streaming normalize must emit the SAME Hadith id as the batch loader (#63).
+
+        ``source_id`` is already corpus-prefixed by the parsers
+        (``generate_source_id`` -> ``sunnah:bukhari:1:1``). The batch loader
+        keys the Hadith node as ``hdt:{source_id}`` (``src/graph/load_nodes.py``
+        line ``hid = f"hdt:{sid}"``). normalize previously prepended
+        ``source_corpus`` a second time, producing the doubled
+        ``hdt:sunnah:sunnah:bukhari:1:1`` and a duplicate node for the same
+        hadith. Assert the streaming id equals the batch id exactly so the two
+        paths MERGE one node, not two.
+        """
+        source_id = "sunnah:bukhari:1:1"
+        rows = [hadith_row(source_id=source_id, source_corpus="sunnah", matn_en="text")]
+        _seed(object_store, sample_message.b2_path, build_hadith_parquet(rows))
+
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        hadiths = self._read_nodes(object_store, nxt.b2_path, "hadiths.parquet")
+        assert len(hadiths) == 1
+        streaming_id = hadiths[0]["id"]
+
+        # The exact id the batch loader would MERGE on (load_nodes.py).
+        batch_id = f"hdt:{source_id}"
+        assert streaming_id == batch_id, (
+            f"streaming Hadith id {streaming_id!r} != batch id {batch_id!r} — "
+            "the corpus prefix is doubled (#63)"
+        )
+        # Defensively pin the exact value so a regression can't pass by
+        # coincidentally agreeing on a wrong-but-equal id.
+        assert streaming_id == "hdt:sunnah:bukhari:1:1"
+        assert "sunnah:sunnah" not in streaming_id
+
     def test_every_node_row_matches_allowed_label_vocabulary(
         self,
         object_store: ObjectStore,

--- a/tests/workers/test_worker_chain_inprocess.py
+++ b/tests/workers/test_worker_chain_inprocess.py
@@ -1,0 +1,344 @@
+"""CI-durable in-process worker-chain scenarios (main#136).
+
+The companion ``tests/integration/test_worker_chain_e2e.py`` drives the same
+four stages through real Kafka + MinIO + Neo4j containers, but is Docker-gated
+(``@pytest.mark.integration``) so CI never runs it. This module exercises the
+**worker-chain contract** —
+``dedup → enrich → normalize → ingest`` — entirely in-process on the faithful
+fake stack from ``tests/workers/conftest.py`` (``FakeS3Client`` →
+``ObjectStore`` + parquet builders), so the chain is a regression guard that
+runs in the default ``pytest -m "not integration"`` lane with zero infra.
+
+The chain contract reused here (per the existing in-process unit tests)::
+
+    after_dedup     = DedupProcessor(store)(msg)
+    after_enrich    = EnrichProcessor(store)(after_dedup)
+    after_normalize = NormalizeProcessor(store)(after_enrich)
+    IngestProcessor(store, neo4j_driver=<fake>)(after_normalize)   # terminal
+
+What this adds over the pre-existing ``test_processor_chain_propagates_batch_id``
+-------------------------------------------------------------------------------
+That test stops at normalize and asserts only batch-id propagation. This
+module carries the chain through the **ingest graph-load tail** and asserts the
+actual graph end-state, using a *faithful* in-process Neo4j fake (``FakeNeo4j``)
+that — unlike a Cypher-logging stub — actually tracks node ids so the ingest
+edge MERGE's ``OPTIONAL MATCH`` endpoint-resolution semantics are reproduced.
+That fidelity is what lets the in-process lane guard two contracts the unit
+suite otherwise leaves to the Docker E2E:
+
+* **Hadith-id parity (#63)** — the corpus-prefixed fixture
+  (``source_id="sunnah:bukhari:1:1"``) must MERGE as ``hdt:sunnah:bukhari:1:1``
+  (the batch loader's ``hdt:{source_id}``), never the doubled
+  ``hdt:sunnah:sunnah:bukhari:1:1``.
+* **Fail-loud edge guard (#22/#33)** — because ``FakeNeo4j`` resolves edge
+  endpoints against the nodes actually MERGEd in the same batch, a happy-path
+  chain produces zero skipped edges and the terminal stage does not raise.
+
+ML deps are NOT required: dedup and enrich degrade gracefully (the chain
+forces ``_ml_unavailable`` to keep CI deterministic without
+``sentence-transformers`` / ``transformers``), so the hadith payload reaches
+normalize and ingest on every hop.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+from typing import Any
+
+import pyarrow.parquet as pq
+import pytest
+
+from workers.dedup.processor import DedupProcessor
+from workers.enrich.processor import EnrichProcessor
+from workers.ingest.processor import IngestProcessor
+from workers.lib.message import PipelineMessage
+from workers.lib.object_store import ObjectStore
+from workers.normalize.processor import NormalizeProcessor
+
+# A corpus-prefixed source_id, exactly as ``generate_source_id`` emits it.
+# This is what makes the #63 doubling observable end to end — a bare "h-1"
+# cannot.
+SOURCE = "sunnah"
+SOURCE_ID = "sunnah:bukhari:1:1"
+EXPECTED_HADITH_ID = f"hdt:{SOURCE_ID}"
+
+# Discriminates a node MERGE from an edge MERGE by the Cypher shape ingest
+# emits (``_build_node_cypher``: ``MERGE (n:`Label` {id: row.id})``).
+_NODE_MERGE_RE = re.compile(r"MERGE \(n:`\w+` \{id: row\.id\}\)")
+
+
+# ---------------------------------------------------------------------------
+# Faithful in-process Neo4j fake
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, record: dict[str, int] | None) -> None:
+        self._record = record
+
+    def single(self) -> dict[str, int] | None:
+        return self._record
+
+
+class _FakeTx:
+    """Reproduces the slice of the Neo4j tx surface ingest uses: ``run`` of a
+    node-MERGE or edge-MERGE Cypher, returning a single record with the same
+    ``merged`` / ``skipped`` counts a real database would.
+
+    Node ids are tracked in a shared set so the edge query's OPTIONAL MATCH
+    endpoint resolution is faithful: an edge whose ``src_id``/``dst_id`` was
+    never MERGEd counts as ``skipped`` — the exact condition the production
+    ``_merge_edges_tx`` fails loud on (#22/#33).
+    """
+
+    def __init__(self, node_ids: set[str]) -> None:
+        self._node_ids = node_ids
+
+    def run(self, query: str, rows: list[dict[str, Any]] | None = None, **_: Any) -> _FakeResult:
+        rows = rows or []
+        if _NODE_MERGE_RE.search(query):
+            for row in rows:
+                self._node_ids.add(row["id"])
+            return _FakeResult({"merged": len(rows)})
+        # Edge MERGE: resolve both endpoints against MERGEd node ids.
+        merged = sum(
+            1 for r in rows if r["src_id"] in self._node_ids and r["dst_id"] in self._node_ids
+        )
+        skipped = len(rows) - merged
+        return _FakeResult({"merged": merged, "skipped": skipped})
+
+
+class _FakeSession:
+    def __init__(self, node_ids: set[str]) -> None:
+        self._node_ids = node_ids
+
+    def __enter__(self) -> _FakeSession:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def execute_write(self, fn: Any) -> Any:
+        return fn(_FakeTx(self._node_ids))
+
+
+class FakeNeo4j:
+    """In-process stand-in for a ``neo4j.Driver`` with a queryable graph.
+
+    Tracks every MERGEd node id so tests can assert the exact graph end-state
+    (e.g. the canonical Hadith id) without a live database.
+    """
+
+    def __init__(self) -> None:
+        self.node_ids: set[str] = set()
+
+    def session(self) -> _FakeSession:
+        return _FakeSession(self.node_ids)
+
+    def close(self) -> None:  # parity with the real driver surface
+        return None
+
+    @property
+    def hadith_ids(self) -> list[str]:
+        return sorted(nid for nid in self.node_ids if nid.startswith("hdt:"))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_raw_batch(store: ObjectStore, key: str, rows: list[dict[str, Any]]) -> None:
+    """Write a HADITH_SCHEMA Parquet batch to the fake store at ``key``."""
+    from tests.factories import build_hadith_table
+
+    table = build_hadith_table(rows)
+    buf = io.BytesIO()
+    pq.write_table(table, buf)
+    store.put_object(key, buf.getvalue())
+
+
+def _run_chain(
+    store: ObjectStore, msg: PipelineMessage, driver: FakeNeo4j
+) -> dict[str, PipelineMessage | None]:
+    """Drive dedup → enrich → normalize → ingest in-process on the fake stack.
+
+    ML is forced unavailable so the chain is deterministic in CI without the
+    optional embedding/classification deps — the documented graceful-degradation
+    path still does the pass-through copy + manifest fan-out the chain needs.
+    """
+    dedup = DedupProcessor(store)
+    dedup._ml_unavailable = True  # type: ignore[attr-defined]
+    enrich = EnrichProcessor(store)
+    enrich._ml_unavailable = True  # type: ignore[attr-defined]
+    normalize = NormalizeProcessor(store)
+    ingest = IngestProcessor(store, neo4j_driver=driver)
+
+    after_dedup = dedup(msg)
+    after_enrich = enrich(after_dedup)
+    after_normalize = normalize(after_enrich)
+    after_ingest = ingest(after_normalize)
+    return {
+        "dedup": after_dedup,
+        "enrich": after_enrich,
+        "normalize": after_normalize,
+        "ingest": after_ingest,
+    }
+
+
+def _read_manifest(store: ObjectStore, prefix: str) -> dict[str, Any]:
+    body = store.get_object(f"{prefix}_MANIFEST.json").read()
+    result: dict[str, Any] = json.loads(body.decode("utf-8"))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_chain_traverses_all_four_stages_into_graph(
+    object_store: ObjectStore,
+    sample_message: PipelineMessage,
+) -> None:
+    """A raw batch flows dedup → enrich → normalize → ingest in-process and the
+    Hadith node lands in the (fake) graph; the terminal stage returns None.
+    """
+    _seed_raw_batch(
+        object_store,
+        sample_message.b2_path,
+        [{"source_id": SOURCE_ID, "source_corpus": SOURCE, "matn_en": "Actions are by intentions"}],
+    )
+    driver = FakeNeo4j()
+
+    hops = _run_chain(object_store, sample_message, driver)
+
+    # batch_id / source survive every hop (the pre-existing propagation guard).
+    assert hops["normalize"].batch_id == sample_message.batch_id  # type: ignore[union-attr]
+    assert hops["normalize"].source == sample_message.source  # type: ignore[union-attr]
+    # Terminal ingest stage returns None.
+    assert hops["ingest"] is None
+    # The Hadith node reached the graph.
+    assert EXPECTED_HADITH_ID in driver.node_ids
+
+
+def test_chain_merges_canonical_hadith_id_no_doubled_corpus(
+    object_store: ObjectStore,
+    sample_message: PipelineMessage,
+) -> None:
+    """End-to-end #63 guard on the CI-durable lane.
+
+    The corpus-prefixed fixture must MERGE as ``hdt:sunnah:bukhari:1:1`` — the
+    batch loader's ``hdt:{source_id}`` — with no doubled corpus segment.
+    """
+    _seed_raw_batch(
+        object_store,
+        sample_message.b2_path,
+        [{"source_id": SOURCE_ID, "source_corpus": SOURCE, "matn_en": "text"}],
+    )
+    driver = FakeNeo4j()
+
+    _run_chain(object_store, sample_message, driver)
+
+    assert driver.hadith_ids == [EXPECTED_HADITH_ID], (
+        f"graph Hadith ids {driver.hadith_ids!r} != [{EXPECTED_HADITH_ID!r}] — "
+        "streaming and batch must MERGE the same node (#63)"
+    )
+    assert all("sunnah:sunnah" not in nid for nid in driver.node_ids), "corpus doubled (#63)"
+
+
+def test_chain_normalize_emits_full_manifest_consumed_by_ingest(
+    object_store: ObjectStore,
+    sample_message: PipelineMessage,
+) -> None:
+    """The normalize → ingest object contract holds across the in-process chain.
+
+    A row carrying an English isnad + a grade exercises every fan-out label, and
+    ingest must consume the manifest-gated per-label Parquets without raising the
+    fail-loud edge guard (every edge endpoint MERGEd in the same batch).
+    """
+    rows = [
+        {
+            "source_id": SOURCE_ID,
+            "source_corpus": SOURCE,
+            "collection_name": "bukhari",
+            "matn_en": "text",
+            "grade": "sahih",
+            "isnad_raw_en": "Narrated Abu Hurayrah from Malik on the authority of Nafi",
+        }
+    ]
+    _seed_raw_batch(object_store, sample_message.b2_path, rows)
+    driver = FakeNeo4j()
+
+    hops = _run_chain(object_store, sample_message, driver)
+
+    # normalize fanned out into every node label.
+    manifest = _read_manifest(object_store, hops["normalize"].b2_path)  # type: ignore[union-attr]
+    labels = {e.get("label") for e in manifest["parquets"] if e.get("label")}
+    assert labels == {"Hadith", "Collection", "Chain", "Narrator", "Grading"}
+
+    # ingest MERGEd the Hadith, its Collection, and at least two narrators —
+    # and did NOT raise, proving every edge endpoint resolved (#22/#33).
+    assert EXPECTED_HADITH_ID in driver.node_ids
+    assert any(nid.startswith("col:") for nid in driver.node_ids)
+    assert sum(1 for nid in driver.node_ids if nid.startswith("nar:")) >= 2
+    assert hops["ingest"] is None
+
+
+def test_chain_is_idempotent_on_replay(
+    object_store: ObjectStore,
+    sample_message: PipelineMessage,
+) -> None:
+    """Re-running the whole chain on the same batch yields the same graph ids.
+
+    Stage outputs use deterministic ids (``hdt:{source_id}``, hashed narrator/
+    chain ids), so a replay MERGEs onto the same nodes — the idempotency the
+    pipeline relies on for at-least-once Kafka delivery.
+    """
+    _seed_raw_batch(
+        object_store,
+        sample_message.b2_path,
+        [{"source_id": SOURCE_ID, "source_corpus": SOURCE, "matn_en": "text", "grade": "sahih"}],
+    )
+
+    driver1 = FakeNeo4j()
+    _run_chain(object_store, sample_message, driver1)
+    first = set(driver1.node_ids)
+
+    driver2 = FakeNeo4j()
+    _run_chain(object_store, sample_message, driver2)
+    second = set(driver2.node_ids)
+
+    assert first == second, "replaying the chain must produce identical node ids"
+    assert EXPECTED_HADITH_ID in first
+
+
+def test_fake_neo4j_edge_guard_matches_production_skip_semantics() -> None:
+    """Guard the fake's own fidelity: an edge to an un-MERGEd endpoint is skipped.
+
+    This pins the property that makes the chain tests meaningful — ``FakeNeo4j``
+    reproduces the OPTIONAL MATCH endpoint resolution, so the production
+    ``_merge_edges_tx`` fail-loud path (#22/#33) is actually reachable in-process
+    rather than rubber-stamped. ``IngestProcessor`` raises ``EndpointMissingError``
+    when an edge references a node absent from the graph.
+    """
+    from workers.ingest.processor import EndpointMissingError, _merge_edges_tx
+
+    driver = FakeNeo4j()
+    with driver.session() as session:
+        # MERGE one node, then an edge whose dst is absent → must count skipped,
+        # which _merge_edges_tx turns into EndpointMissingError.
+        def _attempt(tx: Any) -> Any:
+            tx.run("MERGE (n:`Hadith` {id: row.id})", rows=[{"id": "hdt:present"}])
+            return _merge_edges_tx(
+                tx,
+                label="APPEARS_IN",
+                rows=[
+                    {"src_id": "hdt:present", "dst_id": "col:absent", "props": {}},
+                ],
+            )
+
+        with pytest.raises(EndpointMissingError, match="absent from the graph"):
+            session.execute_write(_attempt)

--- a/workers/normalize/processor.py
+++ b/workers/normalize/processor.py
@@ -28,8 +28,9 @@ Stable-ID generation
 IDs are deterministic so re-processing the same batch produces the same
 node identities (idempotent ingest MERGE). Hash inputs:
 
-* ``Hadith``   — ``hdt:<source_corpus>:<source_id>`` (already canonical
-  from the source parser; no hashing required).
+* ``Hadith``   — ``hdt:<source_id>`` where ``source_id`` is already
+  corpus-prefixed by the parser (``sunnah:bukhari:1:1``); no hashing and
+  no extra corpus prepend (#63). Matches ``src/graph/load_nodes.py``.
 * ``Narrator`` — ``nar:<sha1-24>`` of
   ``<lower(name_en)>|<normalize_arabic(name_ar)>``. Blank sides are
   represented as the empty string so pure-English and pure-Arabic
@@ -179,9 +180,20 @@ def _normalize_arabic_safe(text: str) -> str:
         return text.strip()
 
 
-def _hadith_id(source_corpus: str, source_id: str) -> str:
-    key = f"{source_corpus}:{source_id}"
-    return key if key.startswith("hdt:") else f"hdt:{key}"
+def _hadith_id(source_id: str) -> str:
+    """Canonical Hadith id — ``hdt:<source_id>`` (matches the batch loaders).
+
+    ``source_id`` is already corpus-prefixed by the parsers
+    (``generate_source_id`` emits ``<corpus>:<collection>:<parts>``, e.g.
+    ``sunnah:bukhari:1:1``), so the corpus must NOT be prepended a second
+    time — that produced the doubled ``hdt:sunnah:sunnah:bukhari:1:1`` of
+    #63, which split one hadith into two Neo4j nodes against the batch
+    loader's ``hdt:sunnah:bukhari:1:1``. This now mirrors
+    ``src/graph/load_nodes.py`` (``f"hdt:{sid}"``) and
+    ``src/graph/load_edges.py`` exactly so streaming and batch MERGE the
+    same node.
+    """
+    return source_id if source_id.startswith("hdt:") else f"hdt:{source_id}"
 
 
 def _collection_id(collection_name: str) -> str:
@@ -208,7 +220,7 @@ def _fan_out_row(row: dict[str, Any]) -> tuple[list[_NodeRow], list[_EdgeRow]]:
     collection_name = row["collection_name"]
     sect = row["sect"]
 
-    hid = _hadith_id(source_corpus, source_id)
+    hid = _hadith_id(source_id)
     cid = _collection_id(collection_name)
 
     nodes: list[_NodeRow] = [


### PR DESCRIPTION
## Summary
Refs noorinalabs-main#136 — full worker-chain integration scenarios for `dedup → enrich → normalize → ingest`, delivered as **two legs** per the team-lead spec:

1. **CI-durable in-process chain** (`tests/workers/test_worker_chain_inprocess.py`) — drives all four stages in-process on the faithful fake stack (`FakeS3Client` → `ObjectStore` + parquet builders), with a **faithful** in-process Neo4j fake (`FakeNeo4j`) that tracks MERGEd node ids so the ingest edge MERGE's `OPTIONAL MATCH` endpoint resolution is reproduced. Runs in the default `pytest -m "not integration"` lane — **CI proves the worker-chain contract with zero Docker**.
2. **Docker-gated graph-load tail** (`tests/integration/test_worker_chain_e2e.py`) — the same four stages through **real Kafka + MinIO + Neo4j** testcontainers, terminating in a real Neo4j MERGE. `@pytest.mark.integration`, runs via `make test-integration`; CI-runner-flake leg tracked at noorinalabs-main#631.

`Closes` does not fire cross-repo → **Refs noorinalabs-main#136**.

## What this fills vs the existing tests
- **#55 `test_kafka_worker_e2e.py`** seeds at `pipeline.dedup.done` — the dedup worker never runs. Both legs here run the dedup hop.
- **ig#62 / main#139 `test_e2e_inprocess.py`** asserts node **counts**, not ids.
- **Pre-existing `test_processor_chain_propagates_batch_id`** stops at normalize and asserts only batch-id propagation. The in-process leg here carries the chain through the **ingest graph-load tail** and asserts the real graph end-state.

## Contracts pinned
- **Hadith-id parity (#63)** — corpus-prefixed fixture (`sunnah:bukhari:1:1`) MERGEs as `hdt:sunnah:bukhari:1:1` (the batch loader's `hdt:{source_id}`), never the doubled `hdt:sunnah:sunnah:...`. Guarded in BOTH legs. (Stacked on #66, the #63 fix.)
- **normalize→ingest manifest contract** — full-label fan-out consumed without tripping the fail-loud edge guard.
- **Chain idempotency on replay** — deterministic ids → identical node set.
- **`FakeNeo4j` fidelity guard** — reproduces the production `EndpointMissingError` skip semantics (#22/#33), so the in-process tests are meaningful, not a stub.
- **Admin stage-reset (#108)** against real MinIO — `xfail(strict=True)`; surfaced a real defect (`reset._delete_prefix`'s `delete_objects` rejected by MinIO/B2 with `MissingContentMD5` under botocore≥1.36). Regression guard; reported for a reset-path fix.

## Verification
- In-process leg: **5 passed** in the CI lane. Full Docker-less suite: **602 passed, 4 skipped**.
- Docker leg (live): **2 passed, 1 xfailed** against Kafka+MinIO+Neo4j testcontainers; `ingest_merged` logs confirm one Hadith node with the canonical id.
- CI: `test` / `lint-and-typecheck` / `precommit-ci-sync` GREEN. `security-audit` RED = pre-existing transitive-`pip` CVE PYSEC-2026-196 (fix 26.1.2), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
