### PR TITLE
fix(graph/load_edges): null-safe APPEARS_IN MERGE — SET in-book ordinal (#84)

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -273,15 +273,28 @@ def _load_narrated(
 # 3. APPEARS_IN — hadith -> collection
 # ---------------------------------------------------------------------------
 
+# Identity of an APPEARS_IN edge is the (hadith, collection) PAIR — a hadith
+# appears in a given collection at most once. The positional props (book /
+# chapter / in-book ordinal) describe WHERE in that collection and are not part
+# of its key. They are therefore SET after the MERGE, never inside the MERGE
+# pattern (ingest-platform sibling of da#77): Neo4j refuses to MERGE a
+# relationship with a null property value, and scraped hadiths leave the in-book
+# ordinal null until it is enriched, so a keyed-on-properties MERGE aborts the
+# whole write batch on real scraped data. SET is null-safe.
+#
+# The SET uses the streaming ingest path's coalesce-preserve contract
+# (``r.<f> = coalesce(row.<f>, r.<f>)``) so the two ingest paths converge and a
+# re-run carrying a null ordinal never clobbers a value an earlier load set. The
+# canonical edge key is ``hadith_number_in_book`` (mapped from ``row.hadith_number``,
+# the in-book ordinal — Book 1 Hadith 1), not the bare ``hadith_number`` (da#65).
 _APPEARS_IN_QUERY = """\
 UNWIND $batch AS row
 MATCH (h:Hadith {id: row.hadith_id})
 MATCH (c:Collection {id: row.collection_id})
-MERGE (h)-[:APPEARS_IN {
-    book_number: row.book_number,
-    chapter_number: row.chapter_number,
-    hadith_number: row.hadith_number
-}]->(c)
+MERGE (h)-[r:APPEARS_IN]->(c)
+SET r.book_number = coalesce(row.book_number, r.book_number),
+    r.chapter_number = coalesce(row.chapter_number, r.chapter_number),
+    r.hadith_number_in_book = coalesce(row.hadith_number, r.hadith_number_in_book)
 """
 
 _APPEARS_IN_CHECK = """\

--- a/tests/integration/test_graph_loading.py
+++ b/tests/integration/test_graph_loading.py
@@ -416,6 +416,63 @@ class TestEdgeLoading:
         rows = neo4j_client.execute_read("MATCH ()-[r:APPEARS_IN]->() RETURN count(r) AS cnt")
         assert rows[0]["cnt"] >= 0  # at least the edges were attempted
 
+    def test_appears_in_null_in_book_ordinal_does_not_abort_batch(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        """ingest-platform sibling of da#77: a null in-book ordinal must NOT abort
+        the APPEARS_IN write batch.
+
+        Scraped hadiths carry a null in-book ordinal until it is enriched. The
+        previous ``MERGE (h)-[:APPEARS_IN {hadith_number: row.hadith_number}]->(c)``
+        raised ``Cannot merge relationship using null property value`` and killed
+        the load for *every* hadith in the batch. The mock suite cannot enforce
+        this Neo4j rule, so it must be exercised against a real container.
+
+        Post-fix the positional props are SET after the MERGE under the canonical
+        key ``hadith_number_in_book`` (da#65), so a null ordinal yields an edge
+        with that key simply absent (Neo4j drops a property SET to null) instead
+        of aborting — and the non-null sibling in the same batch still loads.
+        """
+        staging, curated = _write_staging_data(tmp_path)
+        # The Collection node id must match what load_edges builds from
+        # ``{source_corpus}:{collection_name}`` — the corpus-prefixed staging form
+        # ("sunnah:bukhari" -> node "col:sunnah:bukhari").
+        _write_collections_parquet(
+            staging, [{**SAMPLE_COLLECTIONS[0], "collection_id": "sunnah:bukhari"}]
+        )
+        # One hadith with a null in-book ordinal (the da#77 trigger) alongside a
+        # normal one, both in the same collection / write batch.
+        _write_hadiths_parquet(
+            staging,
+            [
+                {**SAMPLE_HADITHS[0], "source_id": "bukhari:1", "hadith_number": None},
+                {**SAMPLE_HADITHS[1], "source_id": "bukhari:2", "hadith_number": 2},
+            ],
+        )
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        edge_results = load_all_edges(neo4j_client, staging, curated, strict=False)
+
+        appears_in = next(r for r in edge_results if r.edge_type == "APPEARS_IN")
+        # Both edges created — the null-ordinal row did not abort the batch.
+        assert appears_in.created == 2
+
+        null_rows = neo4j_client.execute_read(
+            "MATCH (:Hadith {id: 'hdt:bukhari:1'})-[r:APPEARS_IN]->() "
+            "RETURN r.hadith_number_in_book AS num, keys(r) AS keys"
+        )
+        assert len(null_rows) == 1
+        # Neo4j does not persist a property SET to null, so the key is absent
+        # rather than the load erroring on the MERGE.
+        assert null_rows[0]["num"] is None
+        assert "hadith_number_in_book" not in null_rows[0]["keys"]
+
+        # The non-null sibling carries the ordinal under the canonical key.
+        nonnull_rows = neo4j_client.execute_read(
+            "MATCH (:Hadith {id: 'hdt:bukhari:2'})-[r:APPEARS_IN]->() "
+            "RETURN r.hadith_number_in_book AS num"
+        )
+        assert nonnull_rows[0]["num"] == 2
+
     def test_graded_by_edges(self, neo4j_client: Neo4jClient, tmp_path: Path) -> None:
         staging, curated = _write_staging_data(tmp_path)
         load_all_nodes(neo4j_client, staging, curated, strict=False)

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from src.graph.load_edges import EdgeLoadResult, _build_chain_pairs, load_all_edges
+from src.graph.load_edges import (
+    _APPEARS_IN_QUERY,
+    EdgeLoadResult,
+    _build_chain_pairs,
+    load_all_edges,
+)
 from tests.test_graph.conftest import (
     MockNeo4jClient,
     write_hadiths,
@@ -210,6 +215,63 @@ class TestLoadAppearsIn:
         results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
         ai_result = results[2]
         assert ai_result.skipped >= 1
+
+    def test_null_hadith_number_not_skipped_and_loaded(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # ingest-platform sibling of da#77: a null in-book ordinal must NOT be
+        # filtered out (only source_id / collection_name guard the skip path) and
+        # must still reach the write batch. The mock cannot enforce the Neo4j
+        # MERGE-null rule — the structural guards below and the real-Neo4j
+        # integration test (test_graph_loading.py) cover that — but this asserts
+        # the loader keeps building the edge when the ordinal is null.
+        mock_client.set_read_results(
+            [
+                {
+                    "hadith_id": "hdt:h-1",
+                    "collection_id": "col:bukhari",
+                    "hadith_exists": True,
+                    "collection_exists": True,
+                },
+            ]
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "h-1",
+                    "collection_name": "bukhari",
+                    "book_number": 1,
+                    "chapter_number": 1,
+                    "hadith_number": None,  # the da#77 trigger
+                },
+            ],
+        )
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        ai_result = results[2]
+        assert ai_result.skipped == 0
+        assert ai_result.created == 1
+
+    def test_appears_in_query_sets_ordinal_after_merge(self) -> None:
+        # da#77 / da#65: the in-book ordinal is null-unsafe inside a MERGE, so the
+        # positional props are SET after the MERGE under the canonical key
+        # ``hadith_number_in_book`` (mapped from ``row.hadith_number``) using the
+        # streaming path's coalesce-preserve contract.
+        assert (
+            "r.hadith_number_in_book = coalesce(row.hadith_number, r.hadith_number_in_book)"
+            in _APPEARS_IN_QUERY
+        )
+        # The legacy bare ``hadith_number`` edge key must never appear.
+        assert "hadith_number:" not in _APPEARS_IN_QUERY
+
+    def test_appears_in_merge_has_no_property_key_null_unsafe(self) -> None:
+        # da#77: positional props MUST be SET after the MERGE, never inside the
+        # MERGE relationship pattern — Neo4j aborts a MERGE on a null property,
+        # and scraped hadiths carry a null in-book ordinal until enrichment. Guard
+        # the MERGE line so the null-unsafe keyed form can't be reintroduced.
+        merge_line = next(line for line in _APPEARS_IN_QUERY.splitlines() if "MERGE (" in line)
+        assert merge_line.strip() == "MERGE (h)-[r:APPEARS_IN]->(c)"
+        assert "{" not in merge_line  # no inline property map on the MERGE pattern
 
 
 class TestLoadParallelOf:


### PR DESCRIPTION
## Summary

Fixes the ingest-platform worker-path copy of the APPEARS_IN null-property loader bug (sibling of da#77).

`_APPEARS_IN_QUERY` embedded three nullable positional props inside the relationship MERGE pattern:

```cypher
MERGE (h)-[:APPEARS_IN {book_number: ..., chapter_number: ..., hadith_number: row.hadith_number}]->(c)
```

Neo4j refuses to MERGE a relationship with a null property value, so a single scraped hadith whose in-book ordinal is null raises `Cannot merge relationship using null property value` and **aborts the entire write batch** — every hadith in the batch fails to load. The `_load_appears_in` validity filter only guarded `source_id`/`collection_name`, never the ordinal, and `MockNeo4jClient` masked it in tests.

## Fix

- MERGE on the stable `(hadith, collection)` PAIR identity only; `SET` the positional props after the MERGE so a null never participates in relationship identity (null-safe).
- Use the canonical edge key `hadith_number_in_book` (mapped from `row.hadith_number`, the in-book ordinal — Book 1 Hadith 1), not the bare `hadith_number`. This aligns the batch loader with the streaming normalize path (`workers/normalize/processor.py`), `src/models/edges.py`, and `EDGE_PROPERTY_MAP`, which already use it (da#65). The batch loader was the lone holdout.
- Use the streaming path's `coalesce`-preserve contract so a re-run carrying a null ordinal never clobbers a value an earlier load set.

## Tests

- **`test_load_edges.py`** (mock suite): null-ordinal row reaches the batch (not skipped, `created==1`) + structural guards asserting the MERGE line carries no inline property map and the SET uses the canonical `coalesce` key. The mock cannot enforce the Neo4j MERGE-null rule, hence the structural guards.
- **`test_graph_loading.py`** (real Neo4j container): regression test loading a null-ordinal hadith batched with a non-null sibling; asserts both edges created (batch **not** aborted), the null edge has the key absent (Neo4j drops a null-SET prop), and the sibling carries the ordinal under the canonical key. **Verified locally against a live `neo4j:5` container** (`1 passed`).

Full non-integration suite: `645 passed`. ruff (pinned 0.15.11) + mypy clean.

## Test Plan

- [x] `ruff format --check` + `ruff check` (src/tests) — clean
- [x] `mypy src/` — clean
- [x] `pytest -m "not integration"` — 645 passed
- [x] `pytest -m integration` TestEdgeLoading (real Neo4j container) — 3 passed

Closes #84

Reviewers: Léopold Mbongo, Camila Restrepo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
