### PR TITLE
docs: add zsh shell-environment note to CLAUDE.md (#759)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,10 @@ pre-commit install --hook-type pre-push  # push-stage: pip-audit, mypy --strict,
 
 `.claude/lib/pre_commit_ci_sync.py` is the CI gate that fails the build if a check CI enforces is not mirrored in the pre-commit config. Run it locally with `python3 .claude/lib/pre_commit_ci_sync.py .`.
 
+### Shell environment
+
+The development shell is **zsh** (not bash). Write zsh-safe terminal commands and avoid bash-only idioms (`declare -A`, `${!arr[@]}`, unquoted `?`/`*` globs such as `…?ref=main` URLs). Prefer POSIX-portable constructs; reach for `bash -c '...'` explicitly only when bash is genuinely required. Canonical do/don't list: org `docs/TOOLCHAIN.md` "Shell environment" section + `ontology/conventions.md` in `noorinalabs-main`.
+
 ## Configuration
 
 Copy `.env.example` to `.env` for local runs. Workers read `KAFKA_BOOTSTRAP_SERVERS`, `PIPELINE_BUCKET`, `S3_ENDPOINT_URL` (set for MinIO/local, unset for B2 prod), and `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`; the `ingest-worker` additionally needs `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`.


### PR DESCRIPTION
Adds a **Shell environment** subsection under "Code Conventions" in this repo's `CLAUDE.md`.

The note states the development shell is zsh (not bash): write zsh-safe terminal commands, avoid bash-only idioms (`declare -A`, `${!arr[@]}`, unquoted `?`/`*` globs), prefer POSIX-portable constructs, and use `bash -c '...'` only when bash is genuinely required. It points to the canonical do/don't list (org `docs/TOOLCHAIN.md` + `ontology/conventions.md` in `noorinalabs-main`).

Part of #759

### Notes
- Minimal, link-free prose; markdownlint clean (0 errors).
- cspell is scoped to charter/RUNBOOK/workers README — `CLAUDE.md` is out of that glob, so no spell surface added.