### PR TITLE
infra(deps): bump pip → 26.1.2 to clear PYSEC-2026-196 (#71)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1463,11 +1463,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Standalone advisory-DB-drift dep bump (relocated from noorinalabs-main#633 at P4W3 kickoff). `pip` 26.1.1 — which enters via pip-audit's own deps — picked up **PYSEC-2026-196** after the advisory published, turning the `security-audit` (`pip-audit --strict`) CI check **RED** on every ingest-platform PR without any dep file being touched (e.g. #73 carried this red). `uv.lock` was byte-identical to main and green before the advisory landed.

## Change

The one-liner the issue prescribes:

```
uv lock --upgrade-package pip   # 26.1.1 -> 26.1.2
```

**uv.lock only**, and only pip's version + sdist/wheel hashes — no transitive churn (169 packages resolved, **1** updated). No `pyproject.toml` change (pip is not a direct dep; it rides in via pip-audit).

## Verification

Reproduced the CI `security-audit` job locally at this lock:

```
uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt
uv run pip-audit --strict --desc -r /tmp/requirements.txt
# -> No known vulnerabilities found   (exit 0)
```

Export confirms `pip==26.1.2`. Nothing else moved.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)
