### PR TITLE
security(ingest#99): bump bleach>=6.4.0; ignore no-fix linkify ReDoS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,11 @@ jobs:
       - name: Check for known vulnerabilities
         run: |
           uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt
-          uv run pip-audit --strict --desc -r /tmp/requirements.txt
+          # GHSA-g75f-g53v-794x: bleach.linkify(parse_email=True) ReDoS — no
+          # upstream fix released. parse_email is not used anywhere in this repo
+          # (grep -rn parse_email is empty) → non-applicable. Tracked in
+          # noorinalabs-main#703; revisit each wave for an upstream fix.
+          uv run pip-audit --strict --desc --ignore-vuln GHSA-g75f-g53v-794x -r /tmp/requirements.txt
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,11 @@ repos:
         # `uv export` + the advisory DB), so it runs pre-push. `bash -c` wraps
         # the export→audit pipeline as a single hook entry, matching the
         # sibling isnad-graph form.
-        entry: bash -c 'uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt && uv run pip-audit --strict --desc -r /tmp/requirements.txt'
+        # --ignore-vuln GHSA-g75f-g53v-794x: bleach.linkify(parse_email=True)
+        # ReDoS — no upstream fix; parse_email unused in this repo → non-
+        # applicable. Tracked in noorinalabs-main#703; revisit each wave. Kept
+        # identical to ci.yml's security-audit invocation (local⇄CI parity).
+        entry: bash -c 'uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt && uv run pip-audit --strict --desc --ignore-vuln GHSA-g75f-g53v-794x -r /tmp/requirements.txt'
         language: system
         pass_filenames: false
         always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     "structlog>=24.1",
     "python-dotenv>=1.0",
     "kaggle>=1.6",
+    # bleach is transitive via kaggle; pin a direct floor to clear the 6.3.0
+    # advisories GHSA-gj48-438w-jh9v + GHSA-8rfp-98v4-mmr6 (fixed in 6.4.0).
+    # See noorinalabs-main#703 / ingest#99.
+    "bleach>=6.4.0",
     "beautifulsoup4>=4.12",
     "lxml>=5.1",
     "tqdm>=4.66",

--- a/uv.lock
+++ b/uv.lock
@@ -95,14 +95,14 @@ wheels = [
 
 [[package]]
 name = "bleach"
-version = "6.3.0"
+version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
 ]
 
 [[package]]
@@ -1136,6 +1136,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "bleach" },
     { name = "boto3" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -1183,6 +1184,7 @@ ml = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "bleach", specifier = ">=6.4.0" },
     { name = "boto3", specifier = ">=1.34" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },


### PR DESCRIPTION
## Summary
`pip-audit --strict` (CI `security-audit` job + the mirrored pre-push hook) was failing on **bleach 6.3.0** (transitive via `kaggle`), turning the whole P5W5 ingest wave red — this blocked PRs #81, #95, #96, #98 on the same advisory set.

Three advisories on 6.3.0:
| ID | Issue | Fix |
|----|-------|-----|
| GHSA-gj48-438w-jh9v | `formaction` URI sanitization gap | **6.4.0** |
| GHSA-8rfp-98v4-mmr6 | ZWSP `href` scheme bypass | **6.4.0** |
| GHSA-g75f-g53v-794x | `linkify(parse_email=True)` ReDoS | **no upstream fix** |

## Changes
1. **`pyproject.toml`** — add an explicit direct floor `bleach>=6.4.0` (it was transitive-only) so the floor is enforced; `uv lock` → bleach 6.3.0 → 6.4.0.
2. **`.github/workflows/ci.yml`** + **`.pre-commit-config.yaml`** — add `--ignore-vuln GHSA-g75f-g53v-794x` to the pip-audit invocation on **both** sides, kept byte-identical (local⇄CI parity, main#684), with a justification comment.

## Justification for the ignore
- **No upstream fix released** for the ReDoS.
- `bleach.linkify(parse_email=True)` is **not used anywhere in this repo** — `grep -rn parse_email src/ scripts/ workers/` (and a repo-wide `*.py` sweep) returns nothing → **non-applicable**.
- The advisory's OSV affected-range currently caps at 6.3.0, so on 6.4.0 the audit is already clean even **without** the ignore. The ignore is therefore a **forward guard** against an OSV range-widen (no real patch exists), not a current suppression of a live finding.
- Tracked in **noorinalabs-main#703**; revisit each wave for an upstream fix.

## Verification
- `pip-audit --strict --desc -r <exported reqs>` on 6.4.0: **No known vulnerabilities found** (rc=0), both with and without the ignore.
- Sync-drift gate: `OK: pre-commit config mirrors all CI-enforced checks` (rc=0); its pytest suite 21 passed.
- actionlint (with shellcheck on PATH): clean.

Once merged, the other ingest wave PRs (#81/#95/#96/#98) can re-run green.

Reviewers: Bjørn Henriksen, Petra Vidović

Closes #99
