### PR TITLE
infra(P4W6): publish multi-worker GHCR image + wire gated staging bring-up (#83)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,130 @@
+# Publish the multi-worker container image to GitHub Container Registry (GHCR).
+#
+# Image:
+#   ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform   (all 4 worker stages)
+#
+# Satisfies the deploy#440 contract: a single image bundling
+# workers.{dedup,enrich,normalize,ingest}, tagged stg-*, whose pipeline stage
+# is selected by each compose service's `command:` (the profile-gated
+# dedup/enrich/normalize/graph-load workers in
+# noorinalabs-deploy compose/docker-compose.prod.yml).
+#
+# Triggers:
+#   - push to main                       — republishes :latest + :stg-* + :stg-latest
+#   - tag push (v* | phase*-wave*)        — release/wave tags
+#   - workflow_dispatch (manual)          — the GATED staging-publish path: lets the
+#                                           release coordinator publish stg-<short> +
+#                                           stg-latest from the active wave branch so
+#                                           the profiled workers can be brought up on
+#                                           the box BEFORE this branch merges to main
+#                                           (the main#601 E2E moment). See RUNBOOK.md
+#                                           "Deploy procedure".
+#
+# NO deploy fan-in. Unlike isnad-graph/user-service, this workflow does NOT fire
+# a repository_dispatch to noorinalabs-deploy:
+#   - deploy-stg.yml declares only `deploy-noorinalabs-isnad-graph` /
+#     `deploy-noorinalabs-user-service` dispatch types — there is no ingest handler.
+#   - The worker services are profile-gated (`profiles: ["pipeline"]`); deploy-stg's
+#     plain `docker compose ... up -d --remove-orphans` does NOT start them.
+# Bringing the workers up is a deliberate, gated `docker compose --profile pipeline
+# up -d` on the box — the runbook step, not an auto-deploy. See RUNBOOK.md.
+
+name: Publish to GHCR
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+      - "phase*-wave*"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: noorinalabs/noorinalabs-isnad-ingest-platform
+
+jobs:
+  build-and-push:
+    name: Build and push (workers)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (ingest-platform)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          # Org image-tag contract (mirrors isnad-graph ghcr-publish.yml):
+          #   sha-<short>   — immutable, one per push; every event
+          #   latest        — mutable pointer; main-branch push + semver tags
+          #   stg-<short>   — immutable, stg namespace; push-to-main OR manual
+          #                   workflow_dispatch (the gated wave-branch publish)
+          #   stg-latest    — moving pointer to the newest stg-<short>; same enable
+          # prod-* tags are written by the noorinalabs-deploy promote workflow ONLY.
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,prefix=stg-,format=short,enable=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=stg-latest,enable=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: Dockerfile
+          # amd64 only: the VPS is amd64, the workers are pure python/uv, and
+          # there is no arm64 consumer today. A cross-arch QEMU build would be
+          # ~10x slower for no benefit (same rationale as the isnad-graph
+          # frontend). Re-enable arm64 when ARM worker nodes arrive.
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=workers
+          cache-to: type=gha,mode=max,scope=workers
+
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          # Scan by digest — guaranteed present immediately after push and
+          # immune to tag-resolution races (user-service#61 retro).
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          format: table
+          exit-code: "1"
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## GHCR Publish (workers): ${{ job.status }}"
+            echo ""
+            echo "- **Ref:** ${{ github.ref_name }}"
+            echo "- **Image:** ${{ env.REGISTRY }}/${{ env.IMAGE }}"
+            echo "- **Platforms:** linux/amd64"
+            echo "- **SHA:** ${{ github.sha }}"
+            echo "- **Digest:** ${{ steps.build.outputs.digest }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Multi-worker image — the single GHCR artifact the staging/prod compose
+# stack pulls for all four pipeline stages (ip#83).
+#
+# It bundles every worker module (workers.{dedup,enrich,normalize,ingest});
+# the running stage is selected at start time by the compose service's
+# `command:` (see noorinalabs-deploy compose/docker-compose.prod.yml, the
+# profile-gated `dedup-worker` / `enrich-worker` / `normalize-worker` /
+# `graph-load-worker` services from deploy#440). The default CMD below is a
+# guard so a bare `docker run` of this image fails loudly instead of doing
+# nothing.
+#
+# Build from repo root:
+#   docker build -t ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform:dev .
+#
+# Published by .github/workflows/ghcr-publish.yml. The per-stage
+# workers/<stage>/Dockerfile images remain for the self-contained local-dev
+# compose (docker-compose.yaml); this top-level Dockerfile is the one the
+# deployed stack consumes.
+
+FROM python:3.14-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_SYSTEM_PYTHON=1 \
+    UV_LINK_MODE=copy \
+    INGEST_CHECKPOINT_BACKEND=pg
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential curl \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+ && rm /tmp/requirements.txt
+
+COPY src ./src
+COPY workers ./workers
+
+RUN useradd --uid 1000 --create-home --shell /bin/bash worker \
+ && chown -R worker:worker /app
+USER worker
+
+# No default stage — compose overrides `command:` per service. A bare run
+# without a stage is an operator error, so fail fast with the valid choices.
+CMD ["python", "-c", "import sys; sys.exit('select a pipeline stage, e.g. python -m workers.dedup.main (one of: dedup, enrich, normalize, ingest)')"]

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -301,10 +301,14 @@ fail fast instead of every message DLQ-ing.
 make build-workers
 ```
 
-Tags as `dedup-worker:dev`, `enrich-worker:dev`,
-`normalize-worker:dev`, `ingest-worker:dev`. CI tags as
-`ghcr.io/noorinalabs/<worker>:sha-<short>` per the org image-tag
-contract (deploy `ghcr-publish.yml`, see references).
+Tags the per-stage local-dev images as `dedup-worker:dev`,
+`enrich-worker:dev`, `normalize-worker:dev`, `ingest-worker:dev` (used
+by the self-contained `docker-compose.yaml`). The **deployed** artifact
+is a single multi-worker image built from the top-level `Dockerfile`
+and published by this repo's `.github/workflows/ghcr-publish.yml` as
+`ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform:sha-<short>` (+
+`stg-<short>` / `stg-latest`) per the org image-tag contract; the
+compose `command:` selects the stage. See "Deploy procedure" below.
 
 ### Tests
 
@@ -364,39 +368,82 @@ additive format-fix commits is to be avoided.
 
 ## Deploy procedure
 
-> **Status:** Production deployment for the workers is **not yet
-> wired**. The deploy compose stack does not currently reference these
-> images. Cutover is tracked under `planned_issues 105–108` in
-> `ontology/repos/isnad-ingest-platform.yaml` and the multi-repo
-> coordination in `noorinalabs-main`.
+> **Status (ip#83, P4W6):** the staging path is now wired. The deploy
+> compose stack (`noorinalabs-deploy compose/docker-compose.prod.yml`)
+> defines the four worker services — `dedup-worker` / `enrich-worker` /
+> `normalize-worker` / `graph-load-worker` — **profile-gated**
+> (`profiles: ["pipeline"]`), all pulling the single multi-worker image
+> `ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform:${INGEST_IMAGE_TAG:-stg-latest}`
+> with each service's `command:` selecting its stage (deploy#440). This
+> repo's `.github/workflows/ghcr-publish.yml` publishes that image.
+> Bringing the workers up is a **deliberate, gated** `--profile pipeline`
+> step — it is **not** part of the normal app deploy (`deploy-stg.yml`).
 
-When the cutover lands, the deploy procedure will follow the
-established org pattern (mirror the `noorinalabs-deploy` and
-`noorinalabs-isnad-graph` runbooks):
+### Staging pipeline bring-up (gated)
 
-1. **Build + publish** — `ghcr-publish.yml` on push to
-   `deployments/phase-3/wave-N` produces `sha-<short>` and
-   `stg-<short>` + `stg-latest`. Promote to `prod-<short>` +
-   `prod-latest` only via the manual-approval workflow in
-   `noorinalabs-deploy` (org image-tag Contract v6, canonical comment
-   linked in references).
-2. **Pre-deploy** — `noorinalabs-deploy/scripts/db-migrate-gate.sh`
-   already handles user-service / isnad-graph; the ingest-worker
-   bringup needs an analogous "Neo4j connectivity probe" gate before
-   promotion. **Carry-forward.**
-3. **Stg cutover** — auto-deploy on push to wave branch, smoke via
-   `verify-deploy` workflow. Acceptance: workers show
-   `*_worker_starting` in logs, no DLQ traffic for 5 min.
-4. **Prod cutover** — manual approval on the `promote-prod` workflow.
-   Same acceptance battery as stg.
-5. **Post-cutover** — confirm one real batch flows raw → staged via
-   topic offsets and Neo4j MERGE counts (see triage commands below).
+The profiled workers are inert on a normal `docker compose up -d`. To
+bring the pipeline live on staging:
 
-The compose service definitions in
-`docker-compose.yaml` are the authoritative starting point — they
-already declare the env contract. The deploy compose just needs to
-import them with the right `external` networks once Kafka and Neo4j
-are on the prod stack.
+1. **Publish the worker image.** Run `Publish to GHCR`
+   (`ghcr-publish.yml`) via **workflow_dispatch on the active wave
+   branch** (or merge to `main`). This publishes `stg-<short>` +
+   `stg-latest`, so the compose default `INGEST_IMAGE_TAG=stg-latest`
+   resolves. Until this runs, the image is absent from GHCR and step 2
+   cannot pull it. Confirm:
+   ```bash
+   gh api /orgs/noorinalabs/packages/container/noorinalabs-isnad-ingest-platform/versions \
+     --jq '.[].metadata.container.tags[]' | grep -x stg-latest
+   ```
+2. **Bring the workers up on the box** (separate from app deploys):
+   ```bash
+   ssh noorinalabs-stg
+   cd <deploy-checkout>            # where compose/docker-compose.prod.yml lives
+   docker compose -p noorinalabs -f compose/docker-compose.prod.yml \
+     --env-file .env --profile pipeline up -d
+   ```
+   Use the **same `-p noorinalabs` project** as the app stack so the
+   workers join the same network (kafka/neo4j/postgres on `backend`).
+   Do **not** pass `--remove-orphans` here. **Requires Docker Compose
+   ≥ v2.20 on the box** — older Compose treats profile-activated
+   services as orphans, so a later app deploy's
+   `up -d --force-recreate --remove-orphans` (no `--profile`) would
+   reap the workers. Verify once: `docker compose version`.
+3. **Verify** workers are up, offsets advance, and the graph is written
+   (see the verification block below).
+
+```bash
+# (on the box) workers running + healthy
+docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env \
+  --profile pipeline ps --format '{{.Name}}\t{{.Status}}'
+docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env \
+  logs --tail=20 dedup-worker enrich-worker normalize-worker graph-load-worker
+#   expect: *_worker_starting, no repeated DLQ traffic
+
+# Kafka offsets advancing past 0 (pipeline.raw.landed → … → pipeline.normalize.done)
+docker exec <kafka-container> kafka-consumer-groups.sh \
+  --bootstrap-server kafka:9092 --describe --all-groups
+
+# Graph-load landed nodes/edges in Neo4j
+docker exec <neo4j-container> cypher-shell -u neo4j -p "$NEO4J_PASSWORD" \
+  "MATCH (n) RETURN labels(n)[0] AS label, count(*) ORDER BY label;"
+```
+
+**Prod** follows the same shape once promoted: the deploy promote
+workflow writes `prod-<short>` / `prod-latest`; pin `INGEST_IMAGE_TAG`
+to a `prod-*` tag and run the identical gated `--profile pipeline up -d`
+on the prod box.
+
+> **Ordering / blockers for a correct E2E:** the APPEARS_IN
+> null-`hadith_number` MERGE-abort loader bug (ip#84) is **merged on
+> `deployments/phase-4/wave-6`** — required for a real scraped-data run
+> to land instead of aborting. The data half (produce + load real
+> narrator graph) is tracked separately (data-acquisition); this issue
+> is the infrastructure half (pipeline *runnable* on staging).
+
+The local-dev compose service definitions in `docker-compose.yaml`
+remain the authoritative env contract and build the per-stage images
+for self-contained local smoke tests; the deployed stack consumes the
+single multi-worker image built from the top-level `Dockerfile`.
 
 ---
 


### PR DESCRIPTION
Closes #83. **Runtime half** of the data-spine (main#601 criterion #1) — gets the ingest workers runnable on staging. Pairs with the merged deploy half (deploy#440 / PR #441), which added the four profile-gated worker services to `compose/docker-compose.prod.yml`.

## What this delivers (PR-deliverable, mechanically validated)

| File | Change |
|---|---|
| `Dockerfile` (new, top-level) | Single multi-worker image bundling `workers.{dedup,enrich,normalize,ingest}`. Default `CMD` fails fast — each compose service's `command:` selects its stage. Non-root, `read_only`-compatible. |
| `.github/workflows/ghcr-publish.yml` (new) | Publishes `ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform` with `sha-<short>` / `latest` / `stg-<short>` / `stg-latest` tags. Mirrors isnad-graph's pinned-SHA publish + Trivy-by-digest scan. |
| `RUNBOOK.md` | Replaces the stale "not yet wired" Deploy procedure with the real **gated** staging bring-up + verification. |

### Image contract (deploy#440) — satisfied
- All four compose services pull `…/noorinalabs-isnad-ingest-platform:${INGEST_IMAGE_TAG:-stg-latest}` (verified: 4/4 `image:` lines + 4/4 `command:` lines `workers.{dedup,enrich,normalize,ingest}.main`).
- One image, stage chosen by `command:`. The per-stage `workers/<stage>/Dockerfile` images are retained for the self-contained local-dev `docker-compose.yaml`.

### Why NO deploy fan-in (deliberate)
Unlike isnad-graph/user-service, this publish workflow does **not** fire a `repository_dispatch` to noorinalabs-deploy:
- `deploy-stg.yml` declares only `deploy-noorinalabs-isnad-graph` / `deploy-noorinalabs-user-service` dispatch types — no ingest handler.
- The workers are `profiles: ["pipeline"]`; deploy-stg's plain `docker compose … up -d --force-recreate --remove-orphans` does **not** start them.

So bring-up is a gated `--profile pipeline up -d` step, not an auto-deploy. The `stg-*` tags are enabled on **`workflow_dispatch`** too, so the image can be published **from this wave branch** for the gated E2E before it merges to main.

## Mechanical validation (no live publish / no live deploy)
- `actionlint` (shellcheck on PATH): clean on `ghcr-publish.yml`.
- `markdownlint-cli2` + `cspell`: clean on `RUNBOOK.md`. No new markdown links (lychee-safe).
- **Image builds locally** (`docker build`, not pushed): all four `workers.{dedup,enrich,normalize,ingest}.main` import from the single image; default `CMD` exits non-zero; runs as `worker` (non-root).
- Compose contract cross-checked against the merged `compose/docker-compose.prod.yml` @ `deployments/phase-4/wave-6`.

## Runtime runbook — the GATED steps (team-lead to coordinate; the main#601 moment)

> Not run here. Live publish + `--profile pipeline up -d` on the VPS are gated runtime steps.

**(a) Publish the worker image** — run `Publish to GHCR` via `workflow_dispatch` on `deployments/phase-4/wave-6` (or merge to main). Publishes `stg-<short>` + `stg-latest` so compose's default `INGEST_IMAGE_TAG=stg-latest` resolves. Confirm:
```bash
gh api /orgs/noorinalabs/packages/container/noorinalabs-isnad-ingest-platform/versions \
  --jq '.[].metadata.container.tags[]' | grep -x stg-latest
```

**(b) Bring workers up on the box** (separate from app deploys):
```bash
ssh noorinalabs-stg
cd <deploy-checkout>
docker compose -p noorinalabs -f compose/docker-compose.prod.yml \
  --env-file .env --profile pipeline up -d
```
Same `-p noorinalabs` project as the app stack (shared `backend` net for kafka/neo4j/postgres). **No `--remove-orphans` here.**

**(c) Verify** workers up, offsets advancing past 0, graph written:
```bash
docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env \
  --profile pipeline ps --format '{{.Name}}\t{{.Status}}'
docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env \
  logs --tail=20 dedup-worker enrich-worker normalize-worker graph-load-worker
docker exec <kafka> kafka-consumer-groups.sh --bootstrap-server kafka:9092 --describe --all-groups
docker exec <neo4j> cypher-shell -u neo4j -p "$NEO4J_PASSWORD" \
  "MATCH (n) RETURN labels(n)[0] AS label, count(*) ORDER BY label;"
```

## Reviewer notes folded in (from deploy#440)
1. **Compose ≥ v2.20 on the box** — older Compose treats profile-activated services as orphans, so a later app deploy's `up -d --remove-orphans` (no `--profile`) would reap the workers. Verify once: `docker compose version`. (Documented in RUNBOOK.)
2. **GHCR pre-flight** (`PULL_SERVICES`) only includes the ingest image once it is published; until step (a) runs, app deploys correctly skip it (profile-gated, not in the pull set).

## Ordering / blockers
- The APPEARS_IN null-`hadith_number` MERGE-abort loader bug (**ip#84**) is **already merged on `deployments/phase-4/wave-6`** (PR #85) — required for a real scraped-data E2E to land rather than abort.
- The **data half** (produce + load real narrator/edge graph) is tracked in data-acquisition; this issue is the **infrastructure half** (pipeline *runnable* on staging).

## Follow-up (optional, deploy-side; deferred by deploy#440)
One-click bring-up would need a dedicated `deploy-pipeline-stg` dispatch workflow in noorinalabs-deploy (plus `INGEST_IMAGE_TAG` plumbing through `write-deploy-env`). Out of scope here; the gated runbook covers it now. Can file a linked deploy issue if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
