### PR TITLE
fix(models): reconcile vendored SourceCorpus with da canonical (ITQAN + halimbahae + mis + bihar) (#81)

### DIFF
--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -151,6 +151,10 @@ class SourceCorpus(StrEnum):
     FAWAZ = "fawaz"
     OPEN_HADITH = "open_hadith"
     MUHADDITHAT = "muhaddithat"
+    ITQAN = "itqan"
+    HALIMBAHAE = "halimbahae"
+    MIS = "mis"
+    BIHAR = "bihar"
 
 
 class Sect(StrEnum):


### PR DESCRIPTION
## Summary
Reconciles the vendored `src/models/enums.py` `SourceCorpus` enum with data-acquisition's canonical definition, closing the vendoring drift surfaced in ingest#81.

ingest-platform vendors a mirror of da's identity/schema layer. The vendored `SourceCorpus` had drifted, missing **four** members that da `main` already ships:

| member | value | origin |
|--------|-------|--------|
| `ITQAN` | `itqan` | Itqan rijāl narrator source |
| `HALIMBAHAE` | `halimbahae` | P4W4 |
| `MIS` | `mis` | P4W4 |
| `BIHAR` | `bihar` | P4W4 |

The issue title names ITQAN, but its body explicitly scopes the drift to the whole class ("if Itqan **or any newer corpus — halimbahae, mis, bihar** ... data ever streams through, `generate_source_id()` would reject the unknown corpus"). `SOURCE_CORPORA` is derived from this enum (`identity.py:100`), so adding only ITQAN would leave 3/4 of the exact drift the issue describes. All four are already canonical in da `main`, so this fully closes the issue.

**Excluded:** `THAQALAYN_DATA` (da#182) — not yet merged to da `main`, so adding it would vendor a not-yet-canonical member prematurely.

## Verification
- `ruff format --check` + `ruff check src/` — clean
- `mypy src/` — no issues (74 files)
- `pytest -m "not integration"` — 681 passed, 4 skipped

Purely additive enum lines; no existing test enumerates full membership/count, only `SUNNAH` is referenced in tests.

Closes #81. Ref ingest#72, da#82.
