### PR TITLE
fix(normalize): consume shared hadith_node_id() — no double corpus prefix (#72)

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import pyarrow.parquet as pq
 
+from src.parse.identity import hadith_node_id
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
 
@@ -242,7 +243,7 @@ def _load_narrated(
 
     batch: list[dict[str, Any]] = []
     for hid, (_pos, nid) in first_narrators.items():
-        full_hid = f"hdt:{hid}" if not hid.startswith("hdt:") else hid
+        full_hid = hadith_node_id(hid)
         batch.append({"narrator_id": nid, "hadith_id": full_hid})
 
     if not batch:
@@ -321,7 +322,7 @@ def _load_appears_in(
             if not sid or not cname:
                 skipped += 1
                 continue
-            hid = f"hdt:{sid}" if not sid.startswith("hdt:") else sid
+            hid = hadith_node_id(sid)
             # Collection IDs in staging use "{corpus}:{name}" format (e.g. "lk:bukhari").
             # Build the same key so we match the Collection nodes that were loaded.
             corpus = row.get("source_corpus", "")
@@ -413,8 +414,8 @@ def _load_parallel_of(
             skipped += 1
             continue
         # Ensure lower ID -> higher ID for consistent directionality
-        full_a = f"hdt:{id_a}" if not id_a.startswith("hdt:") else id_a
-        full_b = f"hdt:{id_b}" if not id_b.startswith("hdt:") else id_b
+        full_a = hadith_node_id(id_a)
+        full_b = hadith_node_id(id_b)
         if full_a > full_b:
             full_a, full_b = full_b, full_a
         batch.append(
@@ -575,7 +576,7 @@ def _load_graded_by(
             if not sid:
                 skipped += 1
                 continue
-            hid = f"hdt:{sid}" if not sid.startswith("hdt:") else sid
+            hid = hadith_node_id(sid)
             gid = f"grd:{sid}"
             batch.append({"hadith_id": hid, "grading_id": gid})
 

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -15,6 +15,7 @@ from typing import Any
 import pyarrow.parquet as pq
 import yaml
 
+from src.parse.identity import hadith_node_id
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
 
@@ -189,7 +190,7 @@ def _load_hadiths(
                 all_errors.append(f"{fp.name} row {i}: invalid source_id={sid!r}")
                 total_skipped += 1
                 continue
-            hid = f"hdt:{sid}" if not sid.startswith("hdt:") else sid
+            hid = hadith_node_id(sid)
             batch.append(
                 {
                     "id": hid,
@@ -364,7 +365,7 @@ def _load_chains(
         batch.append(
             {
                 "id": chn_id,
-                "hadith_id": f"hdt:{hid}" if not hid.startswith("hdt:") else hid,
+                "hadith_id": hadith_node_id(hid),
                 "chain_index": 0,
                 "full_chain_text_ar": None,
                 "full_chain_text_en": None,
@@ -437,7 +438,7 @@ def _load_gradings(
             batch.append(
                 {
                     "id": gid,
-                    "hadith_id": f"hdt:{sid}" if not sid.startswith("hdt:") else sid,
+                    "hadith_id": hadith_node_id(sid),
                     "scholar_name": _val(row, "collection_name", "unknown"),
                     "grade": grade,
                     "methodology_school": None,

--- a/src/parse/identity.py
+++ b/src/parse/identity.py
@@ -1,0 +1,252 @@
+"""Canonical entity-identity contract for the ingest pipeline.
+
+.. note:: **Vendored mirror.** The canonical source of this module lives in
+   ``noorinalabs-data-acquisition`` at ``src/parse/identity.py`` (introduced by
+   da#82 / PR #102 as the single source of truth for the id grammar). This repo
+   vendors a faithful copy — exactly like ``src/parse/schemas.py`` and
+   ``src/parse/narrator_extraction.py`` — because there is no cross-repo import
+   path between the two packages (both root their package at ``src``). Keep the
+   two byte-for-byte in sync; any divergence re-opens the main#139 double-prefix
+   hazard this module exists to close. The streaming/normalize worker
+   (``workers/normalize/processor.py``) and the in-repo batch loaders
+   (``src/graph/load_{nodes,edges}.py``) all consume :func:`hadith_node_id` from
+   here so a hadith yields exactly one graph node id across every path (#72).
+
+This module is the **single source of truth** for how a ``source_id`` and every
+graph node id is constructed, across *all* ingest paths (the batch
+``src/graph`` loaders here, and the streaming/normalize path in
+``noorinalabs-isnad-ingest-platform``). It is the keystone for da#82 / epic
+da#81: every per-source light-up builds to the grammar defined here.
+
+Grammar
+-------
+``source_id`` (staging key, ``HADITH_SCHEMA.source_id``)::
+
+    <corpus>:<collection>[:<part>...]
+
+* ``<corpus>``     one of :data:`SOURCE_CORPORA` (the ``SourceCorpus`` enum) —
+  the namespace that makes ids collision-safe across sources.
+* ``<collection>`` per-corpus collection slug (e.g. ``"bukhari"``).
+* ``<part>...``    positional disambiguators (``book:chapter:ordinal``, or a
+  per-row index for dataset sources). The corpus appears **exactly once**, as
+  the leading segment.
+
+Graph node ids = ``<type-prefix><bare-id>``::
+
+    Hadith         hdt:<source_id>
+    Collection     col:<corpus>:<collection>
+    Narrator       nar:<canonical-id>
+    Chain          chn:<source_id>-<index>
+    Grading        grd:<source_id>
+
+Two historical identity hazards this module designs out
+-------------------------------------------------------
+1. **Double-prefix** (main#139): the streaming/normalize path prepended the
+   corpus a second time (``hdt:sunnah:sunnah:...``) while the batch loader did
+   not, so the *same* hadith became two graph nodes (toy ``h-1`` fixtures masked
+   it). :func:`hadith_node_id` is the ONE prefixing rule both paths call: it is
+   idempotent on the ``hdt:`` prefix **and** collapses an accidentally doubled
+   leading corpus, so both paths converge on exactly one id per hadith.
+2. **collection-ref vs in-book-ordinal** (da#77): ``source_id``'s positional
+   tail is a stable within-collection key. The *in-book ordinal* that flows to
+   ``APPEARS_IN.hadith_number_in_book`` is the staging ``hadith_number`` column —
+   **not** the collection-wide reference number (sunnah.com exposes both). See
+   ``HADITH_SCHEMA`` and ``src/graph/load_edges.py`` ``_APPEARS_IN_QUERY``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from src.models.enums import SourceCorpus
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "SOURCE_CORPORA",
+    "HADITH_ID_PREFIX",
+    "COLLECTION_ID_PREFIX",
+    "NARRATOR_ID_PREFIX",
+    "CHAIN_ID_PREFIX",
+    "GRADING_ID_PREFIX",
+    "ID_DELIMITER",
+    "apply_prefix",
+    "bare_source_id",
+    "hadith_node_id",
+    "collection_node_id",
+    "narrator_node_id",
+    "chain_node_id",
+    "grading_node_id",
+    "is_double_prefixed",
+    "validate_source_id",
+    "CANONICAL_NAMESPACE",
+    "make_canonical_id",
+]
+
+# Fixed UUID5 namespace for canonical Narrator ids. A canonical narrator's id is
+# ``nar:<uuid5(CANONICAL_NAMESPACE, normalized-name)>`` — deterministic from the
+# narrator's normalized name so every producer (the mention-driven disambiguator
+# in ``src/resolve/disambiguate.py`` and the bio-direct promoter in
+# ``src/resolve/bio_promote.py``) that sees the same name converges on the same
+# Narrator node. This namespace value is load-bearing: changing it re-keys every
+# existing canonical narrator, so it is pinned here as the single source of truth.
+CANONICAL_NAMESPACE = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+# The corpus namespace — derived from the enum so the two never drift. Note that
+# ``sunnah_scraped`` intentionally shares the ``sunnah`` corpus (the scraper and
+# the API describe the same collections, so a shared namespace lets the same
+# hadith dedup to one node).
+SOURCE_CORPORA: frozenset[str] = frozenset(c.value for c in SourceCorpus)
+
+ID_DELIMITER = ":"
+
+HADITH_ID_PREFIX = "hdt:"
+COLLECTION_ID_PREFIX = "col:"
+NARRATOR_ID_PREFIX = "nar:"
+CHAIN_ID_PREFIX = "chn:"
+GRADING_ID_PREFIX = "grd:"
+
+# Every graph type-prefix, longest-first so a stripping pass is unambiguous.
+_TYPE_PREFIXES = (
+    HADITH_ID_PREFIX,
+    COLLECTION_ID_PREFIX,
+    NARRATOR_ID_PREFIX,
+    CHAIN_ID_PREFIX,
+    GRADING_ID_PREFIX,
+)
+
+
+def apply_prefix(value: str, prefix: str) -> str:
+    """Idempotently prepend *prefix* to *value*.
+
+    Replaces the ``f"{p}{v}" if not v.startswith(p) else v`` idiom that was
+    duplicated across every loader. Idempotent: applying the same prefix twice
+    yields the same string.
+    """
+    return value if value.startswith(prefix) else f"{prefix}{value}"
+
+
+def _collapse_double_corpus(body: str) -> str:
+    """Collapse a doubled (or N-times repeated) leading corpus segment.
+
+    ``"sunnah:sunnah:bukhari:1"`` -> ``"sunnah:bukhari:1"``. Only collapses when
+    the repeated leading segment is a *known* corpus, so legitimate repeated
+    slugs deeper in an id (or a non-corpus first segment) are never touched.
+    Emits a warning when it collapses — a collapse means an upstream producer
+    bypassed the canonical builder (the main#139 streaming-path bug), which the
+    operator should still see.
+    """
+    segments = body.split(ID_DELIMITER)
+    collapsed = 0
+    while len(segments) >= 2 and segments[0] in SOURCE_CORPORA and segments[0] == segments[1]:
+        segments.pop(0)
+        collapsed += 1
+    if collapsed:
+        logger.warning(
+            "collapsed_double_corpus_prefix",
+            original=body,
+            canonical=ID_DELIMITER.join(segments),
+            collapsed_segments=collapsed,
+        )
+    return ID_DELIMITER.join(segments)
+
+
+def bare_source_id(value: str) -> str:
+    """Return the canonical *bare* ``source_id`` for *value*.
+
+    Strips a leading ``hdt:`` graph prefix if present, then collapses any
+    doubled leading corpus. This is the single canonicalization point shared by
+    :func:`hadith_node_id`, :func:`chain_node_id` and :func:`grading_node_id`,
+    so every hadith-derived id agrees on one identity for a given hadith.
+    """
+    body = value[len(HADITH_ID_PREFIX) :] if value.startswith(HADITH_ID_PREFIX) else value
+    return _collapse_double_corpus(body)
+
+
+def hadith_node_id(source_id: str) -> str:
+    """Canonical Hadith graph node id for a staging ``source_id``.
+
+    THE one prefixing rule for Hadith nodes — every ingest path (batch loaders,
+    streaming normalize) must route through this so the same hadith yields
+    exactly one node id. Idempotent, and collapses the main#139 double-prefix.
+    """
+    return f"{HADITH_ID_PREFIX}{bare_source_id(source_id)}"
+
+
+def collection_node_id(collection_id: str) -> str:
+    """Canonical Collection graph node id (``col:<corpus>:<collection>``)."""
+    return apply_prefix(collection_id, COLLECTION_ID_PREFIX)
+
+
+def narrator_node_id(canonical_id: str) -> str:
+    """Canonical Narrator graph node id (``nar:<canonical-id>``)."""
+    return apply_prefix(canonical_id, NARRATOR_ID_PREFIX)
+
+
+def make_canonical_id(name_normalized: str) -> str:
+    """Deterministic canonical Narrator id from a *normalized* name.
+
+    Returns ``nar:<uuid5(CANONICAL_NAMESPACE, name_normalized)>``. THE one rule
+    for minting a canonical narrator id — both the mention-driven disambiguator
+    (``src/resolve/disambiguate.py``) and the bio-direct promoter
+    (``src/resolve/bio_promote.py``) route through it so the same normalized name
+    always maps to the same Narrator node (and the ``nar:`` prefix the graph
+    loader ``load_nodes._load_narrators`` validates on import). The input must be
+    pre-normalized (see ``src.utils.arabic.normalize_arabic``) so equivalent
+    spellings collapse to one id.
+    """
+    return narrator_node_id(str(uuid.uuid5(CANONICAL_NAMESPACE, name_normalized)))
+
+
+def chain_node_id(source_id: str, index: int = 0) -> str:
+    """Canonical Chain graph node id (``chn:<source_id>-<index>``)."""
+    if source_id.startswith(CHAIN_ID_PREFIX):
+        return source_id
+    return f"{CHAIN_ID_PREFIX}{bare_source_id(source_id)}-{index}"
+
+
+def grading_node_id(source_id: str) -> str:
+    """Canonical Grading graph node id (``grd:<source_id>``)."""
+    return f"{GRADING_ID_PREFIX}{bare_source_id(source_id)}"
+
+
+def is_double_prefixed(node_id: str) -> bool:
+    """True if *node_id* carries a doubled leading corpus (the main#139 bug).
+
+    Strict detector for tests / CI — unlike :func:`bare_source_id` it does not
+    repair, it only reports, so a guard can fail loudly on a producer that
+    emits doubled ids.
+    """
+    body = node_id
+    for prefix in _TYPE_PREFIXES:
+        if body.startswith(prefix):
+            body = body[len(prefix) :]
+            break
+    segments = body.split(ID_DELIMITER)
+    return len(segments) >= 2 and segments[0] in SOURCE_CORPORA and segments[0] == segments[1]
+
+
+def validate_source_id(source_id: str) -> list[str]:
+    """Return a list of contract violations for *source_id* (empty == valid).
+
+    Checks the grammar: a known leading corpus, at least a collection segment,
+    no empty segments, and no doubled leading corpus. Used by the builder and by
+    tests to assert collision-safety across all 8 sources.
+    """
+    problems: list[str] = []
+    if not source_id:
+        return ["source_id is empty"]
+    segments = source_id.split(ID_DELIMITER)
+    if segments[0] not in SOURCE_CORPORA:
+        problems.append(
+            f"leading segment {segments[0]!r} is not a known corpus "
+            f"(expected one of {sorted(SOURCE_CORPORA)})"
+        )
+    if len(segments) < 2:
+        problems.append("source_id has no collection segment")
+    if any(seg == "" for seg in segments):
+        problems.append("source_id has an empty segment")
+    if is_double_prefixed(source_id):
+        problems.append(f"source_id has a doubled leading corpus: {source_id!r}")
+    return problems

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -114,6 +114,34 @@ class TestLoadHadiths:
         assert len(hadith_batches) >= 1
         assert hadith_batches[0][0]["id"] == "hdt:bukhari-1"
 
+    def test_doubled_corpus_source_id_collapses(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """Batch loader collapses an already-doubled corpus prefix (#72).
+
+        The loader now keys the Hadith node via the shared
+        ``src.parse.identity.hadith_node_id`` rather than the old
+        ``f"hdt:{sid}"`` guard, so a staging ``sunnah:sunnah:bukhari:1`` (the
+        main#139 hazard) collapses to ``hdt:sunnah:bukhari:1`` — the SAME id the
+        streaming/normalize path emits, so both MERGE one node. A realistic
+        corpus-prefixed id is used on purpose: the toy ``bukhari-1`` / ``h-1``
+        fixtures elsewhere have no corpus segment and cannot exercise this bug.
+        """
+        write_hadiths(staging_dir, [{"source_id": "sunnah:sunnah:bukhari:1"}])
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        hadith_batches = [
+            batch
+            for query, batch in mock_client.calls
+            if isinstance(batch, list)
+            and batch
+            and "id" in batch[0]
+            and batch[0]["id"].startswith("hdt:")
+        ]
+        assert len(hadith_batches) >= 1
+        loaded_id = hadith_batches[0][0]["id"]
+        assert loaded_id == "hdt:sunnah:bukhari:1"
+        assert "sunnah:sunnah" not in loaded_id
+
     def test_invalid_source_id_skipped(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:

--- a/tests/test_parse/test_identity.py
+++ b/tests/test_parse/test_identity.py
@@ -1,0 +1,87 @@
+"""Tests for the vendored ``src.parse.identity`` contract.
+
+This module is a faithful mirror of the canonical contract in
+``noorinalabs-data-acquisition`` (``src/parse/identity.py``). These tests pin
+the behaviour the ingest pipeline relies on — chiefly that ``hadith_node_id`` is
+the ONE prefixing rule both the streaming/normalize worker and the in-repo batch
+loaders route through, so a hadith yields exactly one graph node id regardless of
+path (#72 / main#139 double-prefix hazard).
+
+The fixtures deliberately use realistic corpus-prefixed ids
+(``sunnah:bukhari:1``) rather than toy ``h-1`` ids: a bare ``h-1`` has no corpus
+segment and would mask the exact double-prefix bug this contract exists to close.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.parse.identity import (
+    bare_source_id,
+    hadith_node_id,
+    is_double_prefixed,
+    validate_source_id,
+)
+
+
+class TestHadithNodeId:
+    def test_prefixes_bare_source_id(self) -> None:
+        assert hadith_node_id("sunnah:bukhari:1") == "hdt:sunnah:bukhari:1"
+
+    def test_idempotent_on_hdt_prefix(self) -> None:
+        # Already-prefixed input must not gain a second ``hdt:``.
+        assert hadith_node_id("hdt:sunnah:bukhari:1") == "hdt:sunnah:bukhari:1"
+
+    def test_collapses_doubled_corpus(self) -> None:
+        # The headline #72 / main#139 case: a doubled leading corpus collapses
+        # so the streaming and batch paths converge on one id. The old ad-hoc
+        # ``f"hdt:{sid}"`` guard would have produced ``hdt:sunnah:sunnah:...``.
+        assert hadith_node_id("sunnah:sunnah:bukhari:1") == "hdt:sunnah:bukhari:1"
+
+    def test_collapses_doubled_corpus_even_with_hdt_prefix(self) -> None:
+        assert hadith_node_id("hdt:sunnah:sunnah:bukhari:1") == "hdt:sunnah:bukhari:1"
+
+    def test_collapses_triple_corpus(self) -> None:
+        assert hadith_node_id("sunnah:sunnah:sunnah:bukhari:1") == "hdt:sunnah:bukhari:1"
+
+    def test_streaming_and_batch_converge_on_doubled_input(self) -> None:
+        # Both ingest paths now call this one helper, so a doubled staging id
+        # produces a single shared node id rather than two divergent nodes.
+        doubled = "sunnah:sunnah:bukhari:1"
+        clean = "sunnah:bukhari:1"
+        assert hadith_node_id(doubled) == hadith_node_id(clean)
+
+    def test_does_not_touch_repeated_non_leading_segment(self) -> None:
+        # A repeated slug that isn't a doubled *leading corpus* is legitimate
+        # and must be preserved (only the leading corpus collapses).
+        assert hadith_node_id("sunnah:bukhari:bukhari:1") == "hdt:sunnah:bukhari:bukhari:1"
+
+    def test_does_not_collapse_non_corpus_leading_repeat(self) -> None:
+        # ``foo`` is not a known corpus, so a doubled ``foo`` is left alone.
+        assert hadith_node_id("foo:foo:bar") == "hdt:foo:foo:bar"
+
+
+class TestBareSourceId:
+    def test_strips_hdt_and_collapses(self) -> None:
+        assert bare_source_id("hdt:sunnah:sunnah:bukhari:1") == "sunnah:bukhari:1"
+
+
+class TestIsDoublePrefixed:
+    def test_detects_doubled_corpus(self) -> None:
+        assert is_double_prefixed("hdt:sunnah:sunnah:bukhari:1") is True
+
+    def test_clean_id_not_flagged(self) -> None:
+        assert is_double_prefixed("hdt:sunnah:bukhari:1") is False
+
+
+class TestValidateSourceId:
+    def test_clean_source_id_valid(self) -> None:
+        assert validate_source_id("sunnah:bukhari:1") == []
+
+    def test_doubled_corpus_reported(self) -> None:
+        problems = validate_source_id("sunnah:sunnah:bukhari:1")
+        assert any("doubled leading corpus" in p for p in problems)
+
+    @pytest.mark.parametrize("bad", ["", "bukhari", "sunnah::1"])
+    def test_grammar_violations_reported(self, bad: str) -> None:
+        assert validate_source_id(bad) != []

--- a/tests/workers/test_processors.py
+++ b/tests/workers/test_processors.py
@@ -386,6 +386,45 @@ class TestNormalizeProcessor:
         assert streaming_id == "hdt:sunnah:bukhari:1:1"
         assert "sunnah:sunnah" not in streaming_id
 
+    def test_already_doubled_source_id_collapses_to_one_node(
+        self,
+        object_store: ObjectStore,
+        sample_message: PipelineMessage,
+        hadith_row: Any,
+    ) -> None:
+        """A ``source_id`` that ALREADY carries a doubled corpus must collapse (#72).
+
+        The previous ad-hoc guard (``source_id if startswith("hdt:") else
+        f"hdt:{source_id}"``) only deduped the ``hdt:`` prefix — it did NOT
+        collapse a doubled leading *corpus*, so a staging
+        ``sunnah:sunnah:bukhari:1`` (the main#139 hazard, e.g. an upstream
+        producer that prepended the corpus a second time) became
+        ``hdt:sunnah:sunnah:bukhari:1`` — a duplicate node against the batch
+        loader's collapsed ``hdt:sunnah:bukhari:1``. Routing through the shared
+        ``src.parse.identity.hadith_node_id`` collapses it. A realistic
+        corpus-prefixed id is used deliberately: a toy ``h-1`` fixture has no
+        corpus segment and would mask this exact bug class.
+        """
+        from src.parse.identity import hadith_node_id  # noqa: PLC0415 — local to the test
+
+        doubled = "sunnah:sunnah:bukhari:1"
+        rows = [hadith_row(source_id=doubled, source_corpus="sunnah", matn_en="text")]
+        _seed(object_store, sample_message.b2_path, build_hadith_parquet(rows))
+
+        nxt = NormalizeProcessor(object_store)(sample_message)
+
+        hadiths = self._read_nodes(object_store, nxt.b2_path, "hadiths.parquet")
+        assert len(hadiths) == 1
+        streaming_id = hadiths[0]["id"]
+
+        # Collapsed to exactly one corpus segment — the value the batch loader
+        # now also emits (both paths consume the same helper).
+        assert streaming_id == "hdt:sunnah:bukhari:1"
+        assert streaming_id == hadith_node_id(doubled)
+        assert "sunnah:sunnah" not in streaming_id
+        # The pre-fix code would have produced this doubled id; assert it's gone.
+        assert streaming_id != "hdt:sunnah:sunnah:bukhari:1"
+
     def test_every_node_row_matches_allowed_label_vocabulary(
         self,
         object_store: ObjectStore,

--- a/workers/normalize/processor.py
+++ b/workers/normalize/processor.py
@@ -28,9 +28,14 @@ Stable-ID generation
 IDs are deterministic so re-processing the same batch produces the same
 node identities (idempotent ingest MERGE). Hash inputs:
 
-* ``Hadith``   — ``hdt:<source_id>`` where ``source_id`` is already
-  corpus-prefixed by the parser (``sunnah:bukhari:1:1``); no hashing and
-  no extra corpus prepend (#63). Matches ``src/graph/load_nodes.py``.
+* ``Hadith``   — :func:`src.parse.identity.hadith_node_id`, the shared
+  ``hdt:<source_id>`` rule consumed by both this streaming path and the
+  batch loaders (``src/graph/load_{nodes,edges}.py``). ``source_id`` is
+  already corpus-prefixed by the parser (``sunnah:bukhari:1:1``), so the
+  helper is idempotent on the ``hdt:`` prefix AND collapses an
+  accidentally doubled leading corpus (``hdt:sunnah:sunnah:...``) — the
+  main#139 / #63 / #72 double-prefix hazard that previously split one
+  hadith into two Neo4j nodes against the batch loader.
 * ``Narrator`` — ``nar:<sha1-24>`` of
   ``<lower(name_en)>|<normalize_arabic(name_ar)>``. Blank sides are
   represented as the empty string so pure-English and pure-Arabic
@@ -67,6 +72,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
 
+from src.parse.identity import hadith_node_id
 from src.parse.narrator_extraction import extract_narrator_mentions
 from src.parse.schemas import HADITH_SCHEMA
 from workers.lib.log import get_logger
@@ -180,22 +186,6 @@ def _normalize_arabic_safe(text: str) -> str:
         return text.strip()
 
 
-def _hadith_id(source_id: str) -> str:
-    """Canonical Hadith id — ``hdt:<source_id>`` (matches the batch loaders).
-
-    ``source_id`` is already corpus-prefixed by the parsers
-    (``generate_source_id`` emits ``<corpus>:<collection>:<parts>``, e.g.
-    ``sunnah:bukhari:1:1``), so the corpus must NOT be prepended a second
-    time — that produced the doubled ``hdt:sunnah:sunnah:bukhari:1:1`` of
-    #63, which split one hadith into two Neo4j nodes against the batch
-    loader's ``hdt:sunnah:bukhari:1:1``. This now mirrors
-    ``src/graph/load_nodes.py`` (``f"hdt:{sid}"``) and
-    ``src/graph/load_edges.py`` exactly so streaming and batch MERGE the
-    same node.
-    """
-    return source_id if source_id.startswith("hdt:") else f"hdt:{source_id}"
-
-
 def _collection_id(collection_name: str) -> str:
     return f"col:{_normalize_collection_name(collection_name)}"
 
@@ -220,7 +210,7 @@ def _fan_out_row(row: dict[str, Any]) -> tuple[list[_NodeRow], list[_EdgeRow]]:
     collection_name = row["collection_name"]
     sect = row["sect"]
 
-    hid = _hadith_id(source_id)
+    hid = hadith_node_id(source_id)
     cid = _collection_id(collection_name)
 
     nodes: list[_NodeRow] = [


### PR DESCRIPTION
## What & why

Cross-repo **streaming half** of the da#82 / main#139 double-prefix fix (`Closes #72`).

The normalize/streaming worker — and the in-repo batch loaders — built Hadith node ids with an ad-hoc `f"hdt:{sid}" if not sid.startswith("hdt:") else sid` guard. That guard is idempotent on the `hdt:` prefix but does **not** collapse a doubled leading *corpus*: a staging `sunnah:sunnah:bukhari:1` (the main#139 hazard, e.g. an upstream producer that prepended the corpus a second time) became `hdt:sunnah:sunnah:bukhari:1` — a **duplicate Neo4j node** for the same hadith against the batch path. The toy `h-1` fixtures (no corpus segment) masked this bug class entirely.

## The fix — one shared contract, no drift

Every Hadith node-id construction in this repo now routes through the single shared `hadith_node_id()` helper:

- **Vendored `src/parse/identity.py`** — a faithful mirror of data-acquisition's canonical `src/parse/identity.py` (introduced by da#82/PR #102). Same vendoring pattern as the existing `src/parse/schemas.py` / `narrator_extraction.py`; there is **no cross-repo import path** (both packages root at `src`), so a vendored mirror is the consumption mechanism. Header flags it as a mirror to keep in sync. The helper is idempotent on `hdt:` **and** collapses a doubled/N-times-repeated leading corpus (warning-logged when it repairs one).
- **`workers/normalize/processor.py`** — dropped the local `_hadith_id`, calls `hadith_node_id`.
- **`src/graph/load_nodes.py` + `load_edges.py`** — all Hadith id sites routed through the helper, so streaming + batch provably converge on one id per hadith and can't drift.

Chain / Grading / Collection / Narrator id schemes are intentionally **untouched** (out of scope for the hadith double-prefix; changing them would re-key existing nodes).

## Where `hadith_node_id()` lives / how consumed

- **Canonical source:** `noorinalabs-data-acquisition` → `src/parse/identity.py` (da#82/PR #102).
- **Consumed here via:** vendored mirror at `src/parse/identity.py`, imported as `from src.parse.identity import hadith_node_id`. Its only deps (`src.models.enums.SourceCorpus`, `src.utils.logging.get_logger`) already exist in this repo.

## Tests (realistic ids, never toy `h-1` — per the masking-fixture lesson)

- `tests/test_parse/test_identity.py` — direct contract tests: collapse single/double/triple corpus, `hdt:` idempotency, leading-corpus-only collapse (non-leading repeats and non-corpus leads preserved), `is_double_prefixed`, `validate_source_id`.
- `tests/workers/test_processors.py::...test_already_doubled_source_id_collapses_to_one_node` — streaming emits a collapsed single node for an already-doubled `sunnah:sunnah:bukhari:1` (**fails under the old guard**).
- `tests/test_graph/test_load_nodes.py::...test_doubled_corpus_source_id_collapses` — batch loader collapses the same input to the same `hdt:sunnah:bukhari:1`.

## Test Plan

- [x] `pytest tests/test_graph tests/test_parse tests/workers/test_processors.py` → 218 passed, 1 ML-skip.
- [x] `ruff format --check` + `ruff check` (v0.15.11 pin) clean on all 7 files.
- [x] `mypy src/parse/identity.py src/graph/load_nodes.py src/graph/load_edges.py` → no issues.
- [ ] **Runtime (post-merge, owner/cluster):** live local `neo4j:5` load asserting one node per hadith across both streaming + batch paths for a doubled-corpus input (acceptance criterion #2 — needs a Docker/Neo4j box, not a PR-time gate).

Reviewers: @Yusuke Inoue (primary), @Camila Restrepo (secondary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
