### PR TITLE
feat(metrics): pipeline metrics (Kafka lag, B2 size) + reprocess-from-stage (#76)

### DIFF
--- a/docs/pipeline-metrics-api.md
+++ b/docs/pipeline-metrics-api.md
@@ -1,0 +1,134 @@
+# Pipeline metrics & reprocess API (issue #76)
+
+Admin-only HTTP surface the **isnad-graph admin data panel** fetches to show
+pipeline health and to trigger a reprocess. All routes are served by the
+ingest-platform FastAPI app (`src/api/app.py`), mounted under `/admin`, and
+guarded by `require_admin` — the same user-service RS256 admin JWT that
+authorizes the isnad-graph admin dashboard and the reset endpoints.
+
+- Base path: `/admin`
+- Auth: `Authorization: Bearer <user-service access token with role admin>`
+  - missing/invalid token → `401`; valid non-admin → `403`; user-service
+    JWKS unreachable → `503`
+
+Run locally: `uvicorn src.api.app:create_app --factory --port 8002`.
+
+## Stage vocabulary
+
+The pipeline runs four consuming stages, in order. The `stage` names below
+are the stable identifiers used by both the metrics and reprocess routes.
+
+| stage | consumer group | consumes topic | produces topic |
+| --- | --- | --- | --- |
+| `dedup` | `dedup-worker` | `pipeline.raw.landed` | `pipeline.dedup.done` |
+| `enrich` | `enrich-worker` | `pipeline.dedup.done` | `pipeline.enrich.done` |
+| `normalize` | `normalize-worker` | `pipeline.enrich.done` | `pipeline.normalize.done` |
+| `graph-load` | `ingest-worker` | `pipeline.normalize.done` | (terminal) |
+
+This table is the source of truth in `src/pipeline/stages.py` and is pinned
+to the worker wiring by `tests/test_pipeline/test_stages.py`.
+
+## GET /admin/metrics/lag
+
+Per-stage Kafka consumer lag — how far each stage's consumer group is behind
+the head of the topic it consumes. `lag = end_offset - committed_offset`,
+clamped at 0; a partition the group has never committed counts its whole
+head offset as backlog. `total_lag` (per stage and overall) is the sum over
+partitions/stages — the headline "is the pipeline keeping up?" number.
+
+Response `200`:
+
+```json
+{
+  "stages": [
+    {
+      "stage": "dedup",
+      "consumer_group": "dedup-worker",
+      "topic": "pipeline.raw.landed",
+      "total_lag": 12,
+      "partitions": [
+        { "partition": 0, "end_offset": 100, "committed_offset": 88, "lag": 12 }
+      ]
+    }
+  ],
+  "total_lag": 12
+}
+```
+
+- `committed_offset` is `null` when the group has never committed that
+  partition (the partition's `lag` then equals `end_offset`).
+- `stages` always lists all four stages in pipeline order; a stage whose
+  topic has no partitions yet reports `total_lag: 0` and `partitions: []`.
+
+## GET /admin/metrics/storage
+
+B2 object-store size, broken down by the pipeline's stage prefixes plus a
+bucket-wide rollup. `total_bytes` is the sum of object sizes under each
+prefix; `object_count` is the number of objects.
+
+Response `200`:
+
+```json
+{
+  "prefixes": [
+    { "prefix": "raw/", "object_count": 1432, "total_bytes": 9105533 },
+    { "prefix": "dedup/", "object_count": 1280, "total_bytes": 8401200 },
+    { "prefix": "enriched/", "object_count": 1280, "total_bytes": 9550120 },
+    { "prefix": "normalized/", "object_count": 640, "total_bytes": 4120044 },
+    { "prefix": "staged/", "object_count": 640, "total_bytes": 4010990 }
+  ],
+  "total_object_count": 5272,
+  "total_bytes": 35187887
+}
+```
+
+The prefixes match the reset surface's B2 stage layout (`raw/`, `dedup/`,
+`enriched/`, `normalized/`, `staged/`).
+
+## POST /admin/reprocess
+
+Re-run the pipeline from a chosen stage **without deleting staged B2 data**
+(that is the reset surface, `POST /admin/reset/*`). Reprocessing from stage
+*X* rewinds *X*'s consumer group to the start of its consume topic and clears
+the idempotency checkpoints for *X* and every downstream stage, so the
+re-delivered batches are processed again instead of being skipped as
+already-seen. Only the entry stage's group is rewound — downstream stages
+re-consume naturally as *X* re-emits.
+
+Request:
+
+```json
+{ "stage": "enrich", "dry_run": false }
+```
+
+- `stage` (required) — one of the stage names above. Unknown → `422`.
+- `dry_run` (default `false`) — resolve the plan and write a dry-run audit
+  entry **without** touching Kafka or Postgres. The admin panel should call
+  this first to preview the affected stages.
+
+Response `200`:
+
+```json
+{
+  "from_stage": "enrich",
+  "dry_run": false,
+  "audit_entry_path": "data/audit/2026-06-14T….json",
+  "summary": {
+    "from_stage": "enrich",
+    "rewound_group": "enrich-worker",
+    "rewound_topic": "pipeline.dedup.done",
+    "affected_stages": ["enrich", "normalize", "graph-load"],
+    "checkpoints_cleared": { "enrich": 3, "normalize": 5, "graph-load": 2 },
+    "dry_run": false
+  }
+}
+```
+
+Every call (dry-run included) writes an audit entry under `data/audit/`,
+matching the reset surface, so a reprocess is attributable in the audit log.
+
+**Operational note.** Rewinding a consumer group's committed offsets takes
+effect for the worker fleet on its next rebalance/restart — Kafka only allows
+an offset to be altered for a group with no active members on that partition.
+This endpoint triggers the rewind and checkpoint clear; the running workers
+pick it up. This is the same operational contract the reset endpoints carry.

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,9 +1,11 @@
 """FastAPI app factory for the ingest-platform admin HTTP surface.
 
-Exposes the admin-only reset endpoints (issue #70). The reset router is
-mounted under ``/admin`` with ``Depends(require_admin)`` applied at the
-router level, so every reset route is admin-only — there is no
-unauthenticated path to a destructive operation.
+Exposes the admin-only pipeline operations the isnad-graph admin data panel
+drives: the reset endpoints (issue #70), the read-only metrics endpoints
+(consumer lag + object-store size) and the reprocess-from-stage endpoint
+(issue #76). Every router is mounted under ``/admin`` with
+``Depends(require_admin)`` applied at the mount point, so there is no
+unauthenticated path to any operation — destructive or read-only.
 
 Run locally with::
 
@@ -15,6 +17,8 @@ from __future__ import annotations
 from fastapi import Depends, FastAPI
 
 from src.api.auth import require_admin
+from src.api.metrics_router import router as metrics_router
+from src.api.reprocess_router import router as reprocess_router
 from src.api.reset_router import router as reset_router
 
 
@@ -31,12 +35,12 @@ def create_app() -> FastAPI:
         """Unauthenticated liveness probe."""
         return {"status": "ok"}
 
-    # Admin guard is applied once at the mount point — covers every reset route.
-    app.include_router(
-        reset_router,
-        prefix="/admin",
-        dependencies=[Depends(require_admin)],
-    )
+    # Admin guard is applied once per mount point — covers every admin route
+    # (reset, metrics, reprocess) with no unauthenticated path to any of them.
+    admin_guard = [Depends(require_admin)]
+    app.include_router(reset_router, prefix="/admin", dependencies=admin_guard)
+    app.include_router(metrics_router, prefix="/admin", dependencies=admin_guard)
+    app.include_router(reprocess_router, prefix="/admin", dependencies=admin_guard)
 
     return app
 

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -1,17 +1,29 @@
-"""FastAPI dependencies for the reset HTTP surface.
+"""FastAPI dependencies for the reset / metrics / reprocess HTTP surface.
 
-The resetter is provided as a *lazy factory* and the data dir as a plain
-dependency so the unit suite can override them with in-memory fakes
-(``app.dependency_overrides``) without any boto3/Kafka/Neo4j/PG infra — the
-same isolation invariant the CLI keeps via ``_build_reset_clients``.
+The resetter and reprocessor are provided as *lazy factories* and the data
+dir / metrics readers as plain dependencies so the unit suite can override
+them with in-memory fakes (``app.dependency_overrides``) without any
+boto3/Kafka/Neo4j/PG infra — the same isolation invariant the CLI keeps via
+``_build_reset_clients``.
+
+The read-only metrics dependencies (``get_kafka_lag_reader`` /
+``get_object_size_store``) return objects whose live clients are built
+*lazily on first use*, so resolving the dependency opens no connection;
+the connection happens only when a report computation actually reads
+offsets / lists objects. The destructive reprocess dependency keeps the
+reset surface's factory shape so a dry-run never constructs a live client.
 """
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from src.config import get_settings
+from src.pipeline.metrics import KafkaOffsetReader, ObjectSizeStore
+from src.pipeline.reprocess import PipelineReprocessor
 from src.pipeline.reset import PipelineResetter
 
 
@@ -50,6 +62,92 @@ def get_resetter_factory() -> Callable[[], PipelineResetter]:
             kafka_admin=kafka_admin,
             neo4j=neo4j,
             pg=pg,
+            data_dir=get_data_dir(),
+        )
+
+    return _build
+
+
+# ---------------------------------------------------------------------------
+# Metrics dependencies (read-only; lazy live clients)
+# ---------------------------------------------------------------------------
+
+
+class _BotoSizeStore:
+    """Minimal ``ObjectSizeStore`` over a lazily built boto3 S3/B2 client.
+
+    Re-declared here (rather than importing ``workers.lib.object_store``) so
+    ``src`` stays independent of ``workers``, matching the inline ``_Store``
+    the reset CLI builder uses. Constructing it opens no connection — the
+    boto3 client is built on first ``client`` access.
+    """
+
+    def __init__(self, bucket: str, endpoint_url: str | None) -> None:
+        self.bucket = bucket
+        self._endpoint_url = endpoint_url
+        self._client: Any | None = None
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            import boto3  # type: ignore[import-untyped]
+
+            kwargs: dict[str, Any] = {}
+            if self._endpoint_url:
+                kwargs["endpoint_url"] = self._endpoint_url
+            self._client = boto3.client("s3", **kwargs)
+        return self._client
+
+
+def get_object_size_store() -> ObjectSizeStore:
+    """Return an object store for the storage-size metric (lazy boto3 client).
+
+    Reads the bucket / endpoint from the same env vars the workers and reset
+    CLI use (``PIPELINE_BUCKET`` / ``S3_ENDPOINT_URL``). Tests override this
+    with an in-memory fake.
+    """
+    return _BotoSizeStore(
+        bucket=os.environ.get("PIPELINE_BUCKET", "noorinalabs-pipeline"),
+        endpoint_url=os.environ.get("S3_ENDPOINT_URL"),
+    )
+
+
+def get_kafka_lag_reader() -> KafkaOffsetReader:
+    """Return a Kafka offset reader for the consumer-lag metric.
+
+    The adapter builds its admin + consumer clients lazily, so resolving this
+    dependency opens no broker connection. Tests override it with a fake.
+    """
+    from src.pipeline.metrics_adapters import KafkaLagAdapter
+
+    return KafkaLagAdapter(bootstrap_servers=os.environ["KAFKA_BOOTSTRAP_SERVERS"])
+
+
+# ---------------------------------------------------------------------------
+# Reprocess dependency (destructive-ish; lazy factory like the resetter)
+# ---------------------------------------------------------------------------
+
+
+def get_reprocessor_factory() -> Callable[[], PipelineReprocessor]:
+    """Return a *lazy* factory that builds the live reprocessor on demand.
+
+    Mirrors ``get_resetter_factory``: a reprocess dry-run must not open Kafka
+    or Postgres connections, so the live clients stay unbuilt until a route
+    invokes the factory in the non-dry-run branch.
+    """
+
+    def _build() -> PipelineReprocessor:
+        import psycopg
+        from kafka.admin import KafkaAdminClient  # type: ignore[import-untyped]
+
+        from src.pipeline.reprocess_adapters import PgCheckpointResetter
+        from src.pipeline.reset_adapters import KafkaPythonAdmin
+
+        settings = get_settings()
+        bootstrap = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
+        return PipelineReprocessor(
+            kafka=KafkaPythonAdmin(KafkaAdminClient(bootstrap_servers=bootstrap)),
+            checkpoints=PgCheckpointResetter(psycopg.connect(settings.postgres.dsn)),
             data_dir=get_data_dir(),
         )
 

--- a/src/api/metrics_router.py
+++ b/src/api/metrics_router.py
@@ -1,0 +1,134 @@
+"""Admin-only HTTP endpoints exposing pipeline metrics (issue #76).
+
+Two read-only GET endpoints the isnad-graph admin data panel polls:
+
+- ``GET /admin/metrics/lag``     — per-stage Kafka consumer lag + total
+- ``GET /admin/metrics/storage`` — per-B2-prefix object count/bytes + total
+
+Both delegate to the pure report functions in
+:mod:`src.pipeline.metrics`, computed over injected readers
+(``get_kafka_lag_reader`` / ``get_object_size_store``). The admin guard is
+applied at the router mount point in :mod:`src.api.app`
+(``dependencies=[Depends(require_admin)]``), so both routes are admin-only.
+
+Response shapes are the contract the admin panel consumes — see
+``docs/pipeline-metrics-api.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict
+
+from src.api.deps import get_kafka_lag_reader, get_object_size_store
+from src.pipeline.metrics import (
+    KafkaOffsetReader,
+    ObjectSizeStore,
+    compute_lag_report,
+    compute_storage_report,
+)
+
+router = APIRouter(prefix="/metrics", tags=["admin", "metrics"])
+
+
+class PartitionLagModel(BaseModel):
+    """Lag for one (topic, partition) under a stage's consumer group."""
+
+    model_config = ConfigDict(frozen=True)
+
+    partition: int
+    end_offset: int
+    committed_offset: int | None
+    lag: int
+
+
+class StageLagModel(BaseModel):
+    """Lag for one pipeline stage's consumer group on its consume topic."""
+
+    model_config = ConfigDict(frozen=True)
+
+    stage: str
+    consumer_group: str
+    topic: str
+    total_lag: int
+    partitions: list[PartitionLagModel]
+
+
+class LagResponse(BaseModel):
+    """Consumer lag across every pipeline stage."""
+
+    model_config = ConfigDict(frozen=True)
+
+    stages: list[StageLagModel]
+    total_lag: int
+
+
+class PrefixSizeModel(BaseModel):
+    """Object count + byte total under one B2 prefix."""
+
+    model_config = ConfigDict(frozen=True)
+
+    prefix: str
+    object_count: int
+    total_bytes: int
+
+
+class StorageResponse(BaseModel):
+    """Object-store size broken down by stage prefix, plus the rollup."""
+
+    model_config = ConfigDict(frozen=True)
+
+    prefixes: list[PrefixSizeModel]
+    total_object_count: int
+    total_bytes: int
+
+
+@router.get("/lag", response_model=LagResponse)
+def metrics_lag(
+    reader: Annotated[KafkaOffsetReader, Depends(get_kafka_lag_reader)],
+) -> LagResponse:
+    """Per-stage Kafka consumer lag and the pipeline-wide total."""
+    report = compute_lag_report(reader)
+    return LagResponse(
+        stages=[
+            StageLagModel(
+                stage=s.stage,
+                consumer_group=s.consumer_group,
+                topic=s.topic,
+                total_lag=s.total_lag,
+                partitions=[
+                    PartitionLagModel(
+                        partition=p.partition,
+                        end_offset=p.end_offset,
+                        committed_offset=p.committed_offset,
+                        lag=p.lag,
+                    )
+                    for p in s.partitions
+                ],
+            )
+            for s in report.stages
+        ],
+        total_lag=report.total_lag,
+    )
+
+
+@router.get("/storage", response_model=StorageResponse)
+def metrics_storage(
+    store: Annotated[ObjectSizeStore, Depends(get_object_size_store)],
+) -> StorageResponse:
+    """Per-B2-prefix object count + bytes and the bucket-wide rollup."""
+    report = compute_storage_report(store)
+    return StorageResponse(
+        prefixes=[
+            PrefixSizeModel(
+                prefix=p.prefix,
+                object_count=p.object_count,
+                total_bytes=p.total_bytes,
+            )
+            for p in report.prefixes
+        ],
+        total_object_count=report.total_object_count,
+        total_bytes=report.total_bytes,
+    )

--- a/src/api/reprocess_router.py
+++ b/src/api/reprocess_router.py
@@ -1,0 +1,82 @@
+"""Admin-only HTTP endpoint to reprocess the pipeline from a chosen stage (#76).
+
+``POST /admin/reprocess`` rewinds one stage's consumer group and clears the
+idempotency checkpoints for that stage and everything downstream, re-running
+the pipeline from there **without deleting staged B2 data** (that is the
+reset surface's job — :mod:`src.api.reset_router`).
+
+The endpoint mirrors the reset router's shape: a ``dry_run`` flag returns the
+resolved plan and writes a dry-run audit entry without touching infra, and
+the live reprocessor is built (via ``get_reprocessor_factory``) ONLY in the
+non-dry-run branch so a preview never opens Kafka/Postgres connections. The
+admin guard is applied at the mount point in :mod:`src.api.app`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.api.deps import get_data_dir, get_reprocessor_factory
+from src.pipeline.reprocess import PipelineReprocessor, plan_reprocess, write_dry_run_audit
+
+router = APIRouter(prefix="/reprocess", tags=["admin", "reprocess"])
+
+
+class ReprocessRequest(BaseModel):
+    """Reprocess the pipeline from ``stage`` onward."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    stage: str = Field(
+        description="Stage to reprocess from: dedup|enrich|normalize|graph-load",
+    )
+    dry_run: bool = Field(
+        default=False,
+        description="Resolve the plan and write a dry-run audit entry without touching infra.",
+    )
+
+
+class ReprocessResponse(BaseModel):
+    """Result of a reprocess call — the report summary + audit path."""
+
+    model_config = ConfigDict(frozen=True)
+
+    from_stage: str
+    dry_run: bool
+    audit_entry_path: str
+    summary: dict[str, Any]
+
+
+@router.post("", response_model=ReprocessResponse)
+def reprocess(
+    body: ReprocessRequest,
+    reprocessor_factory: Annotated[
+        Callable[[], PipelineReprocessor], Depends(get_reprocessor_factory)
+    ],
+    data_dir: Annotated[Path, Depends(get_data_dir)],
+) -> ReprocessResponse:
+    """Reprocess from ``body.stage``. Unknown stage -> 422; dry-run is inert."""
+    # Validate the stage up front so a bad name is rejected (422) before any
+    # client is built — for both the dry-run and the live path.
+    try:
+        plan_reprocess(body.stage)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    if body.dry_run:
+        report, _entry, audit_path = write_dry_run_audit(body.stage, data_dir=data_dir)
+    else:
+        reprocessor = reprocessor_factory()
+        report, _entry, audit_path = reprocessor.reprocess(body.stage)
+
+    return ReprocessResponse(
+        from_stage=report.from_stage,
+        dry_run=report.dry_run,
+        audit_entry_path=str(audit_path),
+        summary=report.to_summary(),
+    )

--- a/src/pipeline/metrics.py
+++ b/src/pipeline/metrics.py
@@ -1,0 +1,227 @@
+"""Pipeline operational metrics — Kafka consumer lag + B2 object-store size.
+
+Read-only metrics the isnad-graph admin data panel fetches over HTTP
+(issue #76). Two independent reports:
+
+- **Consumer lag** — per stage, per partition, how far each stage's
+  consumer group is behind the head of the topic it consumes. The sum
+  over partitions is the stage's backlog; the sum over stages is the
+  pipeline backlog. This is the headline "is the pipeline keeping up?"
+  signal for the admin panel.
+- **Object-store size** — per B2 stage-prefix object count and byte
+  total, plus the rollup. Tells operators how much staged data each
+  pipeline stage is holding.
+
+Both computations are pure functions over small injected Protocols
+(``KafkaOffsetReader`` / ``ObjectSizeStore``) so the unit suite exercises
+the lag arithmetic and the prefix-summing pagination against in-memory
+fakes — no Kafka broker, no S3/B2. The live adapters live in
+``src/pipeline/metrics_adapters.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from src.pipeline.stages import PIPELINE_STAGES, StageSpec
+
+__all__ = [
+    "KafkaOffsetReader",
+    "LagReport",
+    "ObjectSizeStore",
+    "PartitionLag",
+    "PrefixSize",
+    "StageLag",
+    "StorageReport",
+    "compute_lag_report",
+    "compute_storage_report",
+]
+
+# Canonical B2 stage prefixes whose size the storage report breaks down.
+# Mirrors the object layout documented in issue #105 (and the reset surface's
+# ``STAGE_PREFIXES``). Re-declared here rather than imported from
+# ``src.pipeline.reset`` so the metrics surface does not depend on the reset
+# module; ``tests/test_pipeline/test_metrics.py`` pins the two in sync.
+STORAGE_PREFIXES: tuple[str, ...] = (
+    "raw/",
+    "dedup/",
+    "enriched/",
+    "normalized/",
+    "staged/",
+)
+
+
+# ---------------------------------------------------------------------------
+# Kafka consumer lag
+# ---------------------------------------------------------------------------
+
+
+class KafkaOffsetReader(Protocol):
+    """Offset surface the lag computation needs.
+
+    ``end_offsets`` returns the high-water mark (next offset to be written)
+    per partition for a topic. ``committed_offsets`` returns the last
+    committed offset per partition for a consumer group on a topic;
+    partitions a group has never committed are simply absent from the map.
+    """
+
+    def end_offsets(self, topic: str) -> dict[int, int]: ...
+
+    def committed_offsets(self, group_id: str, topic: str) -> dict[int, int]: ...
+
+
+@dataclass(frozen=True)
+class PartitionLag:
+    """Lag for a single (topic, partition) under one consumer group."""
+
+    partition: int
+    end_offset: int
+    committed_offset: int | None
+    lag: int
+
+
+@dataclass(frozen=True)
+class StageLag:
+    """Lag for one pipeline stage's consumer group on its consume topic."""
+
+    stage: str
+    consumer_group: str
+    topic: str
+    total_lag: int
+    partitions: list[PartitionLag]
+
+
+@dataclass(frozen=True)
+class LagReport:
+    """Consumer lag across every pipeline stage."""
+
+    stages: list[StageLag]
+    total_lag: int
+
+
+def _stage_lag(reader: KafkaOffsetReader, stage: StageSpec) -> StageLag:
+    end = reader.end_offsets(stage.consume_topic)
+    committed = reader.committed_offsets(stage.consumer_group, stage.consume_topic)
+
+    partitions: list[PartitionLag] = []
+    total = 0
+    for partition in sorted(end):
+        end_offset = end[partition]
+        committed_offset = committed.get(partition)
+        # A partition the group has never committed is treated as fully
+        # un-consumed (lag == head): the whole partition is backlog. Clamp
+        # negative lag to 0 — a committed offset can momentarily exceed the
+        # cached end offset under read skew, which is not a real backlog.
+        baseline = committed_offset if committed_offset is not None else 0
+        lag = max(0, end_offset - baseline)
+        total += lag
+        partitions.append(
+            PartitionLag(
+                partition=partition,
+                end_offset=end_offset,
+                committed_offset=committed_offset,
+                lag=lag,
+            )
+        )
+
+    return StageLag(
+        stage=stage.name,
+        consumer_group=stage.consumer_group,
+        topic=stage.consume_topic,
+        total_lag=total,
+        partitions=partitions,
+    )
+
+
+def compute_lag_report(
+    reader: KafkaOffsetReader,
+    *,
+    stages: tuple[StageSpec, ...] = PIPELINE_STAGES,
+) -> LagReport:
+    """Compute per-stage consumer lag and the pipeline-wide total."""
+    stage_lags = [_stage_lag(reader, stage) for stage in stages]
+    return LagReport(
+        stages=stage_lags,
+        total_lag=sum(s.total_lag for s in stage_lags),
+    )
+
+
+# ---------------------------------------------------------------------------
+# B2 object-store size
+# ---------------------------------------------------------------------------
+
+
+class ObjectSizeStore(Protocol):
+    """Subset of the S3/B2 client surface the size report needs.
+
+    Matches ``workers.lib.object_store.ObjectStore`` (``bucket`` + a lazily
+    constructed ``client``) so the same object the workers use satisfies
+    this protocol.
+    """
+
+    bucket: str
+
+    @property
+    def client(self) -> Any: ...
+
+
+@dataclass(frozen=True)
+class PrefixSize:
+    """Object count + byte total under one B2 prefix."""
+
+    prefix: str
+    object_count: int
+    total_bytes: int
+
+
+@dataclass(frozen=True)
+class StorageReport:
+    """Object-store size broken down by stage prefix, plus the rollup."""
+
+    prefixes: list[PrefixSize]
+    total_object_count: int
+    total_bytes: int
+
+
+def _sum_prefix(store: ObjectSizeStore, prefix: str) -> PrefixSize:
+    """Sum object count + bytes under ``prefix`` via paginated listing.
+
+    Uses the paginated ``list_objects_v2`` surface (same as the reset
+    surface's ``_delete_prefix``) so a very large prefix is not truncated to
+    a single response page.
+    """
+    client = store.client
+    count = 0
+    total_bytes = 0
+
+    continuation: str | None = None
+    while True:
+        kwargs: dict[str, Any] = {"Bucket": store.bucket, "Prefix": prefix}
+        if continuation is not None:
+            kwargs["ContinuationToken"] = continuation
+        response = client.list_objects_v2(**kwargs)
+        for obj in response.get("Contents", []) or []:
+            count += 1
+            total_bytes += int(obj.get("Size", 0))
+        if not response.get("IsTruncated"):
+            break
+        continuation = response.get("NextContinuationToken")
+        if continuation is None:
+            break
+
+    return PrefixSize(prefix=prefix, object_count=count, total_bytes=total_bytes)
+
+
+def compute_storage_report(
+    store: ObjectSizeStore,
+    *,
+    prefixes: tuple[str, ...] = STORAGE_PREFIXES,
+) -> StorageReport:
+    """Compute per-prefix object count + bytes and the bucket-wide rollup."""
+    prefix_sizes = [_sum_prefix(store, prefix) for prefix in prefixes]
+    return StorageReport(
+        prefixes=prefix_sizes,
+        total_object_count=sum(p.object_count for p in prefix_sizes),
+        total_bytes=sum(p.total_bytes for p in prefix_sizes),
+    )

--- a/src/pipeline/metrics_adapters.py
+++ b/src/pipeline/metrics_adapters.py
@@ -1,0 +1,91 @@
+"""Live Kafka adapter for the consumer-lag metric (issue #76).
+
+Implements :class:`src.pipeline.metrics.KafkaOffsetReader` against a real
+broker using ``kafka-python``:
+
+- **end offsets** (high-water marks) come from a ``KafkaConsumer`` —
+  ``partitions_for_topic`` + ``end_offsets`` — which is the only
+  kafka-python surface that exposes the log-end offset.
+- **committed offsets** for *another* group come from a
+  ``KafkaAdminClient`` — ``list_consumer_group_offsets`` — so we can read a
+  stage's committed position without joining its consumer group.
+
+The object-store size metric needs no adapter here:
+``workers.lib.object_store.ObjectStore`` already satisfies
+:class:`src.pipeline.metrics.ObjectSizeStore` (``bucket`` + ``client``).
+
+Both clients are injectable so the mapping logic is unit-tested with
+fakes; in production they are built lazily from ``bootstrap_servers``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["KafkaLagAdapter"]
+
+
+class KafkaLagAdapter:
+    """``KafkaOffsetReader`` backed by a live Kafka broker.
+
+    ``admin_client`` and ``consumer`` are injected in tests; in production
+    they are lazily constructed from ``bootstrap_servers`` on first use so
+    importing this module never opens a broker connection.
+    """
+
+    def __init__(
+        self,
+        *,
+        bootstrap_servers: str | None = None,
+        admin_client: Any | None = None,
+        consumer: Any | None = None,
+    ) -> None:
+        if admin_client is None and consumer is None and bootstrap_servers is None:
+            raise ValueError("bootstrap_servers is required when clients are not injected")
+        self._bootstrap = bootstrap_servers
+        self._admin = admin_client
+        self._consumer = consumer
+
+    @property
+    def admin(self) -> Any:
+        if self._admin is None:
+            from kafka.admin import KafkaAdminClient  # type: ignore[import-untyped]
+
+            self._admin = KafkaAdminClient(bootstrap_servers=self._bootstrap)
+        return self._admin
+
+    @property
+    def consumer(self) -> Any:
+        if self._consumer is None:
+            from kafka import KafkaConsumer  # type: ignore[import-untyped]
+
+            # No group_id / no subscription: this consumer is only used for
+            # metadata + end-offset lookups, never to consume records.
+            self._consumer = KafkaConsumer(bootstrap_servers=self._bootstrap)
+        return self._consumer
+
+    def end_offsets(self, topic: str) -> dict[int, int]:
+        # ``kafka`` is already flagged import-untyped at the KafkaConsumer
+        # import above; a second import from the same module needs no ignore.
+        from kafka import TopicPartition
+
+        partitions = self.consumer.partitions_for_topic(topic)
+        if not partitions:
+            return {}
+        tps = [TopicPartition(topic, p) for p in partitions]
+        raw: dict[Any, int] = self.consumer.end_offsets(tps)
+        return {tp.partition: int(offset) for tp, offset in raw.items()}
+
+    def committed_offsets(self, group_id: str, topic: str) -> dict[int, int]:
+        raw: dict[Any, Any] = self.admin.list_consumer_group_offsets(group_id)
+        result: dict[int, int] = {}
+        for tp, meta in raw.items():
+            if tp.topic != topic:
+                continue
+            offset = int(meta.offset)
+            # kafka-python uses -1 for "no committed offset"; omit so the lag
+            # computation treats the partition as never-committed.
+            if offset < 0:
+                continue
+            result[tp.partition] = offset
+        return result

--- a/src/pipeline/reprocess.py
+++ b/src/pipeline/reprocess.py
@@ -1,0 +1,231 @@
+"""Reprocess-from-stage — re-run the pipeline from a chosen stage (issue #76).
+
+Reprocessing from stage *X* re-delivers *X*'s input and lets the pipeline
+flow forward from there, **without deleting any staged B2 data** (that is
+what the reset surface is for). It is the lighter, non-destructive sibling
+of ``src/pipeline/reset.py``.
+
+Two things have to happen for a genuine reprocess:
+
+1. **Rewind X's consumer group to the start of its consume topic** so the
+   stage re-reads every batch it has already seen and re-emits downstream.
+   Downstream stages then re-consume naturally as the re-emitted messages
+   arrive at the tail of their topics — so only the *entry* stage's group
+   is rewound, not every downstream group.
+2. **Clear the idempotency checkpoints for X and every downstream stage.**
+   Each worker guards against duplicate work with a ``(stage, batch_id)``
+   checkpoint (``workers.lib.checkpoint_pg``). A re-delivered batch carries
+   its original ``batch_id``, so without clearing those rows every stage
+   from X onward would treat the re-delivery as already-done and skip it —
+   making the reprocess a silent no-op. The checkpoint stage key equals the
+   stage's ``consumer_group`` (see ``src/pipeline/stages.py``).
+
+Every reprocess (dry-run included) writes an audit entry to ``data/audit/``
+via ``src/pipeline/audit.py``, mirroring the reset surface, so operators
+have a record of who re-ran what and when.
+
+All resource clients (Kafka admin, checkpoint store) are injected so the
+unit suite exercises the orchestration against in-memory fakes — no Kafka,
+no Postgres.
+
+Operational note: like the reset surface's offset reset, rewinding a
+consumer group's committed offsets takes effect for the running workers on
+their next rebalance/restart — Kafka only lets an offset be altered for a
+group with no active members on that partition. The admin panel triggers
+the rewind + checkpoint clear here; the worker fleet picks it up. This is
+the same operational contract the reset endpoints already carry.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from src.pipeline.audit import AuditEntry, create_audit_entry, write_audit_entry
+from src.pipeline.stages import STAGE_BY_NAME, StageSpec, downstream_stages
+
+__all__ = [
+    "CheckpointResetter",
+    "OffsetRewinder",
+    "PipelineReprocessor",
+    "ReprocessPlan",
+    "ReprocessReport",
+    "plan_reprocess",
+    "write_dry_run_audit",
+]
+
+
+class OffsetRewinder(Protocol):
+    """Kafka surface needed to rewind a stage's consumer group.
+
+    Matches ``src.pipeline.reset.KafkaAdmin.reset_consumer_offsets`` so the
+    same ``KafkaPythonAdmin`` adapter satisfies both surfaces — rewinding to
+    the start of the topic re-delivers every batch to the stage.
+    """
+
+    def reset_consumer_offsets(self, topic: str, group_id: str) -> None: ...
+
+
+class CheckpointResetter(Protocol):
+    """Idempotency-checkpoint surface. ``clear`` deletes every checkpoint row
+    for one stage key and returns the number of rows removed."""
+
+    def clear(self, stage_key: str) -> int: ...
+
+
+@dataclass(frozen=True)
+class ReprocessPlan:
+    """Resolved, inspectable plan for a reprocess — what *would* run.
+
+    Shared by the dry-run preview and the executed report so the admin UI
+    sees the exact same affected stages / rewound group / topic in both.
+    """
+
+    from_stage: str
+    rewound_group: str
+    rewound_topic: str
+    affected_stages: list[str]
+
+    def describe(self, *, indent: str = "  ") -> str:
+        lines = [
+            f"REPROCESS from stage '{self.from_stage}':",
+            f"{indent}Rewind consumer group : {self.rewound_group}",
+            f"{indent}On consume topic       : {self.rewound_topic}",
+            f"{indent}Clear checkpoints for  :",
+        ]
+        lines.extend(f"{indent}  - {s}" for s in self.affected_stages)
+        return "\n".join(lines)
+
+
+@dataclass
+class ReprocessReport:
+    """What a reprocess actually did. Saved into the audit-entry summary."""
+
+    from_stage: str
+    rewound_group: str
+    rewound_topic: str
+    affected_stages: list[str] = field(default_factory=list)
+    checkpoints_cleared: dict[str, int] = field(default_factory=dict)
+    duration_seconds: float = 0.0
+    dry_run: bool = False
+
+    def to_summary(self) -> dict[str, Any]:
+        return {
+            "from_stage": self.from_stage,
+            "rewound_group": self.rewound_group,
+            "rewound_topic": self.rewound_topic,
+            "affected_stages": self.affected_stages,
+            "checkpoints_cleared": self.checkpoints_cleared,
+            "dry_run": self.dry_run,
+        }
+
+
+def plan_reprocess(stage_name: str) -> ReprocessPlan:
+    """Resolve the reprocess plan for ``stage_name``.
+
+    Raises ``ValueError`` for an unknown stage (the API maps that to a 422).
+    """
+    stage = _resolve_stage(stage_name)
+    affected = downstream_stages(stage.name)
+    return ReprocessPlan(
+        from_stage=stage.name,
+        rewound_group=stage.consumer_group,
+        rewound_topic=stage.consume_topic,
+        affected_stages=[s.name for s in affected],
+    )
+
+
+def _resolve_stage(stage_name: str) -> StageSpec:
+    stage = STAGE_BY_NAME.get(stage_name)
+    if stage is None:
+        raise ValueError(f"unknown stage: {stage_name!r}. Known: {sorted(STAGE_BY_NAME)}")
+    return stage
+
+
+class PipelineReprocessor:
+    """Coordinates the offset rewind + checkpoint clear and writes an audit entry.
+
+    Dependencies are injected so tests exercise the full flow against fakes —
+    no Kafka, no Postgres.
+    """
+
+    def __init__(
+        self,
+        *,
+        kafka: OffsetRewinder,
+        checkpoints: CheckpointResetter,
+        data_dir: Path,
+    ) -> None:
+        self.kafka = kafka
+        self.checkpoints = checkpoints
+        self.data_dir = data_dir
+
+    def reprocess(self, stage_name: str) -> tuple[ReprocessReport, AuditEntry, Path]:
+        """Rewind the stage's group, clear affected checkpoints, write audit.
+
+        Raises ``ValueError`` for an unknown stage name.
+        """
+        stage = _resolve_stage(stage_name)
+        affected = downstream_stages(stage.name)
+
+        start = time.monotonic()
+
+        # Clear checkpoints for the entry stage and every downstream stage
+        # FIRST, so a re-delivered batch is never skipped between the rewind
+        # and the clear. The checkpoint stage key is the consumer_group.
+        cleared: dict[str, int] = {}
+        for s in affected:
+            cleared[s.name] = self.checkpoints.clear(s.consumer_group)
+
+        # Then rewind only the entry stage's group to re-deliver its input.
+        self.kafka.reset_consumer_offsets(stage.consume_topic, stage.consumer_group)
+
+        report = ReprocessReport(
+            from_stage=stage.name,
+            rewound_group=stage.consumer_group,
+            rewound_topic=stage.consume_topic,
+            affected_stages=[s.name for s in affected],
+            checkpoints_cleared=cleared,
+            duration_seconds=round(time.monotonic() - start, 3),
+        )
+        entry = create_audit_entry(
+            stage=f"reprocess-{stage.name}",
+            duration_seconds=report.duration_seconds,
+            rows_affected=sum(cleared.values()),
+            summary=report.to_summary(),
+        )
+        path = write_audit_entry(self.data_dir, entry)
+        return report, entry, path
+
+
+def write_dry_run_audit(
+    stage_name: str,
+    *,
+    data_dir: Path,
+) -> tuple[ReprocessReport, AuditEntry, Path]:
+    """Record a reprocess dry-run as an audit entry without doing any work.
+
+    Mirrors the reset surface's dry-run: the preview the admin UI calls
+    first must touch no infra, so this is kept module-level (no Kafka/PG
+    adapters constructed) and writes an audit entry with ``dry_run=True`` and
+    zeroed clear counts. Raises ``ValueError`` for an unknown stage name.
+    """
+    plan = plan_reprocess(stage_name)
+    report = ReprocessReport(
+        from_stage=plan.from_stage,
+        rewound_group=plan.rewound_group,
+        rewound_topic=plan.rewound_topic,
+        affected_stages=plan.affected_stages,
+        checkpoints_cleared={s: 0 for s in plan.affected_stages},
+        dry_run=True,
+    )
+    entry = create_audit_entry(
+        stage=f"reprocess-{plan.from_stage}",
+        duration_seconds=0.0,
+        rows_affected=0,
+        summary=report.to_summary(),
+    )
+    path = write_audit_entry(data_dir, entry)
+    return report, entry, path

--- a/src/pipeline/reprocess_adapters.py
+++ b/src/pipeline/reprocess_adapters.py
@@ -1,0 +1,67 @@
+"""Concrete checkpoint adapter for :mod:`src.pipeline.reprocess` (issue #76).
+
+The Kafka side of a reprocess reuses
+``src.pipeline.reset_adapters.KafkaPythonAdmin`` (its
+``reset_consumer_offsets`` rewinds a group to offset 0), so the only new
+adapter here is the checkpoint resetter that clears
+``pipeline.worker_checkpoint`` rows for a stage.
+
+``_CHECKPOINT_TABLE`` is re-declared rather than imported from
+``workers.lib.checkpoint_pg`` to keep ``src`` independent of ``workers``
+(``workers`` imports ``src``, never the reverse — see
+``src/pipeline/stages.py``). ``tests/test_pipeline/test_reprocess.py`` pins
+it against ``workers.lib.checkpoint_pg.CHECKPOINT_TABLE`` so the two
+declarations cannot drift.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+__all__ = ["PgCheckpointResetter"]
+
+# Must equal workers.lib.checkpoint_pg.CHECKPOINT_TABLE (pinned by test).
+_CHECKPOINT_TABLE = "pipeline.worker_checkpoint"
+
+
+class _PgConnection(Protocol):
+    """Minimal psycopg connection surface the resetter needs.
+
+    Mirrors ``workers.lib.checkpoint_pg._PgConnection`` so a fake (or a real
+    ``psycopg.Connection``) works without importing psycopg here.
+    """
+
+    def cursor(self) -> Any: ...
+    def commit(self) -> None: ...
+    def close(self) -> None: ...
+
+
+class PgCheckpointResetter:
+    """Clears ``pipeline.worker_checkpoint`` rows for a stage.
+
+    Implements ``src.pipeline.reprocess.CheckpointResetter``. One connection
+    serves every stage in a reprocess — the resetter is constructed once and
+    ``clear`` is called per affected stage.
+    """
+
+    def __init__(self, conn: _PgConnection) -> None:
+        self._conn = conn
+
+    def clear(self, stage_key: str) -> int:
+        """Delete every checkpoint row for ``stage_key``; return the row count.
+
+        The table name is a fixed module constant (never request-derived), so
+        interpolating it into the statement carries no injection risk; the
+        stage key is a bound parameter.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"DELETE FROM {_CHECKPOINT_TABLE} WHERE stage = %s",
+                (stage_key,),
+            )
+            deleted = int(cur.rowcount) if cur.rowcount is not None else 0
+        self._conn.commit()
+        return deleted
+
+    def close(self) -> None:
+        self._conn.close()

--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -1,0 +1,109 @@
+"""Canonical pipeline-stage topology (issue #76).
+
+The worker pipeline runs four consuming stages in order::
+
+    dedup -> enrich -> normalize -> graph-load
+
+Each stage is a Kafka consumer group that reads one topic, processes a
+batch, and (except the terminal ``graph-load`` stage) produces to the
+next stage's topic. The metrics surface (consumer-lag) and the
+reprocess-from-stage surface both need a single, authoritative table of
+``(stage, consumer-group, consume-topic, produce-topic)`` so they read
+and rewind exactly the topics/groups the workers actually use.
+
+Why this lives in ``src`` rather than importing ``workers.lib.topics``
+-----------------------------------------------------------------------
+``src`` is the library layer; ``workers`` is the application layer built
+on top of it (``workers`` imports ``src``, never the reverse). To keep
+that direction clean — and to match the existing precedent in
+``src/pipeline/reset.py``, which re-declares its stage→topic table rather
+than importing from ``workers`` — the wire-level topic strings are
+re-declared here as literals. ``tests/test_pipeline/test_stages.py`` pins
+them against ``workers.lib.topics`` and the worker entrypoints' wiring, so
+any drift between the two declarations breaks a test rather than silently
+mis-reading a stage's lag.
+
+The ``consumer_group`` string doubles as the **checkpoint stage key**: each
+worker constructs its idempotency checkpoint with
+``build_checkpoint(settings.worker_name)`` and ``worker_name ==
+consumer_group`` for every stage, so the ``pipeline.worker_checkpoint``
+rows for a stage are keyed by this same string. Reprocess relies on that
+equivalence to clear the right checkpoint rows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["PIPELINE_STAGES", "STAGE_BY_NAME", "StageSpec", "downstream_stages"]
+
+
+@dataclass(frozen=True)
+class StageSpec:
+    """One consuming pipeline stage.
+
+    Attributes:
+        name: Short stage identifier used by the admin UI and the
+            reprocess API (``dedup`` | ``enrich`` | ``normalize`` |
+            ``graph-load``).
+        consumer_group: Kafka consumer-group id. Matches
+            ``workers.<stage>.main``'s ``WorkerSettings.consumer_group`` and
+            doubles as the ``pipeline.worker_checkpoint`` stage key.
+        consume_topic: Topic this stage reads (where its lag is measured).
+        produce_topic: Topic this stage writes, or ``None`` for the
+            terminal ``graph-load`` stage.
+    """
+
+    name: str
+    consumer_group: str
+    consume_topic: str
+    produce_topic: str | None
+
+
+# Ordered dedup -> enrich -> normalize -> graph-load. The topic literals MUST
+# equal the corresponding ``workers.lib.topics`` constants — pinned by
+# tests/test_pipeline/test_stages.py.
+PIPELINE_STAGES: tuple[StageSpec, ...] = (
+    StageSpec(
+        name="dedup",
+        consumer_group="dedup-worker",
+        consume_topic="pipeline.raw.landed",
+        produce_topic="pipeline.dedup.done",
+    ),
+    StageSpec(
+        name="enrich",
+        consumer_group="enrich-worker",
+        consume_topic="pipeline.dedup.done",
+        produce_topic="pipeline.enrich.done",
+    ),
+    StageSpec(
+        name="normalize",
+        consumer_group="normalize-worker",
+        consume_topic="pipeline.enrich.done",
+        produce_topic="pipeline.normalize.done",
+    ),
+    StageSpec(
+        name="graph-load",
+        consumer_group="ingest-worker",
+        consume_topic="pipeline.normalize.done",
+        produce_topic=None,
+    ),
+)
+
+STAGE_BY_NAME: dict[str, StageSpec] = {s.name: s for s in PIPELINE_STAGES}
+
+
+def downstream_stages(stage_name: str) -> tuple[StageSpec, ...]:
+    """Return ``stage_name`` and every stage after it, in pipeline order.
+
+    Reprocessing from a stage re-delivers that stage's input and re-emits
+    downstream, so the idempotency checkpoints for the named stage *and*
+    every stage after it must be cleared for the re-delivered batches to be
+    re-processed rather than skipped. Raises ``KeyError`` for an unknown
+    stage name.
+    """
+    if stage_name not in STAGE_BY_NAME:
+        raise KeyError(stage_name)
+    names = [s.name for s in PIPELINE_STAGES]
+    start = names.index(stage_name)
+    return PIPELINE_STAGES[start:]

--- a/tests/test_api/test_metrics_endpoints.py
+++ b/tests/test_api/test_metrics_endpoints.py
@@ -1,0 +1,126 @@
+"""HTTP-layer tests for the admin metrics endpoints (issue #76).
+
+Covers the contract bars:
+
+1. **Auth gate** — both metric routes are admin-only (missing header -> 401;
+   admin -> through), exercising the REAL ``require_admin``.
+2. **Lag shape** — ``GET /admin/metrics/lag`` returns per-stage + total lag
+   computed from the injected offset reader.
+3. **Storage shape** — ``GET /admin/metrics/storage`` returns per-prefix +
+   rollup sizes from the injected object store.
+
+The Kafka offset reader and object store are injected via
+``app.dependency_overrides`` — no broker, no S3/B2.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.api.auth as auth_mod
+from src.api.app import create_app
+from src.api.auth import require_admin
+from src.api.deps import get_kafka_lag_reader, get_object_size_store
+
+
+class _FakeOffsetReader:
+    """Every topic: one partition, head 100; no committed offset -> lag 100."""
+
+    def end_offsets(self, topic: str) -> dict[int, int]:
+        return {0: 100}
+
+    def committed_offsets(self, group_id: str, topic: str) -> dict[int, int]:
+        return {0: 90}
+
+
+class _FakeS3Client:
+    def list_objects_v2(
+        self, *, Bucket: str, Prefix: str, ContinuationToken: str | None = None
+    ) -> dict[str, Any]:
+        if Prefix == "raw/":
+            return {"Contents": [{"Key": "raw/a.parquet", "Size": 5}], "IsTruncated": False}
+        return {"Contents": [], "IsTruncated": False}
+
+
+class _FakeStore:
+    bucket = "noorinalabs-pipeline"
+
+    @property
+    def client(self) -> _FakeS3Client:
+        return _FakeS3Client()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_kafka_lag_reader] = lambda: _FakeOffsetReader()
+    app.dependency_overrides[get_object_size_store] = lambda: _FakeStore()
+    app.dependency_overrides[require_admin] = lambda: "admin-user-id"
+    return TestClient(app)
+
+
+# --- Auth gate (real guard) --------------------------------------------------
+
+
+def _client_real_guard() -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_kafka_lag_reader] = lambda: _FakeOffsetReader()
+    app.dependency_overrides[get_object_size_store] = lambda: _FakeStore()
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_lag_requires_auth() -> None:
+    assert _client_real_guard().get("/admin/metrics/lag").status_code == 401
+
+
+def test_storage_requires_auth() -> None:
+    assert _client_real_guard().get("/admin/metrics/storage").status_code == 401
+
+
+def test_admin_token_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        auth_mod,
+        "verify_user_service_token",
+        lambda _t: {"type": "access", "sub": "a1", "roles": ["admin"]},
+    )
+    resp = _client_real_guard().get(
+        "/admin/metrics/lag", headers={"Authorization": "Bearer admintoken"}
+    )
+    assert resp.status_code == 200
+
+
+# --- Response shapes ---------------------------------------------------------
+
+
+def test_lag_response_shape(client: TestClient) -> None:
+    body = client.get("/admin/metrics/lag").json()
+    assert [s["stage"] for s in body["stages"]] == [
+        "dedup",
+        "enrich",
+        "normalize",
+        "graph-load",
+    ]
+    dedup = body["stages"][0]
+    assert dedup["consumer_group"] == "dedup-worker"
+    assert dedup["topic"] == "pipeline.raw.landed"
+    assert dedup["total_lag"] == 10
+    assert dedup["partitions"][0] == {
+        "partition": 0,
+        "end_offset": 100,
+        "committed_offset": 90,
+        "lag": 10,
+    }
+    assert body["total_lag"] == 40  # 4 stages * 10
+
+
+def test_storage_response_shape(client: TestClient) -> None:
+    body = client.get("/admin/metrics/storage").json()
+    by_prefix = {p["prefix"]: p for p in body["prefixes"]}
+    assert set(by_prefix) == {"raw/", "dedup/", "enriched/", "normalized/", "staged/"}
+    assert by_prefix["raw/"] == {"prefix": "raw/", "object_count": 1, "total_bytes": 5}
+    assert by_prefix["dedup/"]["object_count"] == 0
+    assert body["total_object_count"] == 1
+    assert body["total_bytes"] == 5

--- a/tests/test_api/test_reprocess_endpoints.py
+++ b/tests/test_api/test_reprocess_endpoints.py
@@ -1,0 +1,158 @@
+"""HTTP-layer tests for the admin reprocess endpoint (issue #76).
+
+Covers the contract bars:
+
+1. **Auth gate** — admin-only (missing header -> 401; admin -> through),
+   exercising the REAL ``require_admin``.
+2. **Unknown stage rejected** — a bad stage name is a 422 *before* any client
+   is built.
+3. **Dry-run is inert** — a dry-run writes an audit entry and NEVER invokes
+   the reprocessor factory (no live Kafka/PG client construction).
+4. **Live path** — a non-dry-run reprocess builds the reprocessor once and
+   drives it with the requested stage.
+
+The reprocessor factory + data dir are injected via
+``app.dependency_overrides`` — no Kafka, no Postgres.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.api.auth as auth_mod
+from src.api.app import create_app
+from src.api.auth import require_admin
+from src.api.deps import get_data_dir, get_reprocessor_factory
+from src.pipeline.audit import AuditEntry, create_audit_entry
+from src.pipeline.reprocess import ReprocessReport
+
+
+class _FakeReprocessor:
+    """Records the stage it was asked to reprocess; writes no infra."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def reprocess(self, stage_name: str) -> tuple[ReprocessReport, AuditEntry, Path]:
+        self.calls.append(stage_name)
+        report = ReprocessReport(
+            from_stage=stage_name,
+            rewound_group=f"{stage_name}-worker",
+            rewound_topic="pipeline.test.topic",
+            affected_stages=[stage_name],
+            checkpoints_cleared={stage_name: 0},
+        )
+        entry = create_audit_entry(stage=f"reprocess-{stage_name}", duration_seconds=0.0)
+        return report, entry, Path("/tmp/fake-audit.json")
+
+
+class _FactorySpy:
+    def __init__(self, reprocessor: _FakeReprocessor) -> None:
+        self.reprocessor = reprocessor
+        self.build_count = 0
+
+    def __call__(self) -> _FakeReprocessor:
+        self.build_count += 1
+        return self.reprocessor
+
+
+@pytest.fixture
+def fake_reprocessor() -> _FakeReprocessor:
+    return _FakeReprocessor()
+
+
+@pytest.fixture
+def factory_spy(fake_reprocessor: _FakeReprocessor) -> _FactorySpy:
+    return _FactorySpy(fake_reprocessor)
+
+
+@pytest.fixture
+def client(tmp_path: Path, factory_spy: _FactorySpy) -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_reprocessor_factory] = lambda: factory_spy
+    app.dependency_overrides[get_data_dir] = lambda: tmp_path
+    app.dependency_overrides[require_admin] = lambda: "admin-user-id"
+    return TestClient(app)
+
+
+# --- Auth gate ---------------------------------------------------------------
+
+
+def _client_real_guard(tmp_path: Path, factory_spy: _FactorySpy) -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_reprocessor_factory] = lambda: factory_spy
+    app.dependency_overrides[get_data_dir] = lambda: tmp_path
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_missing_auth_rejected(
+    tmp_path: Path, fake_reprocessor: _FakeReprocessor, factory_spy: _FactorySpy
+) -> None:
+    c = _client_real_guard(tmp_path, factory_spy)
+    resp = c.post("/admin/reprocess", json={"stage": "enrich"})
+    assert resp.status_code == 401
+    assert fake_reprocessor.calls == []
+
+
+def test_admin_token_allowed(
+    tmp_path: Path,
+    factory_spy: _FactorySpy,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        auth_mod,
+        "verify_user_service_token",
+        lambda _t: {"type": "access", "sub": "a1", "roles": ["admin"]},
+    )
+    c = _client_real_guard(tmp_path, factory_spy)
+    resp = c.post(
+        "/admin/reprocess",
+        json={"stage": "enrich"},
+        headers={"Authorization": "Bearer admintoken"},
+    )
+    assert resp.status_code == 200
+
+
+# --- Behaviour ---------------------------------------------------------------
+
+
+def test_unknown_stage_rejected_before_build(
+    client: TestClient, fake_reprocessor: _FakeReprocessor, factory_spy: _FactorySpy
+) -> None:
+    resp = client.post("/admin/reprocess", json={"stage": "bogus"})
+    assert resp.status_code == 422
+    assert fake_reprocessor.calls == []
+    assert factory_spy.build_count == 0
+
+
+def test_live_reprocess_builds_factory_once_and_calls_stage(
+    client: TestClient, fake_reprocessor: _FakeReprocessor, factory_spy: _FactorySpy
+) -> None:
+    resp = client.post("/admin/reprocess", json={"stage": "normalize"})
+    assert resp.status_code == 200
+    assert factory_spy.build_count == 1
+    assert fake_reprocessor.calls == ["normalize"]
+    body: dict[str, Any] = resp.json()
+    assert body["from_stage"] == "normalize"
+    assert body["dry_run"] is False
+    assert body["summary"]["from_stage"] == "normalize"
+
+
+def test_dry_run_is_inert_and_writes_audit(
+    client: TestClient, fake_reprocessor: _FakeReprocessor, factory_spy: _FactorySpy, tmp_path: Path
+) -> None:
+    resp = client.post("/admin/reprocess", json={"stage": "dedup", "dry_run": True})
+    assert resp.status_code == 200
+    # Dry-run never builds the live reprocessor.
+    assert factory_spy.build_count == 0
+    assert fake_reprocessor.calls == []
+    body = resp.json()
+    assert body["dry_run"] is True
+    assert body["from_stage"] == "dedup"
+    audit_files = list((tmp_path / "audit").glob("*.json"))
+    assert len(audit_files) == 1
+    assert Path(body["audit_entry_path"]) == audit_files[0]

--- a/tests/test_pipeline/test_metrics.py
+++ b/tests/test_pipeline/test_metrics.py
@@ -1,0 +1,255 @@
+"""Pipeline metrics: consumer-lag arithmetic + object-store size summing (#76).
+
+All core tests run against in-memory fakes — no Kafka broker, no S3/B2. The
+live Kafka adapter's offset/partition mapping is exercised with fake admin +
+consumer objects keyed by real ``kafka.TopicPartition`` namedtuples.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+from typing import Any
+
+from src.pipeline.metrics import (
+    STORAGE_PREFIXES,
+    compute_lag_report,
+    compute_storage_report,
+)
+from src.pipeline.stages import PIPELINE_STAGES
+
+# ---------------------------------------------------------------------------
+# Consumer lag
+# ---------------------------------------------------------------------------
+
+
+class _FakeOffsetReader:
+    """Returns canned end/committed offsets keyed by topic / (group, topic)."""
+
+    def __init__(
+        self,
+        *,
+        end: dict[str, dict[int, int]],
+        committed: dict[tuple[str, str], dict[int, int]],
+    ) -> None:
+        self._end = end
+        self._committed = committed
+        self.end_calls: list[str] = []
+        self.committed_calls: list[tuple[str, str]] = []
+
+    def end_offsets(self, topic: str) -> dict[int, int]:
+        self.end_calls.append(topic)
+        return self._end.get(topic, {})
+
+    def committed_offsets(self, group_id: str, topic: str) -> dict[int, int]:
+        self.committed_calls.append((group_id, topic))
+        return self._committed.get((group_id, topic), {})
+
+
+def _all_topics_reader(end_each: int, committed_each: int) -> _FakeOffsetReader:
+    """Reader giving every stage one partition with the given end/committed."""
+    end = {s.consume_topic: {0: end_each} for s in PIPELINE_STAGES}
+    committed = {(s.consumer_group, s.consume_topic): {0: committed_each} for s in PIPELINE_STAGES}
+    return _FakeOffsetReader(end=end, committed=committed)
+
+
+def test_lag_report_covers_every_stage_with_per_partition_lag() -> None:
+    reader = _all_topics_reader(end_each=100, committed_each=90)
+    report = compute_lag_report(reader)
+
+    assert [s.stage for s in report.stages] == ["dedup", "enrich", "normalize", "graph-load"]
+    for stage in report.stages:
+        assert stage.total_lag == 10
+        assert len(stage.partitions) == 1
+        assert stage.partitions[0].lag == 10
+        assert stage.partitions[0].end_offset == 100
+        assert stage.partitions[0].committed_offset == 90
+    # 4 stages * 10 lag each.
+    assert report.total_lag == 40
+
+
+def test_lag_sums_across_multiple_partitions() -> None:
+    dedup = PIPELINE_STAGES[0]
+    reader = _FakeOffsetReader(
+        end={dedup.consume_topic: {0: 50, 1: 30, 2: 10}},
+        committed={(dedup.consumer_group, dedup.consume_topic): {0: 40, 1: 30, 2: 0}},
+    )
+    report = compute_lag_report(reader, stages=(dedup,))
+    stage = report.stages[0]
+    # partition lags: 10, 0, 10 -> total 20; partitions sorted by id.
+    assert [p.partition for p in stage.partitions] == [0, 1, 2]
+    assert [p.lag for p in stage.partitions] == [10, 0, 10]
+    assert stage.total_lag == 20
+    assert report.total_lag == 20
+
+
+def test_uncommitted_partition_treated_as_full_backlog() -> None:
+    dedup = PIPELINE_STAGES[0]
+    reader = _FakeOffsetReader(
+        end={dedup.consume_topic: {0: 75}},
+        committed={},  # group never committed
+    )
+    stage = compute_lag_report(reader, stages=(dedup,)).stages[0]
+    assert stage.partitions[0].committed_offset is None
+    assert stage.partitions[0].lag == 75
+    assert stage.total_lag == 75
+
+
+def test_committed_ahead_of_end_clamps_to_zero() -> None:
+    dedup = PIPELINE_STAGES[0]
+    reader = _FakeOffsetReader(
+        end={dedup.consume_topic: {0: 10}},
+        committed={(dedup.consumer_group, dedup.consume_topic): {0: 12}},
+    )
+    stage = compute_lag_report(reader, stages=(dedup,)).stages[0]
+    assert stage.partitions[0].lag == 0
+
+
+def test_empty_topic_yields_zero_lag_no_partitions() -> None:
+    dedup = PIPELINE_STAGES[0]
+    reader = _FakeOffsetReader(end={}, committed={})
+    stage = compute_lag_report(reader, stages=(dedup,)).stages[0]
+    assert stage.partitions == []
+    assert stage.total_lag == 0
+
+
+# ---------------------------------------------------------------------------
+# Object-store size
+# ---------------------------------------------------------------------------
+
+
+class _FakeSizeS3Client:
+    """In-memory S3 client supporting paginated ``list_objects_v2`` with sizes."""
+
+    def __init__(self, objects: dict[tuple[str, str], int], page_size: int = 1000) -> None:
+        # objects: (bucket, key) -> size in bytes
+        self.objects = dict(objects)
+        self._page_size = page_size
+
+    def list_objects_v2(
+        self, *, Bucket: str, Prefix: str, ContinuationToken: str | None = None
+    ) -> dict[str, Any]:
+        keys = sorted(k for (b, k) in self.objects if b == Bucket and k.startswith(Prefix))
+        start = int(ContinuationToken) if ContinuationToken is not None else 0
+        page = keys[start : start + self._page_size]
+        contents = [{"Key": k, "Size": self.objects[(Bucket, k)]} for k in page]
+        next_start = start + self._page_size
+        truncated = next_start < len(keys)
+        out: dict[str, Any] = {"Contents": contents, "IsTruncated": truncated}
+        if truncated:
+            out["NextContinuationToken"] = str(next_start)
+        return out
+
+
+class _FakeStore:
+    def __init__(self, bucket: str, client: _FakeSizeS3Client) -> None:
+        self.bucket = bucket
+        self._client = client
+
+    @property
+    def client(self) -> _FakeSizeS3Client:
+        return self._client
+
+
+def test_storage_prefixes_match_reset_layout() -> None:
+    """The storage breakdown uses the same B2 stage prefixes the reset surface does."""
+    from src.pipeline.reset import STAGE_PREFIXES
+
+    assert set(STORAGE_PREFIXES) == set(STAGE_PREFIXES.values())
+
+
+def test_storage_report_sums_count_and_bytes_per_prefix() -> None:
+    bucket = "noorinalabs-pipeline"
+    objects = {
+        (bucket, "raw/sunnah/a.parquet"): 100,
+        (bucket, "raw/sunnah/b.parquet"): 200,
+        (bucket, "dedup/sunnah/a.parquet"): 50,
+        (bucket, "staged/x.parquet"): 7,
+        # an object outside the known prefixes is ignored by the per-prefix sum
+        (bucket, "other/z.parquet"): 9999,
+    }
+    store = _FakeStore(bucket, _FakeSizeS3Client(objects))
+    report = compute_storage_report(store)
+
+    by_prefix = {p.prefix: p for p in report.prefixes}
+    assert by_prefix["raw/"].object_count == 2
+    assert by_prefix["raw/"].total_bytes == 300
+    assert by_prefix["dedup/"].object_count == 1
+    assert by_prefix["dedup/"].total_bytes == 50
+    assert by_prefix["staged/"].total_bytes == 7
+    assert by_prefix["enriched/"].object_count == 0
+    # rollup excludes the out-of-prefix object.
+    assert report.total_object_count == 4
+    assert report.total_bytes == 357
+
+
+def test_storage_report_paginates_large_prefix() -> None:
+    bucket = "noorinalabs-pipeline"
+    objects = {(bucket, f"raw/{i:04d}.parquet"): 10 for i in range(2500)}
+    store = _FakeStore(bucket, _FakeSizeS3Client(objects, page_size=1000))
+    report = compute_storage_report(store, prefixes=("raw/",))
+    assert report.prefixes[0].object_count == 2500
+    assert report.prefixes[0].total_bytes == 25000
+
+
+# ---------------------------------------------------------------------------
+# Live Kafka adapter mapping (no broker — fake admin/consumer)
+# ---------------------------------------------------------------------------
+
+_Meta = namedtuple("_Meta", "offset")
+
+
+class _FakeConsumer:
+    def __init__(self, partitions: dict[str, set[int]], end: dict[Any, int]) -> None:
+        self._partitions = partitions
+        self._end = end
+
+    def partitions_for_topic(self, topic: str) -> set[int] | None:
+        return self._partitions.get(topic)
+
+    def end_offsets(self, tps: list[Any]) -> dict[Any, int]:
+        return {tp: self._end[tp] for tp in tps}
+
+
+class _FakeAdmin:
+    def __init__(self, offsets: dict[str, dict[Any, _Meta]]) -> None:
+        self._offsets = offsets
+
+    def list_consumer_group_offsets(self, group_id: str) -> dict[Any, _Meta]:
+        return self._offsets.get(group_id, {})
+
+
+def test_kafka_lag_adapter_maps_end_and_committed_offsets() -> None:
+    from kafka import TopicPartition  # type: ignore[import-untyped]
+
+    from src.pipeline.metrics_adapters import KafkaLagAdapter
+
+    topic = "pipeline.raw.landed"
+    tp0, tp1 = TopicPartition(topic, 0), TopicPartition(topic, 1)
+    other = TopicPartition("other.topic", 0)
+
+    consumer = _FakeConsumer(partitions={topic: {0, 1}}, end={tp0: 100, tp1: 200})
+    admin = _FakeAdmin(
+        offsets={
+            "dedup-worker": {
+                tp0: _Meta(90),
+                tp1: _Meta(-1),  # no committed offset -> omitted
+                other: _Meta(5),  # different topic -> filtered out
+            }
+        }
+    )
+    adapter = KafkaLagAdapter(admin_client=admin, consumer=consumer)
+
+    assert adapter.end_offsets(topic) == {0: 100, 1: 200}
+    assert adapter.committed_offsets("dedup-worker", topic) == {0: 90}
+    assert adapter.end_offsets("missing.topic") == {}
+
+
+def test_kafka_lag_adapter_requires_bootstrap_or_clients() -> None:
+    from src.pipeline.metrics_adapters import KafkaLagAdapter
+
+    try:
+        KafkaLagAdapter()
+    except ValueError:
+        pass
+    else:  # pragma: no cover - guard
+        raise AssertionError("expected ValueError without bootstrap or injected clients")

--- a/tests/test_pipeline/test_reprocess.py
+++ b/tests/test_pipeline/test_reprocess.py
@@ -1,0 +1,211 @@
+"""Reprocess-from-stage behaviour (issue #76).
+
+All tests use in-memory fakes — no Kafka, no Postgres. Covers the
+orchestration (clear downstream checkpoints, rewind the entry stage's
+group), the dry-run inert path, audit emission, the unknown-stage guard,
+and the PG checkpoint-resetter SQL.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.pipeline.reprocess import (
+    PipelineReprocessor,
+    plan_reprocess,
+    write_dry_run_audit,
+)
+
+
+class _RecordingKafka:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.resets: list[tuple[str, str]] = []
+
+    def reset_consumer_offsets(self, topic: str, group_id: str) -> None:
+        self.resets.append((topic, group_id))
+        self.events.append(f"rewind:{group_id}")
+
+
+class _RecordingCheckpoints:
+    def __init__(self, events: list[str], counts: dict[str, int] | None = None) -> None:
+        self.events = events
+        self._counts = counts or {}
+        self.cleared: list[str] = []
+
+    def clear(self, stage_key: str) -> int:
+        self.cleared.append(stage_key)
+        self.events.append(f"clear:{stage_key}")
+        return self._counts.get(stage_key, 0)
+
+
+def _read_audit(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def test_reprocess_clears_downstream_checkpoints_and_rewinds_entry_group(
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    kafka = _RecordingKafka(events)
+    checkpoints = _RecordingCheckpoints(
+        events,
+        counts={"enrich-worker": 3, "normalize-worker": 5, "ingest-worker": 2},
+    )
+    r = PipelineReprocessor(kafka=kafka, checkpoints=checkpoints, data_dir=tmp_path)
+
+    report, _entry, path = r.reprocess("enrich")
+
+    # Entry stage + downstream checkpoints cleared (by consumer-group key).
+    assert checkpoints.cleared == ["enrich-worker", "normalize-worker", "ingest-worker"]
+    # Only the entry stage's group is rewound, on its consume topic.
+    assert kafka.resets == [("pipeline.dedup.done", "enrich-worker")]
+
+    assert report.from_stage == "enrich"
+    assert report.rewound_group == "enrich-worker"
+    assert report.rewound_topic == "pipeline.dedup.done"
+    assert report.affected_stages == ["enrich", "normalize", "graph-load"]
+    assert report.checkpoints_cleared == {
+        "enrich": 3,
+        "normalize": 5,
+        "graph-load": 2,
+    }
+    assert report.dry_run is False
+
+    audit = _read_audit(path)
+    assert audit["stage"] == "reprocess-enrich"
+    assert audit["rows_affected"] == 10  # 3 + 5 + 2
+    assert audit["summary"]["from_stage"] == "enrich"
+
+
+def test_reprocess_clears_checkpoints_before_rewinding(tmp_path: Path) -> None:
+    """A re-delivered batch must never be skippable: clear precedes rewind."""
+    events: list[str] = []
+    kafka = _RecordingKafka(events)
+    checkpoints = _RecordingCheckpoints(events)
+    r = PipelineReprocessor(kafka=kafka, checkpoints=checkpoints, data_dir=tmp_path)
+
+    r.reprocess("normalize")
+
+    assert events == ["clear:normalize-worker", "clear:ingest-worker", "rewind:normalize-worker"]
+
+
+def test_reprocess_from_terminal_stage_only_touches_itself(tmp_path: Path) -> None:
+    events: list[str] = []
+    kafka = _RecordingKafka(events)
+    checkpoints = _RecordingCheckpoints(events)
+    r = PipelineReprocessor(kafka=kafka, checkpoints=checkpoints, data_dir=tmp_path)
+
+    report, _entry, _path = r.reprocess("graph-load")
+    assert checkpoints.cleared == ["ingest-worker"]
+    assert kafka.resets == [("pipeline.normalize.done", "ingest-worker")]
+    assert report.affected_stages == ["graph-load"]
+
+
+def test_reprocess_unknown_stage_raises(tmp_path: Path) -> None:
+    r = PipelineReprocessor(
+        kafka=_RecordingKafka([]), checkpoints=_RecordingCheckpoints([]), data_dir=tmp_path
+    )
+    with pytest.raises(ValueError, match="unknown stage"):
+        r.reprocess("bogus")
+
+
+def test_plan_reprocess_resolves_without_executing() -> None:
+    plan = plan_reprocess("dedup")
+    assert plan.from_stage == "dedup"
+    assert plan.rewound_group == "dedup-worker"
+    assert plan.rewound_topic == "pipeline.raw.landed"
+    assert plan.affected_stages == ["dedup", "enrich", "normalize", "graph-load"]
+    assert "REPROCESS from stage 'dedup'" in plan.describe()
+
+
+def test_plan_reprocess_unknown_stage_raises() -> None:
+    with pytest.raises(ValueError, match="unknown stage"):
+        plan_reprocess("bogus")
+
+
+def test_dry_run_audit_writes_entry_without_work(tmp_path: Path) -> None:
+    report, _entry, path = write_dry_run_audit("dedup", data_dir=tmp_path)
+    assert report.dry_run is True
+    assert report.checkpoints_cleared == {
+        "dedup": 0,
+        "enrich": 0,
+        "normalize": 0,
+        "graph-load": 0,
+    }
+    audit = _read_audit(path)
+    assert audit["stage"] == "reprocess-dedup"
+    assert audit["rows_affected"] == 0
+    assert audit["summary"]["dry_run"] is True
+    # The entry landed under <data_dir>/audit/.
+    assert path.parent == tmp_path / "audit"
+
+
+# ---------------------------------------------------------------------------
+# PG checkpoint resetter
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, rowcount: int) -> None:
+        self.rowcount = rowcount
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...]) -> None:
+        self.executed.append((sql, params))
+
+
+class _FakeConn:
+    def __init__(self, rowcount: int) -> None:
+        self._cursor = _FakeCursor(rowcount)
+        self.commits = 0
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_pg_checkpoint_resetter_deletes_by_stage_and_commits() -> None:
+    from src.pipeline.reprocess_adapters import PgCheckpointResetter
+
+    conn = _FakeConn(rowcount=7)
+    resetter = PgCheckpointResetter(conn)
+    deleted = resetter.clear("enrich-worker")
+
+    assert deleted == 7
+    assert conn.commits == 1
+    sql, params = conn._cursor.executed[0]
+    assert "DELETE FROM" in sql
+    assert "WHERE stage = %s" in sql
+    assert params == ("enrich-worker",)
+
+
+def test_pg_checkpoint_resetter_table_matches_worker_ddl() -> None:
+    """The resetter targets the SAME table the workers' checkpoint DDL creates."""
+    from src.pipeline import reprocess_adapters
+    from workers.lib.checkpoint_pg import CHECKPOINT_TABLE
+
+    assert reprocess_adapters._CHECKPOINT_TABLE == CHECKPOINT_TABLE
+
+
+def test_pg_checkpoint_resetter_null_rowcount_is_zero() -> None:
+    from src.pipeline.reprocess_adapters import PgCheckpointResetter
+
+    conn = _FakeConn(rowcount=None)  # type: ignore[arg-type]
+    assert PgCheckpointResetter(conn).clear("dedup-worker") == 0

--- a/tests/test_pipeline/test_stages.py
+++ b/tests/test_pipeline/test_stages.py
@@ -1,0 +1,80 @@
+"""Pin the canonical pipeline-stage table (issue #76).
+
+``src.pipeline.stages`` re-declares the wire-level topic strings and
+consumer-group ids rather than importing ``workers.lib.topics`` (``src``
+stays independent of ``workers``). These tests are the coupling that makes
+any drift between the two declarations — or between the table and the worker
+entrypoints' actual wiring — fail loudly rather than silently mis-reading a
+stage's lag or rewinding the wrong group.
+"""
+
+from __future__ import annotations
+
+from src.pipeline.stages import (
+    PIPELINE_STAGES,
+    STAGE_BY_NAME,
+    StageSpec,
+    downstream_stages,
+)
+from workers.lib import topics
+
+
+def test_stage_topics_match_workers_topic_constants() -> None:
+    """Each stage's consume/produce topic equals the workers' SSOT constant."""
+    expected: dict[str, tuple[str, str | None]] = {
+        "dedup": (topics.PIPELINE_RAW_LANDED, topics.PIPELINE_DEDUP_DONE),
+        "enrich": (topics.PIPELINE_DEDUP_DONE, topics.PIPELINE_ENRICH_DONE),
+        "normalize": (topics.PIPELINE_ENRICH_DONE, topics.PIPELINE_NORMALIZE_DONE),
+        "graph-load": (topics.PIPELINE_NORMALIZE_DONE, None),
+    }
+    for stage in PIPELINE_STAGES:
+        assert (stage.consume_topic, stage.produce_topic) == expected[stage.name]
+
+
+def test_consumer_groups_match_worker_entrypoints() -> None:
+    """Consumer-group ids match ``workers.<stage>.main``'s WorkerSettings.
+
+    These strings double as the ``pipeline.worker_checkpoint`` stage keys,
+    so a rename here must be a conscious cross-module decision.
+    """
+    groups = {s.name: s.consumer_group for s in PIPELINE_STAGES}
+    assert groups == {
+        "dedup": "dedup-worker",
+        "enrich": "enrich-worker",
+        "normalize": "normalize-worker",
+        "graph-load": "ingest-worker",
+    }
+
+
+def test_stage_chain_is_contiguous() -> None:
+    """Every non-terminal stage produces exactly the next stage's consume topic."""
+    for prev, nxt in zip(PIPELINE_STAGES, PIPELINE_STAGES[1:], strict=False):
+        assert prev.produce_topic == nxt.consume_topic
+    assert PIPELINE_STAGES[-1].produce_topic is None  # graph-load is terminal
+
+
+def test_stage_by_name_covers_every_stage() -> None:
+    assert set(STAGE_BY_NAME) == {s.name for s in PIPELINE_STAGES}
+    for name, spec in STAGE_BY_NAME.items():
+        assert isinstance(spec, StageSpec)
+        assert spec.name == name
+
+
+def test_downstream_stages_returns_stage_and_successors_in_order() -> None:
+    assert [s.name for s in downstream_stages("dedup")] == [
+        "dedup",
+        "enrich",
+        "normalize",
+        "graph-load",
+    ]
+    assert [s.name for s in downstream_stages("normalize")] == ["normalize", "graph-load"]
+    assert [s.name for s in downstream_stages("graph-load")] == ["graph-load"]
+
+
+def test_downstream_stages_unknown_raises() -> None:
+    try:
+        downstream_stages("bogus")
+    except KeyError:
+        pass
+    else:  # pragma: no cover - guard
+        raise AssertionError("expected KeyError for unknown stage")

--- a/workers/lib/checkpoint_pg.py
+++ b/workers/lib/checkpoint_pg.py
@@ -15,9 +15,15 @@ from typing import Any, Protocol
 
 from workers.lib.log import get_logger
 
-__all__ = ["PgCheckpoint", "_PgConnection"]
+__all__ = ["CHECKPOINT_TABLE", "PgCheckpoint", "_PgConnection"]
 
 _logger = get_logger("workers.checkpoint_pg")
+
+# Fully-qualified checkpoint table. Exported so out-of-worker callers that must
+# clear checkpoint rows by stage — the reprocess surface
+# (``src/pipeline/reprocess_adapters.py``) — reference the same table this
+# module's DDL creates instead of re-deriving the name.
+CHECKPOINT_TABLE = "pipeline.worker_checkpoint"
 
 # TTL sweep defaults (#42). The sweep is a no-op until the row count for a
 # stage exceeds ``_SWEEP_THRESHOLD_ROWS``; below that the index stays trivially
@@ -43,10 +49,10 @@ class _PgConnection(Protocol):
     def close(self) -> None: ...
 
 
-_DDL = """
+_DDL = f"""
 CREATE SCHEMA IF NOT EXISTS pipeline;
 
-CREATE TABLE IF NOT EXISTS pipeline.worker_checkpoint (
+CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE} (
     stage      text        NOT NULL,
     batch_id   text        NOT NULL,
     marked_at  timestamptz NOT NULL DEFAULT now(),
@@ -54,7 +60,7 @@ CREATE TABLE IF NOT EXISTS pipeline.worker_checkpoint (
 );
 
 CREATE INDEX IF NOT EXISTS worker_checkpoint_marked_at_idx
-    ON pipeline.worker_checkpoint (marked_at);
+    ON {CHECKPOINT_TABLE} (marked_at);
 """
 
 


### PR DESCRIPTION
## Summary

Closes #76. Adds the admin-only HTTP surface the isnad-graph admin data panel consumes to monitor and steer the pipeline, plus a non-destructive reprocess-from-stage capability.

All routes mount under `/admin` and are guarded by `require_admin` (same user-service RS256 admin JWT as the existing reset endpoints) — no unauthenticated path to any operation.

### Endpoints
- **`GET /admin/metrics/lag`** — per-stage, per-partition Kafka consumer lag + pipeline total. `lag = end_offset − committed_offset` (clamped at 0; an uncommitted partition counts its full head as backlog).
- **`GET /admin/metrics/storage`** — per-B2-prefix object count + bytes, plus a bucket-wide rollup, over the `raw/ dedup/ enriched/ normalized/ staged/` stage layout.
- **`POST /admin/reprocess`** — re-run the pipeline from a chosen stage **without deleting staged B2 data** (that's the reset surface). Rewinds the entry stage's consumer group to the start of its consume topic and clears the idempotency checkpoints for that stage and every downstream stage, so re-delivered batches are reprocessed rather than skipped as already-seen. `dry_run` previews the plan and writes a dry-run audit entry without building a live client (mirrors reset).

### Design
- Core logic in `src/pipeline/metrics.py` and `src/pipeline/reprocess.py` is pure over small injected Protocols (`KafkaOffsetReader`, `ObjectSizeStore`, `OffsetRewinder`, `CheckpointResetter`), so the unit suite exercises the lag arithmetic, prefix-summing pagination, and rewind/checkpoint-clear orchestration with in-memory fakes — no Kafka, S3/B2, or Postgres. Live adapters (`*_adapters.py`) keep SDK imports function-local, matching the reset surface.
- Canonical stage topology in `src/pipeline/stages.py` is re-declared in `src` (rather than importing `workers`, preserving the `workers → src` direction) and **pinned** to `workers.lib.topics` + the worker entrypoints by `tests/test_pipeline/test_stages.py`, so drift fails a test instead of silently mis-reading a stage's lag.
- Exported `CHECKPOINT_TABLE` from `workers.lib.checkpoint_pg` (and routed the DDL through it) so the reprocess checkpoint-resetter clears the exact table the workers create — pinned by test.
- Every reprocess (dry-run included) writes an audit entry under `data/audit/`, consistent with the reset surface.

### Contract / docs
The metric + endpoint contract for the admin-panel consumer is documented in `docs/pipeline-metrics-api.md` (stage vocabulary, response schemas, dry-run semantics, and the consumer-group-rebalance operational note).

## Test Plan
- `ruff check` + `ruff format --check` over `src/ workers/ tests/` — clean.
- `mypy src/` (strict) — clean.
- `pytest -m "not integration"` — **681 passed, 4 skipped** (includes 36 new tests across stages/metrics/reprocess core + both API routers).
- `markdownlint-cli2` over the docs corpus — 0 errors (new doc included).

### What can't be unit-tested here (runtime acceptance)
The live Kafka offset reads, B2 listing, and the actual offset-rewind/checkpoint-clear against a running broker + Postgres require a deployed stack. The adapter mapping logic is covered with fake admin/consumer objects; end-to-end behavior is a post-merge staging check. Per the operational note in the doc, an offset rewind only takes effect for a consumer group with no active members on the partition (same contract the reset endpoints already carry).

## Reviewers
@bjornhenriksen @petravidovic — please focus on: (1) the reprocess semantics (clear-before-rewind ordering; clearing downstream checkpoints vs. rewinding only the entry group); (2) the lag arithmetic edge cases (uncommitted partition, committed-ahead clamp); (3) the src↔workers stage-table pinning approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
