### PR TITLE
test(infra): centralize testcontainers neo4j tag into shared NEO4J_TEST_IMAGE (#96)

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,10 @@
+"""Integration test package.
+
+Shared constants for the testcontainers-based integration suite.
+"""
+
+# Single source of truth for the testcontainers Neo4j base image tag.
+# Org-standardized on neo4j:5-community (noorinalabs-main#642) to share the image
+# cache and avoid redundant CI pulls. This is the upstream community base image,
+# NOT the app's custom isnad-graph-neo4j:5-community (which bundles APOC/plugins).
+NEO4J_TEST_IMAGE = "neo4j:5-community"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@ from testcontainers.neo4j import Neo4jContainer
 from testcontainers.postgres import PostgresContainer
 
 from src.utils.neo4j_client import Neo4jClient
+from tests.integration import NEO4J_TEST_IMAGE
 
 NEO4J_TEST_PASSWORD = "testpassword123"
 
@@ -14,7 +15,7 @@ NEO4J_TEST_PASSWORD = "testpassword123"
 @pytest.fixture(scope="session")
 def neo4j_container():
     """Start a real Neo4j container for integration tests."""
-    container = Neo4jContainer("neo4j:5-community", password=NEO4J_TEST_PASSWORD)
+    container = Neo4jContainer(NEO4J_TEST_IMAGE, password=NEO4J_TEST_PASSWORD)
     with container as neo4j:
         yield neo4j
 

--- a/tests/integration/test_ingest_neo4j_wall_clock.py
+++ b/tests/integration/test_ingest_neo4j_wall_clock.py
@@ -71,6 +71,7 @@ from neo4j import Driver, GraphDatabase  # noqa: E402
 from neo4j.exceptions import ServiceUnavailable  # noqa: E402
 from testcontainers.neo4j import Neo4jContainer  # noqa: E402
 
+from tests.integration import NEO4J_TEST_IMAGE  # noqa: E402
 from tests.workers.conftest import FakeConsumer, FakeProducer  # noqa: E402
 
 # ``_write_batch`` is reused from the unit suite so the on-the-wire
@@ -137,7 +138,7 @@ def neo4j_container_killable():
     container to force the driver into its retry loop — a session-scoped
     container would be dead for every test after the first.
     """
-    container = Neo4jContainer("neo4j:5-community", password=NEO4J_TEST_PASSWORD)
+    container = Neo4jContainer(NEO4J_TEST_IMAGE, password=NEO4J_TEST_PASSWORD)
     container.start()
     try:
         yield container

--- a/tests/integration/test_kafka_worker_e2e.py
+++ b/tests/integration/test_kafka_worker_e2e.py
@@ -68,6 +68,7 @@ from testcontainers.minio import MinioContainer  # noqa: E402
 from testcontainers.neo4j import Neo4jContainer  # noqa: E402
 
 from tests.factories import build_hadith_table  # noqa: E402
+from tests.integration import NEO4J_TEST_IMAGE  # noqa: E402
 from workers.enrich.processor import EnrichProcessor  # noqa: E402
 from workers.ingest.processor import IngestProcessor  # noqa: E402
 from workers.lib.message import PipelineMessage, serialize_message  # noqa: E402
@@ -108,7 +109,7 @@ def minio_container() -> Iterator[MinioContainer]:
 
 @pytest.fixture(scope="module")
 def neo4j_container_module() -> Iterator[Neo4jContainer]:
-    container = Neo4jContainer("neo4j:5-community", password=NEO4J_TEST_PASSWORD)
+    container = Neo4jContainer(NEO4J_TEST_IMAGE, password=NEO4J_TEST_PASSWORD)
     with container as neo4j:
         yield neo4j
 

--- a/tests/integration/test_worker_chain_e2e.py
+++ b/tests/integration/test_worker_chain_e2e.py
@@ -72,6 +72,7 @@ from testcontainers.minio import MinioContainer  # noqa: E402
 from testcontainers.neo4j import Neo4jContainer  # noqa: E402
 
 from tests.factories import build_hadith_table  # noqa: E402
+from tests.integration import NEO4J_TEST_IMAGE  # noqa: E402
 from workers.dedup.processor import DedupProcessor  # noqa: E402
 from workers.enrich.processor import EnrichProcessor  # noqa: E402
 from workers.ingest.processor import IngestProcessor  # noqa: E402
@@ -120,7 +121,7 @@ def minio_container() -> Iterator[MinioContainer]:
 
 @pytest.fixture(scope="module")
 def neo4j_container_module() -> Iterator[Neo4jContainer]:
-    with Neo4jContainer("neo4j:5-community", password=NEO4J_TEST_PASSWORD) as neo4j:
+    with Neo4jContainer(NEO4J_TEST_IMAGE, password=NEO4J_TEST_PASSWORD) as neo4j:
         yield neo4j
 
 


### PR DESCRIPTION
## What

Centralizes the testcontainers Neo4j base image tag into a single shared constant, `NEO4J_TEST_IMAGE`, defined in `tests/integration/__init__.py`. All four integration modules now import it instead of repeating the literal.

Resolves **#96** (split per-repo from **noorinalabs-main#642** — neo4j test-image tag standardization, P5W5).

## Findings / scope

The repo was **already on `neo4j:5-community`** at every site, so issue tasks 1–2 (align the tag) were no-ops here. The remaining gap was task 3: the tag was duplicated as a bare string across four files with no single source of truth, free to drift.

Sites consolidated:
- `tests/integration/conftest.py` (`neo4j_container` fixture)
- `tests/integration/test_kafka_worker_e2e.py` (`neo4j_container_module`)
- `tests/integration/test_worker_chain_e2e.py` (`neo4j_container_module`)
- `tests/integration/test_ingest_neo4j_wall_clock.py` (`neo4j_container_killable`)

The new constant carries a comment noting it is the **upstream community base image**, distinct from the app's custom `isnad-graph-neo4j:5-community` (APOC/plugins), which is intentionally **left untouched** per the issue.

Out of scope (left as-is): `NEO4J_TEST_PASSWORD = "testpassword123"` is similarly duplicated across the same files, but that is separate from the tag-pin issue.

## Changes

- `tests/integration/__init__.py` — define `NEO4J_TEST_IMAGE = "neo4j:5-community"` (single source of truth).
- 4 modules — import the constant and pass it to `Neo4jContainer(...)`.

No behavior change: the tag value is identical; this only removes the duplication.

## Verification

- `ruff@0.15.11 format --check` + `ruff check` on `tests/integration/` — clean.
- `pytest tests/integration/ --collect-only` — 23 tests collect; the new `from tests.integration import NEO4J_TEST_IMAGE` import resolves across all four modules.
- `mypy src/` — no issues (74 files).
- `pytest -m "not integration"` — 681 passed, 4 skipped, 29 deselected.
- Integration tests themselves require Docker (importorskip-gated) and were not executed in-sandbox.

## Reviewers

@Tomás Carvalho and @Petra Vidović (2 reviewers per charter).

Closes #96
