### PR TITLE
tech-debt(ci-parity): mirror cspell into pre-commit + classify cspell kind (rollout of main#684)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -23,11 +23,15 @@ step vs a `ruff` pre-commit `id:`). We normalize both sides to a small set of
 kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
-    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build
+    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
+    cspell
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
-understand.
+understand. Closing a blind spot here means ADDING the kind to
+`_KIND_PATTERNS` (cf. `cspell`, noorinalabs-main#684) so a CI job that runs it
+starts demanding a pre-commit mirror — an un-classified CI check is silently
+un-mirrored, which is the exact divergence this gate exists to prevent.
 
 Input Language
 ==============
@@ -80,6 +84,13 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "actionlint": ("actionlint",),
     "pip-audit": ("pip-audit", "pip audit"),
     "build": ("build-and-validate", "build-and-test", "npm run build"),
+    # `cspell` closes the spell-check blind spot (noorinalabs-main#684): docs.yml's
+    # `Spellcheck (cspell)` job runs the `streetsidesoftware/cspell-action`, but
+    # until this kind existed an un-classified spell gate produced ZERO drift
+    # signal, so the repo could enforce cspell in CI with no pre-commit mirror —
+    # new domain vocabulary then failed only after push. Patterns cover the action
+    # ref, the bundled-CLI step name, and the generic job/step word.
+    "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -108,6 +108,85 @@ jobs:
         self.assertNotIn("ruff-lint", kinds)
 
 
+class CspellKindClassification(unittest.TestCase):
+    """noorinalabs-main#684: the spell-check blind spot. docs.yml's
+    `Spellcheck (cspell)` job must classify as the `cspell` kind on EITHER
+    expression — the `streetsidesoftware/cspell-action` `uses:` ref, the
+    bundled-CLI `cspell` step/run, or the generic `spellcheck` word — and a
+    pre-commit cspell hook must classify too, so a CI spell gate with no local
+    mirror produces harmful drift instead of silence."""
+
+    def test_cspell_action_uses_ref_classified(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    name: Spellcheck (cspell)
+    steps:
+      - name: cspell
+        uses: streetsidesoftware/cspell-action@de2a73e # v8.4.0
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_cspell_cli_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  spell:
+    steps:
+      - run: npx cspell --config .cspell.json "**/*.md"
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_generic_spellcheck_word_classified(self) -> None:
+        # A repo that names the step/run with the generic word still registers.
+        self.assertIn("cspell", kinds_from_ci("      - run: make spellcheck\n"))
+
+    def test_precommit_cspell_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+"""
+        self.assertIn("cspell", kinds_from_precommit(cfg))
+
+    def test_ci_cspell_without_precommit_is_harmful_drift(self) -> None:
+        # The exact divergence #684 exists to catch: CI enforces cspell, the
+        # pre-commit config does not mirror it.
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("cspell", harmful)
+
+    def test_ci_cspell_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("cspell", harmful)
+
+
 class BuildKindTightening(unittest.TestCase):
     """#576: runtime `docker build` / `docker buildx` steps are image-MOVING,
     not a build-QUALITY gate a local pre-commit hook can mirror — they must

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,9 @@
 #
 # Stage split:
 #   pre-commit (fast, every commit) — ruff-format + ruff-lint over the python
-#     surface, plus actionlint over the workflows (mirrors docs.yml's actionlint
-#     job; fast, no Docker).
+#     surface, actionlint over the workflows (mirrors docs.yml's actionlint job),
+#     and cspell over the authored-prose docs (mirrors docs.yml's spellcheck
+#     job); all fast, no Docker.
 #   pre-push   (heavier, every push) — mypy strict + the pytest suite + the
 #     pip-audit vulnerability scan. These run the whole src/ + tests surface (or
 #     resolve the full dependency set), so they're push-time not commit-time to
@@ -40,9 +41,9 @@
 #     docs.yml enforces in CI also runs locally — keeping the UNSCOPED sync-drift
 #     gate (which scans every workflow, docs.yml included) green.
 #
-# The kind-level mirror (ruff-lint, ruff-format, mypy, pytest, actionlint present
-# on both sides) is enforced in CI by `.claude/lib/pre_commit_ci_sync.py` — if a
-# future edit drops one side, that gate fails the build.
+# The kind-level mirror (ruff-lint, ruff-format, mypy, pytest, actionlint, cspell
+# present on both sides) is enforced in CI by `.claude/lib/pre_commit_ci_sync.py`
+# — if a future edit drops one side, that gate fails the build.
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -61,6 +62,28 @@ repos:
     hooks:
       - id: actionlint
         name: actionlint (workflows)
+
+  # cspell mirrors the `Spellcheck (cspell)` CI job in docs.yml (the sync-drift
+  # gate now classifies the `cspell` kind — noorinalabs-main#684 — so a
+  # CI-enforced spell gate not mirrored here turns the gate red, same contract as
+  # actionlint above). New domain vocabulary then fails `pre-commit run` locally
+  # instead of only surfacing as a CI red after push. Pinned to v8.4.0 of
+  # cspell-cli to match the exact cspell the `streetsidesoftware/cspell-action@…
+  # v8.4.0` CI step bundles — same engine + dictionaries on both sides.
+  # `language: node`, so pre-commit provisions its own node/cspell env (no system
+  # cspell required).
+  #
+  # `files` is the regex equivalent of the CI action's authored-prose glob set
+  # (the team charter, RUNBOOK, workers README); `--config .cspell.json` reuses
+  # the same dictionaries + ignore rules CI loads, so a word that passes locally
+  # passes in CI and vice-versa.
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+        args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
+        files: ^(\.claude/team/charter\.md|RUNBOOK\.md|workers/README\.md)$
 
   # Heavier checks run at pre-push (mirror CI's mypy + test + security-audit
   # jobs). Run as `local`/`system` hooks via `uv run` so the pinned tools from


### PR DESCRIPTION
## What

Rollout of the parent cspell CI⇄pre-commit parity fix (**noorinalabs-main#684**) to this repo. Closes the spell-check blind spot in the sync-drift gate and mirrors the CI cspell job locally.

## Why

`docs.yml`'s `Spellcheck (cspell)` job (`streetsidesoftware/cspell-action@…v8.4.0`) was an **un-classified kind** for `.claude/lib/pre_commit_ci_sync.py`, so the gate produced zero drift signal for it — the repo could enforce cspell in CI with no pre-commit mirror, and new domain vocabulary failed only after push.

## Changes

**Part 1 — sync-drift gate (`.claude/lib/`)**
- Add the `cspell` canonical kind to `_KIND_PATTERNS`: `("cspell", "spellcheck", "streetsidesoftware/cspell")` (action ref, bundled-CLI step name, generic word).
- Add a `CspellKindClassification` test class: CI classification (uses-ref / CLI-run / generic word), pre-commit classification, and both drift directions (harmful when un-mirrored, none when mirrored). This repo's test file has no `_EXPECTED_KINDS` table, so nothing to update there.

**Part 2 — pre-commit mirror (`.pre-commit-config.yaml`)**
- Add a pinned `streetsidesoftware/cspell-cli` **v8.4.0** hook — the exact cspell the `cspell-action@…v8.4.0` CI step bundles, so the same engine + dictionaries run on both sides.
- Scoped via `files: ^(\.claude/team/charter\.md|RUNBOOK\.md|workers/README\.md)$` — the regex equivalent of the CI action's authored-prose glob — with `--config .cspell.json`.

Now that the kind is classified, the CI cspell job **demands** the pre-commit mirror; dropping either side turns the sync-drift gate red.

## Verification (local)

- `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced checks.`
- `pytest .claude/lib/tests/test_pre_commit_ci_sync.py -q` → 27 passed (+3 subtests).
- `pre-commit run --all-files` (commit stage) → ruff-format, ruff-lint, actionlint, **cspell** all Passed (no new words blessed — authored prose was already clean).
- Pre-push hooks (pip-audit, mypy-strict, pytest) green on push.

**Pinned version:** cspell-cli `v8.4.0` (matches `streetsidesoftware/cspell-action@de2a73e…` # v8.4.0).

Closes #112
Part of noorinalabs-main#684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2U19RpdPtzAv8qfjQwacx
