### PR TITLE
feat(reset): distinct confirmation_method=api for HTTP reset (SIEM) (#74)

### DIFF
--- a/src/api/reset_router.py
+++ b/src/api/reset_router.py
@@ -163,8 +163,12 @@ def reset_full(
     """Full obliterate. Rejects the call unless the OBLITERATE token is supplied.
 
     The token is the API-boundary equivalent of the operator typing
-    ``OBLITERATE`` at the CLI prompt, so we record ``confirmation_method =
-    "interactive"`` for SIEM parity with a typed confirmation.
+    ``OBLITERATE`` at the CLI prompt, but it arrives over HTTP rather than a
+    TTY, so we record ``confirmation_method = "api"`` (issue #74) to keep
+    HTTP-driven resets cleanly attributable in SIEM, distinct from a typed
+    CLI confirmation (``"interactive"``). The value is fixed by this endpoint,
+    never read from the request body, so an API reset is honestly attributed
+    and a caller cannot spoof the channel.
     """
     if body.confirmation != OBLITERATE_TOKEN:
         raise HTTPException(
@@ -174,7 +178,7 @@ def reset_full(
 
     return _run_reset(
         ResetScope.full_scope(),
-        confirmation_method="interactive",
+        confirmation_method="api",
         dry_run=body.dry_run,
         resetter_factory=resetter_factory,
         data_dir=data_dir,

--- a/src/pipeline/reset.py
+++ b/src/pipeline/reset.py
@@ -217,8 +217,15 @@ class ResetReport:
         }
 
 
-# Allowed values for ``confirmation_method`` — keep in sync with CLI flag mapping.
-CONFIRMATION_METHODS: frozenset[str] = frozenset({"interactive", "yes-flag", "not-required"})
+# Allowed values for ``confirmation_method`` — keep in sync with CLI flag mapping
+# and the HTTP reset endpoints (``src/api/reset_router.py``). Each value is a
+# distinct authorization channel so SIEM can attribute a reset to how it was
+# triggered:
+#   interactive  — operator typed OBLITERATE at the CLI/TTY prompt
+#   yes-flag     — CLI ``--yes`` runbook automation
+#   not-required — non-obliterate scope (stage/source)
+#   api          — OBLITERATE token supplied via the admin HTTP endpoint
+CONFIRMATION_METHODS: frozenset[str] = frozenset({"interactive", "yes-flag", "not-required", "api"})
 
 
 class PipelineResetter:
@@ -252,8 +259,9 @@ class PipelineResetter:
         """Execute a reset and persist an audit entry.
 
         ``confirmation_method`` records how the operator authorized the run
-        (``"interactive"``, ``"yes-flag"``, or ``"not-required"``) so SIEM
-        can distinguish runbook automation from a typed OBLITERATE confirm.
+        (``"interactive"``, ``"yes-flag"``, ``"not-required"``, or ``"api"``)
+        so SIEM can distinguish runbook automation, a typed OBLITERATE confirm,
+        and an HTTP-driven admin reset from one another.
 
         Returns the report, the audit entry, and the path where the
         audit entry was written.

--- a/tests/test_api/test_reset_endpoints.py
+++ b/tests/test_api/test_reset_endpoints.py
@@ -225,11 +225,13 @@ def test_full_reset_with_obliterate_executes(
     assert len(fake_resetter.calls) == 1
     scope, confirmation_method = fake_resetter.calls[0]
     assert scope.level == "full"
-    # API-supplied OBLITERATE token maps to the CLI's typed-confirm method.
-    assert confirmation_method == "interactive"
+    # Issue #74: the OBLITERATE token over HTTP records the distinct "api"
+    # method (not "interactive") so SIEM can attribute it to the admin endpoint.
+    # The endpoint fixes this value itself — it is not read from the request body.
+    assert confirmation_method == "api"
     body: dict[str, Any] = resp.json()
     assert body["level"] == "full"
-    assert body["confirmation_method"] == "interactive"
+    assert body["confirmation_method"] == "api"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_reset.py
+++ b/tests/test_pipeline/test_reset.py
@@ -410,6 +410,18 @@ class TestAuditSummaryFieldsExplicit:
         summary = json.loads(audit_path.read_text())["summary"]
         assert summary["confirmation_method"] == "interactive"
 
+    def test_confirmation_method_api_recorded(
+        self, resetter: PipelineResetter, tmp_path: Path
+    ) -> None:
+        """Issue #74: an HTTP-driven full reset records ``"api"`` so SIEM can
+        distinguish it from a typed CLI confirmation."""
+        _report, _entry, audit_path = resetter.reset(
+            ResetScope.full_scope(), confirmation_method="api"
+        )
+
+        summary = json.loads(audit_path.read_text())["summary"]
+        assert summary["confirmation_method"] == "api"
+
     def test_confirmation_method_rejects_unknown_value(self, resetter: PipelineResetter) -> None:
         with pytest.raises(ValueError, match="invalid confirmation_method"):
             resetter.reset(ResetScope.stage_scope("raw"), confirmation_method="approved")
@@ -417,7 +429,7 @@ class TestAuditSummaryFieldsExplicit:
     def test_confirmation_methods_enum_locked(self) -> None:
         """Guard test — adding/removing a confirmation method is a contract
         change for downstream SIEM dashboards. Bump intentionally."""
-        assert CONFIRMATION_METHODS == frozenset({"interactive", "yes-flag", "not-required"})
+        assert CONFIRMATION_METHODS == frozenset({"interactive", "yes-flag", "not-required", "api"})
 
     def test_report_carries_new_fields_for_caller_inspection(
         self, resetter: PipelineResetter


### PR DESCRIPTION
Closes #74

## What

The admin `POST /admin/reset/full` endpoint previously recorded `confirmation_method="interactive"` for an OBLITERATE token supplied over HTTP (a contract-valid reuse from #73). SIEM/audit therefore could not distinguish an API-triggered full reset from an operator typing `OBLITERATE` at the CLI/TTY prompt. This adds a distinct `"api"` channel.

## Changes

- **`src/pipeline/reset.py`** — add `"api"` to `CONFIRMATION_METHODS` frozenset; update docstrings. The four channels are now:
  - `interactive` — operator typed OBLITERATE at the CLI/TTY prompt
  - `yes-flag` — CLI `--yes` runbook automation
  - `not-required` — non-obliterate scope (stage/source)
  - **`api`** — OBLITERATE token supplied via the admin HTTP endpoint
- **`src/api/reset_router.py`** — `/full` now records `confirmation_method="api"` (was `"interactive"`).
- **tests** — `test_confirmation_methods_enum_locked` guard bumped; new `test_confirmation_method_api_recorded`; endpoint test asserts `"api"`.

## Security / audit lens

The `"api"` value is **fixed by the `/full` endpoint itself** — it is never read from the request body (`FullResetRequest` uses `extra="forbid"` and only accepts `confirmation` + `dry_run`). So a real API reset is honestly attributed and a caller cannot spoof the channel.

## SIEM coordination (acceptance item)

Per the issue, isnad-graph SIEM consumers that filter on `confirmation_method` must learn the new `"api"` value (ig#971) so admin-driven full resets are not misclassified/invisible. Flagging for cross-repo coordination, not drift.

## Reviewers

@Léopold Mbongo (primary) + @Petra Vidović (secondary)

## Test Plan

- `ENVIRONMENT=test uv run pytest tests/test_pipeline/test_reset.py tests/test_api/test_reset_endpoints.py` — 44 passed
- `ruff format --check` + `ruff check` — clean
- `mypy src/pipeline/reset.py src/api/reset_router.py` — no issues
