### PR TITLE
feat(api): admin-only HTTP reset endpoints wrapping the reset CLI surface (#70)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
     "rapidfuzz>=3.6",
     "kafka-python>=2.0",
     "boto3>=1.34",
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.34",
+    "python-jose[cryptography]>=3.3",
 ]
 
 [project.scripts]
@@ -106,6 +109,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["kaggle", "kaggle.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["jose", "jose.*"]
 ignore_missing_imports = true
 
 [tool.pydantic-mypy]

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,6 @@
+"""HTTP API surface for the ingest platform.
+
+Currently exposes the admin-only pipeline-reset endpoints (issue #70) that
+wrap the reset CLI surface (issue #9) so the isnad-graph admin reset UI can
+drive pipeline resets over HTTP. The app factory lives in :mod:`src.api.app`.
+"""

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,0 +1,44 @@
+"""FastAPI app factory for the ingest-platform admin HTTP surface.
+
+Exposes the admin-only reset endpoints (issue #70). The reset router is
+mounted under ``/admin`` with ``Depends(require_admin)`` applied at the
+router level, so every reset route is admin-only — there is no
+unauthenticated path to a destructive operation.
+
+Run locally with::
+
+    uvicorn src.api.app:create_app --factory --port 8002
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI
+
+from src.api.auth import require_admin
+from src.api.reset_router import router as reset_router
+
+
+def create_app() -> FastAPI:
+    """Construct the FastAPI application."""
+    app = FastAPI(
+        title="isnad-ingest admin API",
+        description="Admin-only pipeline operations (reset surface).",
+        version="0.1.0",
+    )
+
+    @app.get("/healthz", tags=["health"])
+    def healthz() -> dict[str, str]:
+        """Unauthenticated liveness probe."""
+        return {"status": "ok"}
+
+    # Admin guard is applied once at the mount point — covers every reset route.
+    app.include_router(
+        reset_router,
+        prefix="/admin",
+        dependencies=[Depends(require_admin)],
+    )
+
+    return app
+
+
+app = create_app()

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -1,0 +1,176 @@
+"""Admin authentication for the reset HTTP surface.
+
+Mirrors the isnad-graph admin restriction so the *same* user-service RS256
+JWT (validated against user-service's JWKS) authorizes a reset here as on the
+isnad-graph admin dashboard. The reset endpoints are destructive, so the
+guard is admin-only — a valid non-admin token is rejected with 403.
+
+This is a deliberately slimmed copy of isnad-graph's
+``src/api/middleware.py`` + ``src/api/auth.py`` auth path: JWKS fetch with a
+TTL cache, RS256 verification with a single key-rotation retry, role
+resolution from the ``roles`` claim, and a ``require_admin`` FastAPI
+dependency. Kept self-contained (no shared package) because the two services
+are independent repos.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from enum import StrEnum
+
+import httpx
+from fastapi import HTTPException, Request
+from jose import JWTError, jwt
+
+from src.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class Role(StrEnum):
+    """User roles with hierarchical privilege levels (matches isnad-graph)."""
+
+    VIEWER = "viewer"
+    EDITOR = "editor"
+    MODERATOR = "moderator"
+    ADMIN = "admin"
+
+
+ROLE_HIERARCHY: dict[Role, int] = {
+    Role.VIEWER: 0,
+    Role.EDITOR: 1,
+    Role.MODERATOR: 2,
+    Role.ADMIN: 3,
+}
+
+# user-service role string -> local Role. Matches isnad-graph's map so role
+# resolution is identical across services.
+_USER_SERVICE_ROLE_MAP: dict[str, Role] = {
+    "admin": Role.ADMIN,
+    "moderator": Role.MODERATOR,
+    "researcher": Role.EDITOR,
+    "editor": Role.EDITOR,
+    "reader": Role.VIEWER,
+    "viewer": Role.VIEWER,
+    "trial": Role.VIEWER,
+}
+
+
+def _resolve_role(roles: list[str]) -> Role:
+    """Pick the highest-privilege role from the JWT ``roles`` claim."""
+    best = Role.VIEWER
+    best_level = 0
+    for r in roles:
+        mapped = _USER_SERVICE_ROLE_MAP.get(r.lower(), Role.VIEWER)
+        level = ROLE_HIERARCHY.get(mapped, 0)
+        if level > best_level:
+            best = mapped
+            best_level = level
+    return best
+
+
+# ---------------------------------------------------------------------------
+# JWKS-based RS256 JWT validation (mirrors isnad-graph/src/api/auth.py)
+# ---------------------------------------------------------------------------
+
+_jwks_cache: dict[str, object] | None = None
+_jwks_fetched_at: float = 0.0
+
+
+def _get_jwks_url() -> str:
+    base = get_settings().auth.user_service_url.rstrip("/")
+    return f"{base}/.well-known/jwks.json"
+
+
+def fetch_jwks() -> dict[str, object]:
+    """Fetch JWKS from user-service, using a TTL-based in-memory cache.
+
+    Raises ``httpx.HTTPError`` if the JWKS endpoint is unreachable.
+    """
+    global _jwks_cache, _jwks_fetched_at  # noqa: PLW0603
+    ttl = get_settings().auth.user_service_jwks_cache_ttl
+    now = time.monotonic()
+    if _jwks_cache is not None and (now - _jwks_fetched_at) < ttl:
+        return _jwks_cache
+
+    resp = httpx.get(_get_jwks_url(), timeout=10.0)
+    resp.raise_for_status()
+    _jwks_cache = resp.json()
+    _jwks_fetched_at = now
+    return _jwks_cache
+
+
+def invalidate_jwks_cache() -> None:
+    """Force the next ``fetch_jwks`` call to re-fetch from user-service."""
+    global _jwks_cache, _jwks_fetched_at  # noqa: PLW0603
+    _jwks_cache = None
+    _jwks_fetched_at = 0.0
+
+
+def verify_user_service_token(token: str) -> dict[str, object]:
+    """Validate an RS256 JWT issued by user-service using its JWKS.
+
+    Invalidates the cache and retries once on signature failure to handle
+    key rotation. Returns the decoded payload.
+
+    Raises:
+        ValueError: token invalid, expired, or bad signature.
+        httpx.HTTPError: JWKS endpoint unreachable.
+    """
+    jwks = fetch_jwks()
+    try:
+        payload: dict[str, object] = jwt.decode(token, jwks, algorithms=["RS256"])
+    except JWTError:
+        logger.info("JWKS verification failed, invalidating cache and retrying")
+        invalidate_jwks_cache()
+        jwks = fetch_jwks()
+        try:
+            payload = jwt.decode(token, jwks, algorithms=["RS256"])
+        except JWTError as exc:
+            raise ValueError(f"Invalid token: {exc}") from exc
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# FastAPI dependency
+# ---------------------------------------------------------------------------
+
+
+def require_admin(request: Request) -> str:
+    """FastAPI dependency: require an authenticated user-service admin.
+
+    Returns the caller's identity (``sub``) so routes can attribute the
+    reset in the audit log. Raises:
+
+    - 401 — missing/invalid Authorization header, bad/expired token, or a
+      non-``access`` token type.
+    - 403 — valid token whose resolved role is below ADMIN.
+    - 503 — user-service JWKS endpoint unreachable.
+    """
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+
+    token = auth_header.removeprefix("Bearer ")
+
+    try:
+        payload = verify_user_service_token(token)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid or expired token") from None
+    except httpx.HTTPError:
+        raise HTTPException(status_code=503, detail="Authentication service unavailable") from None
+
+    if payload.get("type") != "access":
+        raise HTTPException(status_code=401, detail="Invalid token type")
+
+    subject = payload.get("sub")
+    if not isinstance(subject, str):
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+
+    roles_claim = payload.get("roles")
+    roles_list: list[str] = roles_claim if isinstance(roles_claim, list) else []
+    if _resolve_role(roles_list) != Role.ADMIN:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    return subject

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -1,0 +1,43 @@
+"""FastAPI dependencies for the reset HTTP surface.
+
+The resetter and data dir are provided as dependencies so the unit suite can
+override them with in-memory fakes (``app.dependency_overrides``) without any
+boto3/Kafka/Neo4j/PG infra — the same isolation invariant the CLI keeps via
+``_build_reset_clients``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.config import get_settings
+from src.pipeline.reset import PipelineResetter
+
+
+def get_data_dir() -> Path:
+    """Directory under which audit entries are written (``<data>/audit/``).
+
+    Matches the CLI's ``_cmd_reset`` derivation so API-driven and CLI-driven
+    resets land their audit log in the same place.
+    """
+    return Path(get_settings().data_raw_dir).parent
+
+
+def get_resetter() -> PipelineResetter:
+    """Build the real PipelineResetter wired to live infra adapters.
+
+    Reuses the CLI's ``_build_reset_clients`` so there is a single place that
+    constructs the boto3 / Kafka / Neo4j / PG adapters. Tests override this
+    dependency with a fake resetter.
+    """
+    from src.cli import _build_reset_clients
+
+    settings = get_settings()
+    object_store, kafka_admin, neo4j, pg = _build_reset_clients(settings)
+    return PipelineResetter(
+        object_store=object_store,
+        kafka_admin=kafka_admin,
+        neo4j=neo4j,
+        pg=pg,
+        data_dir=get_data_dir(),
+    )

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -1,13 +1,14 @@
 """FastAPI dependencies for the reset HTTP surface.
 
-The resetter and data dir are provided as dependencies so the unit suite can
-override them with in-memory fakes (``app.dependency_overrides``) without any
-boto3/Kafka/Neo4j/PG infra — the same isolation invariant the CLI keeps via
-``_build_reset_clients``.
+The resetter is provided as a *lazy factory* and the data dir as a plain
+dependency so the unit suite can override them with in-memory fakes
+(``app.dependency_overrides``) without any boto3/Kafka/Neo4j/PG infra — the
+same isolation invariant the CLI keeps via ``_build_reset_clients``.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 from src.config import get_settings
@@ -23,21 +24,33 @@ def get_data_dir() -> Path:
     return Path(get_settings().data_raw_dir).parent
 
 
-def get_resetter() -> PipelineResetter:
-    """Build the real PipelineResetter wired to live infra adapters.
+def get_resetter_factory() -> Callable[[], PipelineResetter]:
+    """Return a *lazy* factory that builds the live resetter on demand.
 
-    Reuses the CLI's ``_build_reset_clients`` so there is a single place that
-    constructs the boto3 / Kafka / Neo4j / PG adapters. Tests override this
-    dependency with a fake resetter.
+    Returning a factory rather than a resetter is deliberate: FastAPI resolves
+    a route's dependencies on EVERY request, including ``dry_run=True``. If we
+    built the resetter here, every dry-run preview — the safe affordance
+    ig#970's admin UI calls first — would eagerly open Kafka + Postgres
+    connections (``_build_reset_clients`` reads ``KAFKA_BOOTSTRAP_SERVERS`` and
+    eagerly connects). With a factory, the live boto3/Kafka/Neo4j/PG clients
+    stay UNBUILT until a route actually invokes it in the non-dry-run branch,
+    so a dry-run touches no infra.
+
+    Reuses the CLI's ``_build_reset_clients`` so adapter construction lives in
+    one place. Tests override this dependency with a factory returning a fake.
     """
-    from src.cli import _build_reset_clients
 
-    settings = get_settings()
-    object_store, kafka_admin, neo4j, pg = _build_reset_clients(settings)
-    return PipelineResetter(
-        object_store=object_store,
-        kafka_admin=kafka_admin,
-        neo4j=neo4j,
-        pg=pg,
-        data_dir=get_data_dir(),
-    )
+    def _build() -> PipelineResetter:
+        from src.cli import _build_reset_clients
+
+        settings = get_settings()
+        object_store, kafka_admin, neo4j, pg = _build_reset_clients(settings)
+        return PipelineResetter(
+            object_store=object_store,
+            kafka_admin=kafka_admin,
+            neo4j=neo4j,
+            pg=pg,
+            data_dir=get_data_dir(),
+        )
+
+    return _build

--- a/src/api/reset_router.py
+++ b/src/api/reset_router.py
@@ -1,0 +1,175 @@
+"""Admin-only HTTP endpoints wrapping the pipeline reset CLI surface.
+
+Three endpoints mirror the three CLI reset scopes (issue #9):
+
+- ``POST /admin/reset/stage``  — wipe one stage's B2 prefix + Kafka offsets
+- ``POST /admin/reset/source`` — wipe every stage prefix for one source
+- ``POST /admin/reset/full``   — full obliterate (B2 + Kafka + Neo4j + PG)
+
+The destructive ``/full`` endpoint preserves the CLI's ``OBLITERATE``
+confirmation semantics at the API boundary: the request MUST carry
+``confirmation == "OBLITERATE"`` or the call is rejected before any work is
+done. Every call routes through the real ``PipelineResetter``, which writes
+an audit entry per reset (dry-run included).
+
+The admin guard is applied at the router level in :mod:`src.api.app`
+(``dependencies=[Depends(require_admin)]``), so every route here is
+admin-only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.api.deps import get_data_dir, get_resetter
+from src.pipeline.reset import PipelineResetter, ResetScope, write_dry_run_audit
+
+router = APIRouter(prefix="/reset", tags=["admin", "reset"])
+
+# The literal an operator must supply to authorize a full reset. Mirrors the
+# CLI's typed ``OBLITERATE`` confirmation (src/cli.py ``_cmd_reset``).
+OBLITERATE_TOKEN = "OBLITERATE"
+
+
+class _ResetRequestBase(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    dry_run: bool = Field(
+        default=False,
+        description="Validate scope and write a dry-run audit entry without touching infra.",
+    )
+
+
+class StageResetRequest(_ResetRequestBase):
+    """Reset one pipeline stage."""
+
+    stage: str = Field(description="Stage to reset: raw|dedup|enriched|normalized|staged")
+
+
+class SourceResetRequest(_ResetRequestBase):
+    """Reset every stage prefix for one data source."""
+
+    source: str = Field(description="Source identifier, e.g. 'sunnah-api' (no '/').")
+
+
+class FullResetRequest(_ResetRequestBase):
+    """Full pipeline obliterate. Requires the OBLITERATE confirmation token."""
+
+    confirmation: str = Field(
+        description=f"Must equal '{OBLITERATE_TOKEN}' to authorize the destructive full reset.",
+    )
+
+
+class ResetResponse(BaseModel):
+    """Result of a reset call — the resetter's report summary + audit path."""
+
+    model_config = ConfigDict(frozen=True)
+
+    level: str
+    dry_run: bool
+    confirmation_method: str
+    audit_entry_path: str
+    summary: dict[str, Any]
+
+
+def _run_reset(
+    scope: ResetScope,
+    *,
+    confirmation_method: str,
+    dry_run: bool,
+    resetter: PipelineResetter,
+    data_dir: Path,
+) -> ResetResponse:
+    """Execute (or dry-run) a reset and shape the HTTP response.
+
+    Both paths emit an audit entry — real resets via ``PipelineResetter.reset``,
+    dry-runs via ``write_dry_run_audit`` — matching the CLI exactly.
+    """
+    if dry_run:
+        report, _entry, audit_path = write_dry_run_audit(
+            scope, confirmation_method=confirmation_method, data_dir=data_dir
+        )
+    else:
+        report, _entry, audit_path = resetter.reset(scope, confirmation_method=confirmation_method)
+
+    return ResetResponse(
+        level=report.level,
+        dry_run=report.dry_run,
+        confirmation_method=report.confirmation_method,
+        audit_entry_path=str(audit_path),
+        summary=report.to_summary(),
+    )
+
+
+@router.post("/stage", response_model=ResetResponse)
+def reset_stage(
+    body: StageResetRequest,
+    resetter: Annotated[PipelineResetter, Depends(get_resetter)],
+    data_dir: Annotated[Path, Depends(get_data_dir)],
+) -> ResetResponse:
+    """Wipe one stage's B2 prefix and reset that stage's Kafka consumer offsets."""
+    try:
+        scope = ResetScope.stage_scope(body.stage)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    # Stage scope is non-obliterate; the CLI records it as "not-required".
+    return _run_reset(
+        scope,
+        confirmation_method="not-required",
+        dry_run=body.dry_run,
+        resetter=resetter,
+        data_dir=data_dir,
+    )
+
+
+@router.post("/source", response_model=ResetResponse)
+def reset_source(
+    body: SourceResetRequest,
+    resetter: Annotated[PipelineResetter, Depends(get_resetter)],
+    data_dir: Annotated[Path, Depends(get_data_dir)],
+) -> ResetResponse:
+    """Wipe every stage prefix for one data source."""
+    try:
+        scope = ResetScope.source_scope(body.source)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return _run_reset(
+        scope,
+        confirmation_method="not-required",
+        dry_run=body.dry_run,
+        resetter=resetter,
+        data_dir=data_dir,
+    )
+
+
+@router.post("/full", response_model=ResetResponse)
+def reset_full(
+    body: FullResetRequest,
+    resetter: Annotated[PipelineResetter, Depends(get_resetter)],
+    data_dir: Annotated[Path, Depends(get_data_dir)],
+) -> ResetResponse:
+    """Full obliterate. Rejects the call unless the OBLITERATE token is supplied.
+
+    The token is the API-boundary equivalent of the operator typing
+    ``OBLITERATE`` at the CLI prompt, so we record ``confirmation_method =
+    "interactive"`` for SIEM parity with a typed confirmation.
+    """
+    if body.confirmation != OBLITERATE_TOKEN:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Full reset requires confirmation == '{OBLITERATE_TOKEN}'.",
+        )
+
+    return _run_reset(
+        ResetScope.full_scope(),
+        confirmation_method="interactive",
+        dry_run=body.dry_run,
+        resetter=resetter,
+        data_dir=data_dir,
+    )

--- a/src/api/reset_router.py
+++ b/src/api/reset_router.py
@@ -19,13 +19,14 @@ admin-only.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
-from src.api.deps import get_data_dir, get_resetter
+from src.api.deps import get_data_dir, get_resetter_factory
 from src.pipeline.reset import PipelineResetter, ResetScope, write_dry_run_audit
 
 router = APIRouter(prefix="/reset", tags=["admin", "reset"])
@@ -81,19 +82,24 @@ def _run_reset(
     *,
     confirmation_method: str,
     dry_run: bool,
-    resetter: PipelineResetter,
+    resetter_factory: Callable[[], PipelineResetter],
     data_dir: Path,
 ) -> ResetResponse:
     """Execute (or dry-run) a reset and shape the HTTP response.
 
     Both paths emit an audit entry — real resets via ``PipelineResetter.reset``,
     dry-runs via ``write_dry_run_audit`` — matching the CLI exactly.
+
+    The resetter is built (via ``resetter_factory``) ONLY in the non-dry-run
+    branch, so a dry-run never constructs the live boto3/Kafka/Neo4j/PG
+    clients — keeping the preview path inert, which ig#970's admin UI relies on.
     """
     if dry_run:
         report, _entry, audit_path = write_dry_run_audit(
             scope, confirmation_method=confirmation_method, data_dir=data_dir
         )
     else:
+        resetter = resetter_factory()
         report, _entry, audit_path = resetter.reset(scope, confirmation_method=confirmation_method)
 
     return ResetResponse(
@@ -108,7 +114,7 @@ def _run_reset(
 @router.post("/stage", response_model=ResetResponse)
 def reset_stage(
     body: StageResetRequest,
-    resetter: Annotated[PipelineResetter, Depends(get_resetter)],
+    resetter_factory: Annotated[Callable[[], PipelineResetter], Depends(get_resetter_factory)],
     data_dir: Annotated[Path, Depends(get_data_dir)],
 ) -> ResetResponse:
     """Wipe one stage's B2 prefix and reset that stage's Kafka consumer offsets."""
@@ -122,7 +128,7 @@ def reset_stage(
         scope,
         confirmation_method="not-required",
         dry_run=body.dry_run,
-        resetter=resetter,
+        resetter_factory=resetter_factory,
         data_dir=data_dir,
     )
 
@@ -130,7 +136,7 @@ def reset_stage(
 @router.post("/source", response_model=ResetResponse)
 def reset_source(
     body: SourceResetRequest,
-    resetter: Annotated[PipelineResetter, Depends(get_resetter)],
+    resetter_factory: Annotated[Callable[[], PipelineResetter], Depends(get_resetter_factory)],
     data_dir: Annotated[Path, Depends(get_data_dir)],
 ) -> ResetResponse:
     """Wipe every stage prefix for one data source."""
@@ -143,7 +149,7 @@ def reset_source(
         scope,
         confirmation_method="not-required",
         dry_run=body.dry_run,
-        resetter=resetter,
+        resetter_factory=resetter_factory,
         data_dir=data_dir,
     )
 
@@ -151,7 +157,7 @@ def reset_source(
 @router.post("/full", response_model=ResetResponse)
 def reset_full(
     body: FullResetRequest,
-    resetter: Annotated[PipelineResetter, Depends(get_resetter)],
+    resetter_factory: Annotated[Callable[[], PipelineResetter], Depends(get_resetter_factory)],
     data_dir: Annotated[Path, Depends(get_data_dir)],
 ) -> ResetResponse:
     """Full obliterate. Rejects the call unless the OBLITERATE token is supplied.
@@ -170,6 +176,6 @@ def reset_full(
         ResetScope.full_scope(),
         confirmation_method="interactive",
         dry_run=body.dry_run,
-        resetter=resetter,
+        resetter_factory=resetter_factory,
         data_dir=data_dir,
     )

--- a/src/config.py
+++ b/src/config.py
@@ -26,11 +26,26 @@ class PostgresSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="PG_")
 
 
+class AuthSettings(BaseSettings):
+    """Auth settings for the admin HTTP surface.
+
+    Mirrors isnad-graph's ``AuthSettings`` so the same user-service RS256
+    JWT validates identically in both services — an admin token minted for
+    the isnad-graph admin dashboard is accepted by the reset endpoints here.
+    """
+
+    user_service_url: str = "http://localhost:8001"
+    user_service_jwks_cache_ttl: int = 3600
+
+    model_config = SettingsConfigDict(env_prefix="AUTH_")
+
+
 class Settings(BaseSettings):
     """Root application settings, composed from nested service settings."""
 
     neo4j: Neo4jSettings = Neo4jSettings()
     postgres: PostgresSettings = PostgresSettings()
+    auth: AuthSettings = AuthSettings()
 
     sunnah_api_key: str = ""
     kaggle_username: str = ""

--- a/tests/test_api/test_reset_endpoints.py
+++ b/tests/test_api/test_reset_endpoints.py
@@ -20,13 +20,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
 import src.api.auth as auth_mod
 from src.api.app import create_app
 from src.api.auth import require_admin
-from src.api.deps import get_data_dir, get_resetter
+from src.api.deps import get_data_dir, get_resetter_factory
 from src.pipeline.audit import AuditEntry, create_audit_entry
 from src.pipeline.reset import ResetReport, ResetScope
 
@@ -51,16 +52,39 @@ class _FakeResetter:
         return report, entry, Path("/tmp/fake-audit.json")
 
 
+class _FactorySpy:
+    """Stands in for ``get_resetter_factory``'s return value.
+
+    Counts how many times it is *invoked* (i.e. how many times a route asked
+    to build the live resetter). A dry-run must never invoke it — that is the
+    dry-run-inert property — so ``build_count`` lets tests assert no live
+    client construction happens on a dry run.
+    """
+
+    def __init__(self, resetter: _FakeResetter) -> None:
+        self.resetter = resetter
+        self.build_count = 0
+
+    def __call__(self) -> _FakeResetter:
+        self.build_count += 1
+        return self.resetter
+
+
 @pytest.fixture
 def fake_resetter() -> _FakeResetter:
     return _FakeResetter()
 
 
 @pytest.fixture
-def client(tmp_path: Path, fake_resetter: _FakeResetter) -> TestClient:
-    """App with a fake resetter + tmp data dir, admin guard satisfied."""
+def factory_spy(fake_resetter: _FakeResetter) -> _FactorySpy:
+    return _FactorySpy(fake_resetter)
+
+
+@pytest.fixture
+def client(tmp_path: Path, factory_spy: _FactorySpy) -> TestClient:
+    """App with a fake resetter factory + tmp data dir, admin guard satisfied."""
     app = create_app()
-    app.dependency_overrides[get_resetter] = lambda: fake_resetter
+    app.dependency_overrides[get_resetter_factory] = lambda: factory_spy
     app.dependency_overrides[get_data_dir] = lambda: tmp_path
     # Authenticated-admin caller for the non-auth-focused tests.
     app.dependency_overrides[require_admin] = lambda: "admin-user-id"
@@ -72,29 +96,34 @@ def client(tmp_path: Path, fake_resetter: _FakeResetter) -> TestClient:
 # ---------------------------------------------------------------------------
 
 
-def _client_with_real_guard(tmp_path: Path, fake_resetter: _FakeResetter) -> TestClient:
+def _client_with_real_guard(tmp_path: Path, factory_spy: _FactorySpy) -> TestClient:
     app = create_app()
-    app.dependency_overrides[get_resetter] = lambda: fake_resetter
+    app.dependency_overrides[get_resetter_factory] = lambda: factory_spy
     app.dependency_overrides[get_data_dir] = lambda: tmp_path
     return TestClient(app, raise_server_exceptions=True)
 
 
-def test_missing_auth_header_rejected(tmp_path: Path, fake_resetter: _FakeResetter) -> None:
-    c = _client_with_real_guard(tmp_path, fake_resetter)
+def test_missing_auth_header_rejected(
+    tmp_path: Path, fake_resetter: _FakeResetter, factory_spy: _FactorySpy
+) -> None:
+    c = _client_with_real_guard(tmp_path, factory_spy)
     resp = c.post("/admin/reset/stage", json={"stage": "raw"})
     assert resp.status_code == 401
     assert fake_resetter.calls == []
 
 
 def test_non_admin_token_forbidden(
-    tmp_path: Path, fake_resetter: _FakeResetter, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    fake_resetter: _FakeResetter,
+    factory_spy: _FactorySpy,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         auth_mod,
         "verify_user_service_token",
         lambda _token: {"type": "access", "sub": "u1", "roles": ["viewer"]},
     )
-    c = _client_with_real_guard(tmp_path, fake_resetter)
+    c = _client_with_real_guard(tmp_path, factory_spy)
     resp = c.post(
         "/admin/reset/stage",
         json={"stage": "raw"},
@@ -105,14 +134,17 @@ def test_non_admin_token_forbidden(
 
 
 def test_admin_token_allowed(
-    tmp_path: Path, fake_resetter: _FakeResetter, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    fake_resetter: _FakeResetter,
+    factory_spy: _FactorySpy,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         auth_mod,
         "verify_user_service_token",
         lambda _token: {"type": "access", "sub": "admin1", "roles": ["admin"]},
     )
-    c = _client_with_real_guard(tmp_path, fake_resetter)
+    c = _client_with_real_guard(tmp_path, factory_spy)
     resp = c.post(
         "/admin/reset/stage",
         json={"stage": "raw"},
@@ -123,20 +155,43 @@ def test_admin_token_allowed(
 
 
 def test_non_access_token_type_rejected(
-    tmp_path: Path, fake_resetter: _FakeResetter, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    fake_resetter: _FakeResetter,
+    factory_spy: _FactorySpy,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         auth_mod,
         "verify_user_service_token",
         lambda _token: {"type": "refresh", "sub": "admin1", "roles": ["admin"]},
     )
-    c = _client_with_real_guard(tmp_path, fake_resetter)
+    c = _client_with_real_guard(tmp_path, factory_spy)
     resp = c.post(
         "/admin/reset/stage",
         json={"stage": "raw"},
         headers={"Authorization": "Bearer refreshtoken"},
     )
     assert resp.status_code == 401
+    assert fake_resetter.calls == []
+
+
+def test_jwks_unreachable_returns_503(
+    tmp_path: Path,
+    fake_resetter: _FakeResetter,
+    factory_spy: _FactorySpy,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(_token: str) -> dict[str, object]:
+        raise httpx.ConnectError("user-service down")
+
+    monkeypatch.setattr(auth_mod, "verify_user_service_token", _boom)
+    c = _client_with_real_guard(tmp_path, factory_spy)
+    resp = c.post(
+        "/admin/reset/stage",
+        json={"stage": "raw"},
+        headers={"Authorization": "Bearer anytoken"},
+    )
+    assert resp.status_code == 503
     assert fake_resetter.calls == []
 
 
@@ -220,7 +275,7 @@ def test_invalid_source_rejected_before_reset(
 
 
 def test_dry_run_writes_audit_without_invoking_resetter(
-    client: TestClient, fake_resetter: _FakeResetter, tmp_path: Path
+    client: TestClient, fake_resetter: _FakeResetter, factory_spy: _FactorySpy, tmp_path: Path
 ) -> None:
     resp = client.post("/admin/reset/full", json={"confirmation": "OBLITERATE", "dry_run": True})
     assert resp.status_code == 200
@@ -232,3 +287,37 @@ def test_dry_run_writes_audit_without_invoking_resetter(
     audit_files = list((tmp_path / "audit").glob("*.json"))
     assert len(audit_files) == 1
     assert Path(body["audit_entry_path"]) == audit_files[0]
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/admin/reset/stage", {"stage": "raw", "dry_run": True}),
+        ("/admin/reset/source", {"source": "sunnah-api", "dry_run": True}),
+        ("/admin/reset/full", {"confirmation": "OBLITERATE", "dry_run": True}),
+    ],
+)
+def test_dry_run_never_builds_the_resetter(
+    client: TestClient,
+    factory_spy: _FactorySpy,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    """Regression (Petra, #73): a dry-run must NOT construct the live resetter.
+
+    The resetter factory builds boto3/Kafka/Neo4j/PG clients (eager Kafka +
+    PG connects). If a route resolved it eagerly, a dry-run preview — the safe
+    affordance ig#970's admin UI calls first — would open those connections.
+    ``build_count == 0`` proves the factory is never invoked on a dry run, so
+    no live client is constructed.
+    """
+    resp = client.post(path, json=payload)
+    assert resp.status_code == 200
+    assert factory_spy.build_count == 0
+
+
+def test_real_reset_builds_the_resetter_once(client: TestClient, factory_spy: _FactorySpy) -> None:
+    """Counterpart: a non-dry-run reset DOES build the resetter (exactly once)."""
+    resp = client.post("/admin/reset/stage", json={"stage": "raw"})
+    assert resp.status_code == 200
+    assert factory_spy.build_count == 1

--- a/tests/test_api/test_reset_endpoints.py
+++ b/tests/test_api/test_reset_endpoints.py
@@ -1,0 +1,234 @@
+"""HTTP-layer tests for the admin reset endpoints (issue #70).
+
+Covers the three contract bars the PR must hold:
+
+1. **Auth gate** — admin-only is enforced (missing header -> 401,
+   non-admin -> 403, admin -> through). The real ``require_admin`` runs;
+   only ``verify_user_service_token`` is stubbed so no JWKS network call.
+2. **Confirmation-required** — the destructive full reset rejects a request
+   that lacks the ``OBLITERATE`` token *before* touching the reset surface.
+3. **Calls the reset surface** — each endpoint drives the real
+   ``PipelineResetter`` with the correct scope, and dry-run still writes an
+   audit entry without invoking the live resetter.
+
+No boto3/Kafka/Neo4j/PG: the resetter and data dir are injected via
+``app.dependency_overrides``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.api.auth as auth_mod
+from src.api.app import create_app
+from src.api.auth import require_admin
+from src.api.deps import get_data_dir, get_resetter
+from src.pipeline.audit import AuditEntry, create_audit_entry
+from src.pipeline.reset import ResetReport, ResetScope
+
+
+class _FakeResetter:
+    """Records the scope/confirmation it was called with; writes no infra."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[ResetScope, str]] = []
+
+    def reset(
+        self, scope: ResetScope, *, confirmation_method: str = "not-required"
+    ) -> tuple[ResetReport, AuditEntry, Path]:
+        self.calls.append((scope, confirmation_method))
+        report = ResetReport(
+            level=scope.level,
+            confirmation_method=confirmation_method,
+            scope_stage=scope.stage,
+            scope_source=scope.source,
+        )
+        entry = create_audit_entry(stage=f"reset-{scope.level}", duration_seconds=0.0)
+        return report, entry, Path("/tmp/fake-audit.json")
+
+
+@pytest.fixture
+def fake_resetter() -> _FakeResetter:
+    return _FakeResetter()
+
+
+@pytest.fixture
+def client(tmp_path: Path, fake_resetter: _FakeResetter) -> TestClient:
+    """App with a fake resetter + tmp data dir, admin guard satisfied."""
+    app = create_app()
+    app.dependency_overrides[get_resetter] = lambda: fake_resetter
+    app.dependency_overrides[get_data_dir] = lambda: tmp_path
+    # Authenticated-admin caller for the non-auth-focused tests.
+    app.dependency_overrides[require_admin] = lambda: "admin-user-id"
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# 1. Auth gate — exercise the REAL require_admin
+# ---------------------------------------------------------------------------
+
+
+def _client_with_real_guard(tmp_path: Path, fake_resetter: _FakeResetter) -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_resetter] = lambda: fake_resetter
+    app.dependency_overrides[get_data_dir] = lambda: tmp_path
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_missing_auth_header_rejected(tmp_path: Path, fake_resetter: _FakeResetter) -> None:
+    c = _client_with_real_guard(tmp_path, fake_resetter)
+    resp = c.post("/admin/reset/stage", json={"stage": "raw"})
+    assert resp.status_code == 401
+    assert fake_resetter.calls == []
+
+
+def test_non_admin_token_forbidden(
+    tmp_path: Path, fake_resetter: _FakeResetter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        auth_mod,
+        "verify_user_service_token",
+        lambda _token: {"type": "access", "sub": "u1", "roles": ["viewer"]},
+    )
+    c = _client_with_real_guard(tmp_path, fake_resetter)
+    resp = c.post(
+        "/admin/reset/stage",
+        json={"stage": "raw"},
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 403
+    assert fake_resetter.calls == []
+
+
+def test_admin_token_allowed(
+    tmp_path: Path, fake_resetter: _FakeResetter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        auth_mod,
+        "verify_user_service_token",
+        lambda _token: {"type": "access", "sub": "admin1", "roles": ["admin"]},
+    )
+    c = _client_with_real_guard(tmp_path, fake_resetter)
+    resp = c.post(
+        "/admin/reset/stage",
+        json={"stage": "raw"},
+        headers={"Authorization": "Bearer admintoken"},
+    )
+    assert resp.status_code == 200
+    assert len(fake_resetter.calls) == 1
+
+
+def test_non_access_token_type_rejected(
+    tmp_path: Path, fake_resetter: _FakeResetter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        auth_mod,
+        "verify_user_service_token",
+        lambda _token: {"type": "refresh", "sub": "admin1", "roles": ["admin"]},
+    )
+    c = _client_with_real_guard(tmp_path, fake_resetter)
+    resp = c.post(
+        "/admin/reset/stage",
+        json={"stage": "raw"},
+        headers={"Authorization": "Bearer refreshtoken"},
+    )
+    assert resp.status_code == 401
+    assert fake_resetter.calls == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Confirmation-required for the destructive full reset
+# ---------------------------------------------------------------------------
+
+
+def test_full_reset_without_confirmation_rejected(
+    client: TestClient, fake_resetter: _FakeResetter
+) -> None:
+    # Field omitted -> 422 (schema requires it), and nothing executed.
+    resp = client.post("/admin/reset/full", json={})
+    assert resp.status_code == 422
+    assert fake_resetter.calls == []
+
+
+def test_full_reset_wrong_confirmation_rejected(
+    client: TestClient, fake_resetter: _FakeResetter
+) -> None:
+    resp = client.post("/admin/reset/full", json={"confirmation": "yes please"})
+    assert resp.status_code == 400
+    assert fake_resetter.calls == []
+
+
+def test_full_reset_with_obliterate_executes(
+    client: TestClient, fake_resetter: _FakeResetter
+) -> None:
+    resp = client.post("/admin/reset/full", json={"confirmation": "OBLITERATE"})
+    assert resp.status_code == 200
+    assert len(fake_resetter.calls) == 1
+    scope, confirmation_method = fake_resetter.calls[0]
+    assert scope.level == "full"
+    # API-supplied OBLITERATE token maps to the CLI's typed-confirm method.
+    assert confirmation_method == "interactive"
+    body: dict[str, Any] = resp.json()
+    assert body["level"] == "full"
+    assert body["confirmation_method"] == "interactive"
+
+
+# ---------------------------------------------------------------------------
+# 3. Endpoints drive the real reset surface with the right scope
+# ---------------------------------------------------------------------------
+
+
+def test_stage_reset_calls_resetter_with_stage_scope(
+    client: TestClient, fake_resetter: _FakeResetter
+) -> None:
+    resp = client.post("/admin/reset/stage", json={"stage": "dedup"})
+    assert resp.status_code == 200
+    scope, method = fake_resetter.calls[0]
+    assert scope.level == "stage"
+    assert scope.stage == "dedup"
+    assert method == "not-required"
+
+
+def test_source_reset_calls_resetter_with_source_scope(
+    client: TestClient, fake_resetter: _FakeResetter
+) -> None:
+    resp = client.post("/admin/reset/source", json={"source": "sunnah-api"})
+    assert resp.status_code == 200
+    scope, _method = fake_resetter.calls[0]
+    assert scope.level == "source"
+    assert scope.source == "sunnah-api"
+
+
+def test_unknown_stage_rejected_before_reset(
+    client: TestClient, fake_resetter: _FakeResetter
+) -> None:
+    resp = client.post("/admin/reset/stage", json={"stage": "bogus"})
+    assert resp.status_code == 422
+    assert fake_resetter.calls == []
+
+
+def test_invalid_source_rejected_before_reset(
+    client: TestClient, fake_resetter: _FakeResetter
+) -> None:
+    resp = client.post("/admin/reset/source", json={"source": "bad/source"})
+    assert resp.status_code == 422
+    assert fake_resetter.calls == []
+
+
+def test_dry_run_writes_audit_without_invoking_resetter(
+    client: TestClient, fake_resetter: _FakeResetter, tmp_path: Path
+) -> None:
+    resp = client.post("/admin/reset/full", json={"confirmation": "OBLITERATE", "dry_run": True})
+    assert resp.status_code == 200
+    # Dry-run goes through write_dry_run_audit, NOT the live resetter.
+    assert fake_resetter.calls == []
+    body = resp.json()
+    assert body["dry_run"] is True
+    # A real audit entry was written under the injected data dir.
+    audit_files = list((tmp_path / "audit").glob("*.json"))
+    assert len(audit_files) == 1
+    assert Path(body["audit_entry_path"]) == audit_files[0]

--- a/uv.lock
+++ b/uv.lock
@@ -376,6 +376,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
+    { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158", size = 3304154, upload-time = "2026-06-09T22:32:16.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24", size = 3817138, upload-time = "2026-06-09T22:32:00.388Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/3e768b4c3bc78201583fa35a0e18f640dd782ff41afba88f8545481a8874/cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345", size = 7989830, upload-time = "2026-06-09T22:31:07.8Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/13/6476736484b94041110c8340a3eb63962fea4975baea8cb4a512adb44d4d/cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4", size = 4689201, upload-time = "2026-06-09T22:31:09.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/62/65a87f34d2a431546e2509b85d55e8c90df86d668f6731da64d538512ac2/cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991", size = 4702822, upload-time = "2026-06-09T22:32:24.409Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/59/810b5204b0a9b10f4b6bc06bd551a8b609803cd931806bc3b71884b225e5/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265", size = 4694875, upload-time = "2026-06-09T22:32:08.737Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/d8ca05ffea724eec6d232ea6f18e74c269eb6bdfdcc9bfba689790d1325f/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17", size = 5290385, upload-time = "2026-06-09T22:31:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8c/3be6cb4da181f5bb6c19cf560c2359d60644a6b5fc5b57854e528f47b296/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411", size = 4737082, upload-time = "2026-06-09T22:32:22.66Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/f6/d5f60a5a1434dbfd949e227fd0065d194c7e6b6ac526b17f5c06152b8231/cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02", size = 4325328, upload-time = "2026-06-09T22:32:10.777Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b7/ba75dd947a14b6ad907b01ae8f6b5b348cdd1b48142f0063dee9e20c1d9d/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa", size = 4694530, upload-time = "2026-06-09T22:31:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/50d6b9e8aff12d8b67afaeb3569335e32dc83a5723e3bbded24fdac9f809/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3", size = 5245046, upload-time = "2026-06-09T22:31:25.774Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/04/618f4115cfc0add0838c82507aa18a346089428da8653ad38b3ff36f5cb3/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c", size = 4736660, upload-time = "2026-06-09T22:32:12.676Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9c/06e062462a0de28a3b3911322eded4c16deb9f441b1b7575d3dc59488ab5/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72", size = 4822229, upload-time = "2026-06-09T22:31:17.062Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/be/0561971eaaee4b8a0e7d5113c536921063ab91aaf23278ac374eaf881e11/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9", size = 4966364, upload-time = "2026-06-09T22:31:32.842Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/27/728c77876f12b000820b69ae490f3c4083775e79e07827e9e60be07ad209/cryptography-48.0.1-cp314-cp314t-win32.whl", hash = "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471", size = 3278498, upload-time = "2026-06-09T22:31:29.154Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/79a612c6d7b1e6ee0edd43633d53035bec2cfb78c82b76f7864f39e36f34/cryptography-48.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2", size = 3798790, upload-time = "2026-06-09T22:31:56.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
+    { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
+    { url = "https://files.pythonhosted.org/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1", size = 3282307, upload-time = "2026-06-09T22:30:53.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac", size = 3793408, upload-time = "2026-06-09T22:32:15.191Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -503,6 +556,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
 
 [[package]]
+name = "ecdsa"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
+]
+
+[[package]]
 name = "editdistance"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -534,6 +599,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/6b/12bb4037921c38bb2c0b4cfc213ca7e04bbbebbfea89b0b5746248ce446e/faiss_cpu-1.13.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b32eb4065bac352b52a9f5ae07223567fab0a976c7d05017c01c45a1c24264f", size = 25102239, upload-time = "2025-12-24T10:27:13.476Z" },
     { url = "https://files.pythonhosted.org/packages/b0/b1/daaab8046f56c60079648bd83774f61b283b59a9930a2f60790ee4cdedfe/faiss_cpu-1.13.2-cp314-cp314-win_amd64.whl", hash = "sha256:c8b645e7d56591aa35dc75415bb53a62e4a494dba010e16f4b67daeffd830bd7", size = 18892621, upload-time = "2025-12-24T10:27:33.923Z" },
     { url = "https://files.pythonhosted.org/packages/06/6f/5eaf3e249c636e616ebb52e369a4a2f1d32b1caf9a611b4f917b3dd21423/faiss_cpu-1.13.2-cp314-cp314-win_arm64.whl", hash = "sha256:8113a2a80b59fe5653cf66f5c0f18be0a691825601a52a614c30beb1fca9bc7c", size = 8556374, upload-time = "2025-12-24T10:27:36.653Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -607,6 +688,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
 ]
 
 [[package]]
@@ -1034,6 +1137,7 @@ source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "kafka-python" },
     { name = "kaggle" },
@@ -1045,11 +1149,13 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "python-jose", extra = ["cryptography"] },
     { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "structlog" },
     { name = "tenacity" },
     { name = "tqdm" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
@@ -1078,6 +1184,7 @@ ml = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "boto3", specifier = ">=1.34" },
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "kafka-python", specifier = ">=2.0" },
     { name = "kaggle", specifier = ">=1.6" },
@@ -1089,11 +1196,13 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pydantic-settings", specifier = ">=2.1" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rapidfuzz", specifier = ">=3.6" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "tenacity", specifier = ">=8.2" },
     { name = "tqdm", specifier = ">=4.66" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
 
 [package.metadata.requires-dev]
@@ -1526,6 +1635,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1725,6 +1843,25 @@ wheels = [
 ]
 
 [[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
+]
+
+[package.optional-dependencies]
+cryptography = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "python-slugify"
 version = "8.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1877,6 +2014,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]
@@ -2057,6 +2206,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -2364,6 +2525,50 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "21.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2379,12 +2584,86 @@ wheels = [
 ]
 
 [[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
 name = "webencodings"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Exposes the pipeline **reset CLI surface** (#9) over HTTP so the isnad-graph admin reset UI (ig#970) can drive pipeline resets. Carved from noorinalabs-main#138 at P4W3 kickoff.

Three admin-only endpoints under `/admin/reset`, each routing through the **real** `PipelineResetter` and emitting an audit entry per call:

| Endpoint | Scope | Body |
|---|---|---|
| `POST /admin/reset/stage`  | one stage's B2 prefix + Kafka offsets | `{stage, dry_run?}` |
| `POST /admin/reset/source` | every stage prefix for one source | `{source, dry_run?}` |
| `POST /admin/reset/full`   | full obliterate (B2 + Kafka + Neo4j + PG) | `{confirmation, dry_run?}` |

## Contract decisions

- **Admin-only** — mirrors the isnad-graph admin restriction: the *same* user-service RS256 JWT (validated against user-service JWKS, role resolved from the `roles` claim) authorizes here. `require_admin` is applied at the router mount, so every reset route is guarded. Non-admin → **403**, missing/invalid/non-`access` token → **401**, JWKS unreachable → **503**. `src/api/auth.py` is a deliberately slimmed copy of isnad-graph's auth path (same role map, JWKS TTL cache, single key-rotation retry).
- **OBLITERATE confirmation preserved at the API boundary** — `/full` rejects any request whose `confirmation != "OBLITERATE"` (**400**) *before* touching the reset surface; a missing field is **422**. The supplied token maps to the CLI's typed-confirm path, recorded as `confirmation_method = "interactive"` for SIEM parity.
- **Audit per call** — real resets via `PipelineResetter.reset`, dry-runs via `write_dry_run_audit` (both emit an entry), matching the CLI exactly.
- **One client builder** — reuses `cli._build_reset_clients`; resetter + data dir are FastAPI deps so the unit suite runs with no boto3/Kafka/Neo4j/PG.

## Endpoint contract for ig#970 (admin UI)

Base path `/admin/reset`. Send `Authorization: Bearer <admin user-service JWT>`. Full reset requires `{"confirmation": "OBLITERATE"}`. All three accept optional `dry_run: true` (validates scope + writes a dry-run audit entry, touches no infra). Response: `{level, dry_run, confirmation_method, audit_entry_path, summary}`. App served via `uvicorn src.api.app:create_app --factory`; unauthenticated `GET /healthz` liveness probe.

## Testing

- `tests/test_api/test_reset_endpoints.py` — 12 tests across the three bars: auth gate (401 / 403 / admin-through / non-access-type), confirmation-required (full reset rejected before the surface is touched), and each endpoint driving the resetter with the correct scope; dry-run writes an audit entry without invoking the live resetter.
- CI-equivalent local run: `mypy src/` clean, `ruff check`/`format --check` clean over `src workers tests`, full suite **617 passed, 3 skipped** (non-integration/non-ml).
- **Live leg** (real MinIO/B2 + Kafka + Neo4j + PG wipe) needs the running stack — covered by the existing reset suite + CLI path. This PR adds and tests the **HTTP layer**; that contract correctness is the PR-time bar.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
