### PR TITLE
fix(reset): _delete_prefix works against real MinIO/B2 (MissingContentMD5) (#69)

### DIFF
--- a/src/pipeline/reset.py
+++ b/src/pipeline/reset.py
@@ -391,7 +391,15 @@ def _delete_prefix(store: _ObjectStoreProto, prefix: S3Prefix) -> int:
     """Delete every object under ``prefix`` in ``store.bucket``.
 
     Returns the number of objects deleted. Uses the paginated ``list_objects_v2``
-    surface so very large prefixes don't blow past a single-response limit.
+    surface so very large prefixes don't blow past a single-response limit, and
+    removes each key with the per-object ``delete_object`` (S3 ``DeleteObject``)
+    rather than the bulk ``delete_objects`` (``DeleteObjects``). The bulk op
+    requires a ``Content-MD5``/checksum header that boto3 (botocore>=1.36) no
+    longer adds by default, so real S3-compatible stores (MinIO, Backblaze B2)
+    reject it with ``MissingContentMD5`` — AWS S3 happens to be lenient, which
+    is why it slipped through. ``DeleteObject`` carries no such requirement and
+    matches the per-object delete ``ObjectStore.rename_object`` already uses
+    (#69).
     """
     client = store.client
     deleted = 0
@@ -403,10 +411,9 @@ def _delete_prefix(store: _ObjectStoreProto, prefix: S3Prefix) -> int:
             kwargs["ContinuationToken"] = continuation
         response = client.list_objects_v2(**kwargs)
         contents = response.get("Contents", []) or []
-        if contents:
-            to_delete = [{"Key": obj["Key"]} for obj in contents]
-            client.delete_objects(Bucket=store.bucket, Delete={"Objects": to_delete, "Quiet": True})
-            deleted += len(to_delete)
+        for obj in contents:
+            client.delete_object(Bucket=store.bucket, Key=obj["Key"])
+            deleted += 1
         if not response.get("IsTruncated"):
             break
         continuation = response.get("NextContinuationToken")

--- a/tests/integration/test_minio_reset_delete.py
+++ b/tests/integration/test_minio_reset_delete.py
@@ -1,0 +1,121 @@
+"""Focused real-MinIO regression guard for ``reset._delete_prefix`` (#69).
+
+``src/pipeline/reset._delete_prefix`` wipes a stage's objects during an admin
+reset. It used the bulk ``delete_objects`` (S3 ``DeleteObjects``) op, which
+boto3 (botocore>=1.36) no longer auto-signs with a ``Content-MD5``/checksum
+header — so real S3-compatible stores (MinIO, Backblaze B2) reject it with
+``MissingContentMD5``. AWS S3 is lenient, and the unit suite's ``FakeS3Client``
+is in-memory, so the defect only shows against a *real* store.
+
+The full ``dedup→…→ingest`` chain E2E
+(``test_worker_chain_e2e.test_admin_stage_reset_wipes_only_normalized_prefix_on_real_minio``)
+also guards this, but stands up THREE containers (Kafka, MinIO, Neo4j). This
+module isolates the object-store delete path against a SINGLE MinIO container so
+the regression is caught fast, without the chain or the Kafka/Neo4j stack — a
+test that would have failed (``MissingContentMD5``) before the per-object
+``delete_object`` fix and passes after.
+
+Runtime requirement
+-------------------
+``@pytest.mark.integration`` — needs Docker (testcontainers spins up a MinIO
+container). Excluded from the default ``pytest -m "not integration"`` run;
+runs via ``make test-integration``. ``importorskip`` on
+``testcontainers.minio`` / ``boto3`` keeps a Docker-less lane collecting cleanly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+pytest.importorskip("testcontainers.minio")
+pytest.importorskip("boto3")
+
+import boto3  # noqa: E402
+from botocore.config import Config  # noqa: E402
+from testcontainers.minio import MinioContainer  # noqa: E402
+
+from src.pipeline.reset import _delete_prefix  # noqa: E402
+from workers.lib.object_store import ObjectStore  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+TEST_BUCKET = "noorinalabs-pipeline"
+
+
+@pytest.fixture(scope="module")
+def minio_container() -> Iterator[MinioContainer]:
+    with MinioContainer(access_key="minio", secret_key="minio12345") as minio:
+        yield minio
+
+
+@pytest.fixture
+def minio_store(minio_container: MinioContainer) -> ObjectStore:
+    """Real ``ObjectStore`` (boto3) on the MinIO container, bucket pre-created.
+
+    Path-style addressing because MinIO does not serve virtual-host bucket
+    subdomains.
+    """
+    cfg = minio_container.get_config()
+    client = boto3.client(
+        "s3",
+        endpoint_url=f"http://{cfg['endpoint']}",
+        aws_access_key_id=cfg["access_key"],
+        aws_secret_access_key=cfg["secret_key"],
+        region_name="us-east-1",
+        config=Config(s3={"addressing_style": "path"}),
+    )
+    try:
+        client.create_bucket(Bucket=TEST_BUCKET)
+    except client.exceptions.BucketAlreadyOwnedByYou:
+        pass
+    return ObjectStore(bucket=TEST_BUCKET, client=client)
+
+
+def _keys_under(store: ObjectStore, prefix: str) -> list[str]:
+    resp = store.client.list_objects_v2(Bucket=store.bucket, Prefix=prefix)
+    return sorted(obj["Key"] for obj in resp.get("Contents", []) or [])
+
+
+def test_delete_prefix_against_real_minio_no_missing_content_md5(
+    minio_store: ObjectStore,
+) -> None:
+    """``_delete_prefix`` wipes only its prefix on a real store, no MD5 error.
+
+    Before the fix this raised ``botocore ... MissingContentMD5`` on the bulk
+    ``delete_objects`` call; the per-object ``delete_object`` path carries no
+    such requirement, so the prefix is emptied and the sibling prefix survives.
+    """
+    for key in ("normalized/sunnah/b1/f.parquet", "normalized/sunnah/b2/f.parquet"):
+        minio_store.put_object(key, b"x")
+    # A sibling prefix that must NOT be touched by the scoped delete.
+    minio_store.put_object("raw/sunnah/b1/f.parquet", b"x")
+
+    assert len(_keys_under(minio_store, "normalized/")) == 2
+
+    deleted = _delete_prefix(minio_store, "normalized/")
+
+    assert deleted == 2
+    assert _keys_under(minio_store, "normalized/") == []
+    assert _keys_under(minio_store, "raw/") == ["raw/sunnah/b1/f.parquet"]
+
+
+def test_delete_prefix_paginates_past_single_response_on_real_minio(
+    minio_store: ObjectStore,
+) -> None:
+    """Deletes every key when the listing spans multiple list_objects_v2 pages.
+
+    S3/MinIO cap ``list_objects_v2`` at 1000 keys per response; seed >1000 so
+    the resetter's continuation-token loop is exercised against the real store
+    and every object is removed (not just the first page).
+    """
+    page = "paged/"
+    seeded = [f"{page}{i:05d}.parquet" for i in range(1001)]
+    for key in seeded:
+        minio_store.put_object(key, b"x")
+
+    deleted = _delete_prefix(minio_store, page)
+
+    assert deleted == len(seeded)
+    assert _keys_under(minio_store, page) == []

--- a/tests/integration/test_worker_chain_e2e.py
+++ b/tests/integration/test_worker_chain_e2e.py
@@ -365,19 +365,6 @@ def test_streaming_hadith_id_matches_batch_loader_through_real_neo4j(
     assert all("sunnah:sunnah" not in i for i in ids), "corpus prefix doubled (#63)"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "BUG (#69): src/pipeline/reset._delete_prefix "
-        "calls client.delete_objects() which a real S3-compatible store (MinIO, "
-        "and B2) rejects with 'MissingContentMD5' under botocore>=1.36 — the bulk "
-        "DeleteObjects op needs a Content-MD5/checksum header boto3 no longer adds "
-        "by default. The unit suite never caught it because FakeS3Client.delete_"
-        "objects is an in-memory no-op. This integration scenario is the regression "
-        "guard; remove the xfail once reset uses per-object delete_object (which "
-        "ObjectStore already does) or sets the checksum header."
-    ),
-)
 def test_admin_stage_reset_wipes_only_normalized_prefix_on_real_minio(
     bootstrap: str,
     minio_store: ObjectStore,
@@ -390,8 +377,12 @@ def test_admin_stage_reset_wipes_only_normalized_prefix_on_real_minio(
     objects — the upstream raw/ and dedup/ payloads survive, so the stage can be
     re-run without re-acquiring or re-deduping. The unit suite proves the reset
     *logic* against ``FakeS3Client``; this proves it against the real
-    ``list_objects_v2`` / ``delete_objects`` S3 surface the resetter calls — and
-    currently surfaces a real defect in that surface (see the ``xfail`` reason).
+    ``list_objects_v2`` / ``delete_object`` S3 surface the resetter calls.
+
+    Was ``xfail(strict)`` while ``_delete_prefix`` used the bulk
+    ``delete_objects`` (``DeleteObjects``), which MinIO/B2 reject with
+    ``MissingContentMD5`` under botocore>=1.36; un-xfail'd once the resetter
+    switched to per-object ``delete_object`` (#69).
     """
     from src.pipeline.reset import (
         STAGE_PREFIXES,

--- a/tests/test_pipeline/test_reset.py
+++ b/tests/test_pipeline/test_reset.py
@@ -25,7 +25,12 @@ from src.pipeline.reset import (
 
 
 class _FakeS3Client:
-    """In-memory S3 client supporting ``list_objects_v2`` + ``delete_objects``."""
+    """In-memory S3 client supporting ``list_objects_v2`` + ``delete_object``.
+
+    Models the per-object ``delete_object`` (``DeleteObject``) surface the
+    resetter uses — NOT the bulk ``delete_objects``, which real S3-compatible
+    stores reject with ``MissingContentMD5`` under botocore>=1.36 (#69).
+    """
 
     def __init__(self, objects: dict[tuple[str, str], bytes] | None = None) -> None:
         self.objects: dict[tuple[str, str], bytes] = dict(objects or {})
@@ -39,10 +44,9 @@ class _FakeS3Client:
             "IsTruncated": False,
         }
 
-    def delete_objects(self, *, Bucket: str, Delete: dict[str, Any]) -> dict[str, Any]:
-        for obj in Delete["Objects"]:
-            self.objects.pop((Bucket, obj["Key"]), None)
-        return {"Deleted": Delete["Objects"]}
+    def delete_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:
+        self.objects.pop((Bucket, Key), None)
+        return {}
 
 
 class _FakeStore:


### PR DESCRIPTION
Closes #69

## Problem
`src/pipeline/reset._delete_prefix` (reset.py:~390) wiped a stage's objects during admin reset via the **bulk** `client.delete_objects(...)` (S3 `DeleteObjects`). Under **botocore ≥ 1.36**, boto3 no longer auto-adds the `Content-MD5`/checksum header that the bulk op requires, so real S3-compatible stores (**MinIO, Backblaze B2**) reject the request with **`MissingContentMD5`**. AWS S3 is lenient, which is why it wasn't caught against AWS. Net: admin stage-reset was broken against any real object store — it only "passed" because the unit suite's `FakeS3Client` is an in-memory no-op (a test-mock-masks-production-failure, same class as da#77 null-MERGE and ig#63 id double-prefix this wave).

## Fix
Delete each key under the prefix with the per-object **`delete_object`** (`DeleteObject`) — which carries no `Content-MD5` requirement and matches the per-object delete `ObjectStore.rename_object` already uses (`workers/lib/object_store.py:152`). The paginated `list_objects_v2` continuation loop is unchanged, so large/truncated listings still page through fully.

```diff
-        if contents:
-            to_delete = [{"Key": obj["Key"]} for obj in contents]
-            client.delete_objects(Bucket=store.bucket, Delete={"Objects": to_delete, "Quiet": True})
-            deleted += len(to_delete)
+        for obj in contents:
+            client.delete_object(Bucket=store.bucket, Key=obj["Key"])
+            deleted += 1
```

## How it's tested (against a real-ish client, not the masking mock)
- **New `tests/integration/test_minio_reset_delete.py`** — drives `_delete_prefix` against a **real testcontainers MinIO** container (single container, fast; vs the 3-container chain E2E). Case 1: seeds two keys under `normalized/` + a sibling `raw/` key, asserts the prefix is emptied, the sibling survives, count is correct, **no `MissingContentMD5`**. Case 2: seeds >1000 keys to exercise the continuation-token pagination path against the real store.
  - **Bug-catch verified:** temporarily reverting `_delete_prefix` to the old bulk `delete_objects` makes this test fail with exactly `botocore.exceptions.ClientError: ... (MissingContentMD5) ... DeleteObjects ... Missing required header ... Content-Md5`. With the per-object fix it passes. So the test genuinely guards the regression — it is not a no-op like the old fake.
- **Un-xfail'd** the #67 real-MinIO reset→rerun scenario in `tests/integration/test_worker_chain_e2e.py` (`test_admin_stage_reset_wipes_only_normalized_prefix_on_real_minio`) — the full-chain regression guard the issue referenced. Removed the strict-xfail and refreshed its docstring.
- **Updated the unit `FakeS3Client`** (`tests/test_pipeline/test_reset.py`) to model `delete_object` rather than bulk `delete_objects`, so the fake tracks the production surface and can't re-mask the bug.

### Test results (this branch, run locally with Docker)
- `tests/test_pipeline/test_reset.py` — **26 passed**
- `tests/integration/test_minio_reset_delete.py` (real MinIO) — **2 passed**
- ruff 0.15.11 format `--check` + lint — clean; `mypy src/pipeline/reset.py` — clean.

## Serial-merge note (for the wave coordinator)
This PR touches `src/pipeline/reset.py` **only inside `_delete_prefix` (~L390–417)** and `_FakeS3Client` in the unit test. ingest#74 (Kalinda) touches the `CONFIRMATION_METHODS` constant / `_validate_confirmation_method` (~L380, a different region of the same file) — **non-overlapping**, so the two should merge cleanly in either order. Flagging for sequencing per the brief.

## Reviewers
@Léopold Mbongo (primary) · @Petra Vidović (secondary)

## Test Plan
- [x] Per-object delete path emties a prefix against real MinIO with no `MissingContentMD5`
- [x] Sibling prefixes survive a scoped delete; deleted-count is exact
- [x] Pagination (>1000 keys) deletes every object
- [x] #67 real-MinIO reset→rerun scenario flips xfail→pass
- [x] Unit suite green with the `delete_object` fake
- [ ] (CI) integration lane runs the new test where Docker is available (`make test-integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
