### PR TITLE
ci(base-pin): wire Dockerfile base-pin gate into CI/pre-commit + README local-hooks docs (#114)

### DIFF
--- a/.claude/lib/check_dockerfile_base_pin.py
+++ b/.claude/lib/check_dockerfile_base_pin.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Lint Dockerfile `FROM` statements for digest-pin + distro-upgrade compliance.
+
+Deterministic conversion of `.claude/team/charter/tech-decisions.md § Base Image
+Pinning` (noorinalabs-main#735, the charter-prose-inventory worklist item #4 /
+epic #726). The section requires every `FROM` to use a **digest-pinned tag**
+(`image:tag@sha256:<digest>`) **combined with an in-image package upgrade**, to
+close the two failure modes it names — floating-tag drift and within-tag package
+drift (the shape isnad-graph#853 hit).
+
+What this gate enforces (verbatim from the section's distro table)
+================================================================
+For every `FROM` that is not exempt:
+
+1. The image reference MUST carry an `@sha256:` digest pin.
+2. The stage MUST run the package-manager upgrade matching the base distro:
+
+   | Family      | Pin shape               | Upgrade command                                 |
+   |-------------|-------------------------|-------------------------------------------------|
+   | Alpine      | image:tag@sha256:digest | `RUN apk upgrade --no-cache`                    |
+   | Debian-slim | image:tag@sha256:digest | `apt-get update && apt-get -y upgrade && clean` |
+   | Distroless  | image:tag@sha256:digest | none — no package manager (pinned-only is fine) |
+
+   The distro family is inferred from the image name: `alpine` → Alpine,
+   `distroless` → Distroless (no upgrade required), otherwise the glibc/Debian
+   default (an apt upgrade is required). A genuinely-other base that has no
+   package manager should carry the `# RATIONALE:` exemption below.
+
+Exemptions honored (verbatim from the section)
+=============================================
+- **`scratch`** final/any layer — no package manager; the upstream stages that
+  produced its contents still follow the rule and are checked on their own
+  `FROM`.
+- **Distroless** — pinned-only is sufficient (no package manager); the digest
+  pin is still required.
+- **Multi-stage stage reference** — a `FROM <earlier-stage>` inherits the
+  upstream stage's pin, so it is not re-checked (the named stage was checked at
+  its defining `FROM`).
+- **Vendor images** documented with an inline `# RATIONALE:` comment on the
+  `FROM` line (or the comment line immediately above it).
+
+CLI
+===
+    python3 .claude/lib/check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]
+
+Exit codes:
+    0 — every FROM in every file is compliant (or exempt)
+    1 — at least one violation (each printed as `path:line: FROM <image> — <why>`)
+    2 — usage / file-not-found error
+
+This is a reusable template (same CLI/exit-code shape as
+`.claude/lib/pre_commit_ci_sync.py`) so it wires identically into a repo's
+pre-commit config and its CI. The parent repo `noorinalabs-main` ships no
+Dockerfiles itself; the cross-repo rollout that points this at each child's
+Dockerfiles is a #735 follow-up.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# `FROM` is the only keyword we parse; Dockerfile keywords are case-insensitive.
+_FROM_RE = re.compile(r"^\s*FROM\s+(?P<rest>\S.*?)\s*$", re.IGNORECASE)
+# A leading `--platform=...` flag precedes the image and must be stripped.
+_PLATFORM_RE = re.compile(r"^--platform=\S+\s+", re.IGNORECASE)
+# A trailing `AS <stage>` names the build stage.
+_AS_RE = re.compile(r"\s+AS\s+(?P<stage>\S+)\s*$", re.IGNORECASE)
+
+# Upgrade-command signatures per distro family (searched over the stage body).
+_ALPINE_UPGRADE_RE = re.compile(r"\bapk\s+upgrade\b", re.IGNORECASE)
+# `apt-get update && apt-get -y upgrade` / `apt upgrade` — an apt invocation
+# followed (in the same command segment) by `upgrade`. `apt-get update` alone
+# does NOT match (that is "update", not "upgrade").
+_DEBIAN_UPGRADE_RE = re.compile(r"\bapt(?:-get)?\s+(?:-{1,2}\S+\s+)*upgrade\b", re.IGNORECASE)
+
+_RATIONALE_RE = re.compile(r"#\s*RATIONALE:", re.IGNORECASE)
+
+
+class FromStatement:
+    """One parsed `FROM` line: its image ref, optional stage name, exemptions."""
+
+    def __init__(self, lineno: int, image: str, stage: str | None, has_rationale: bool) -> None:
+        self.lineno = lineno
+        self.image = image
+        self.stage = stage
+        self.has_rationale = has_rationale
+
+
+def _preceding_comment_has_rationale(lines: list[str], from_idx: int) -> bool:
+    """True if the comment line(s) immediately above `from_idx` carry RATIONALE."""
+    j = from_idx - 1
+    while j >= 0:
+        stripped = lines[j].strip()
+        if stripped == "":
+            j -= 1
+            continue
+        if stripped.startswith("#"):
+            return bool(_RATIONALE_RE.search(stripped))
+        return False
+    return False
+
+
+def parse_froms(text: str) -> list[FromStatement]:
+    """Parse every `FROM` statement in a Dockerfile, in source order."""
+    lines = text.splitlines()
+    froms: list[FromStatement] = []
+    for idx, raw in enumerate(lines):
+        m = _FROM_RE.match(raw)
+        if not m:
+            continue
+        rest = m.group("rest")
+        has_rationale = bool(_RATIONALE_RE.search(raw)) or _preceding_comment_has_rationale(
+            lines, idx
+        )
+        # Drop any trailing inline comment, then a leading --platform flag.
+        code = rest.split("#", 1)[0].strip()
+        code = _PLATFORM_RE.sub("", code).strip()
+        stage: str | None = None
+        as_m = _AS_RE.search(code)
+        if as_m is not None:
+            stage = as_m.group("stage")
+            code = code[: as_m.start()].strip()
+        image = code.split()[0] if code.split() else ""
+        froms.append(FromStatement(idx + 1, image, stage, has_rationale))
+    return froms
+
+
+def _stage_body(text: str, from_lineno: int, next_from_lineno: int | None) -> str:
+    """Return the text between a `FROM` (exclusive) and the next `FROM`/EOF."""
+    lines = text.splitlines()
+    start = from_lineno  # from_lineno is 1-based; body starts on the next line
+    end = (next_from_lineno - 1) if next_from_lineno is not None else len(lines)
+    return "\n".join(lines[start:end])
+
+
+def check_dockerfile_text(path: str, text: str) -> list[str]:
+    """Return a list of human-readable violation strings for one Dockerfile."""
+    violations: list[str] = []
+    froms = parse_froms(text)
+    defined_stages: set[str] = set()
+    for i, stmt in enumerate(froms):
+        next_lineno = froms[i + 1].lineno if i + 1 < len(froms) else None
+        image_l = stmt.image.lower()
+
+        # Exemptions, in order. `scratch` and stage-references have no package
+        # manager / inherit the upstream pin; a documented vendor RATIONALE opts
+        # out explicitly. Record this stage's own name for later references.
+        is_exempt = image_l == "scratch" or image_l in defined_stages or stmt.has_rationale
+        if stmt.stage:
+            defined_stages.add(stmt.stage.lower())
+        if is_exempt:
+            continue
+
+        if "@sha256:" not in stmt.image:
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — not digest-pinned "
+                f"(require image:tag@sha256:<digest>)"
+            )
+
+        body = _stage_body(text, stmt.lineno, next_lineno)
+        if "distroless" in image_l:
+            continue  # distroless has no package manager; pinned-only is sufficient
+        if "alpine" in image_l:
+            if not _ALPINE_UPGRADE_RE.search(body):
+                violations.append(
+                    f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Alpine upgrade "
+                    f"step (RUN apk upgrade --no-cache)"
+                )
+        elif not _DEBIAN_UPGRADE_RE.search(body):
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Debian upgrade step "
+                f"(RUN apt-get update && apt-get -y upgrade && apt-get clean)"
+            )
+    return violations
+
+
+def check_file(path: Path) -> list[str]:
+    return check_dockerfile_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("Base Image Pinning violations (tech-decisions.md § Base Image Pinning, #735):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nEvery FROM must be digest-pinned (image:tag@sha256:<digest>) AND carry "
+            "the matching distro upgrade (apk/apt). Exemptions: scratch, distroless "
+            "(pin-only), a FROM that references an earlier stage, or a vendor image with "
+            "an inline `# RATIONALE:` comment on the FROM line."
+        )
+        return 1
+
+    print("OK: all Dockerfile FROM statements are digest-pinned with the required upgrade.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -24,7 +24,7 @@ kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
     terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
-    cspell
+    cspell, dockerfile-base-pin
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
@@ -91,6 +91,17 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # new domain vocabulary then failed only after push. Patterns cover the action
     # ref, the bundled-CLI step name, and the generic job/step word.
     "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
+    # `dockerfile-base-pin` is the charter-prose→code gate rolled in by #744
+    # (built in noorinalabs-main#735): every Dockerfile FROM must be digest-pinned
+    # AND carry the matching distro upgrade. ci.yml's `base-pin` job and the
+    # `dockerfile-base-pin` pre-commit hook both invoke
+    # `.claude/lib/check_dockerfile_base_pin.py`, so classifying this kind makes
+    # the local mirror mandatory — dropping either side is harmful drift, not
+    # silence (#684 parity). The `fixture-realism` kind is intentionally NOT
+    # classified here: this repo carries no Arabic NER/graph-load DATA fixtures
+    # (Arabic appears only inline in tests/test_parse/*.py unit sources), so there
+    # is no fixture-realism gate on either side to mirror.
+    "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_check_dockerfile_base_pin.py
+++ b/.claude/lib/tests/test_check_dockerfile_base_pin.py
@@ -1,0 +1,195 @@
+"""Tests for check_dockerfile_base_pin — the Base Image Pinning gate (#735).
+
+Verifies the deterministic conversion of `tech-decisions.md § Base Image
+Pinning`: every FROM must be digest-pinned AND carry the matching distro
+upgrade, with the section's exact exemptions (scratch, distroless, stage
+references, vendor `# RATIONALE:`). Positive cases use the real required pattern
+the section documents; negative cases use the exact prohibited shapes it names
+(floating tag, pin-only, apk-only).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_dockerfile_base_pin import (  # noqa: E402
+    check_dockerfile_text,
+    main,
+    parse_froms,
+)
+
+# A real digest (truncated only for readability is NOT allowed by the checker —
+# it needs the literal `@sha256:` marker, which these carry in full shape).
+_DIGEST = "@sha256:0272e4609f1b5f3a2d8c9e1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4"
+
+
+class CompliantFromsPass(unittest.TestCase):
+    def test_alpine_pinned_with_apk_upgrade(self) -> None:
+        df = f"""# Digest-pinned tag + apk upgrade for defense-in-depth
+FROM nginx:stable-alpine3.23{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_debian_slim_pinned_with_apt_upgrade(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST}
+RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_distroless_pin_only_is_sufficient(self) -> None:
+        # Distroless has no package manager — pinned-only passes, no upgrade.
+        df = f"FROM gcr.io/distroless/static-debian12{_DIGEST}\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_scratch_final_layer_exempt(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM scratch
+COPY --from=builder /app /app
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_stage_reference_inherits_pin(self) -> None:
+        # `FROM builder` references an earlier stage; it inherits the pin and is
+        # not re-checked for a digest or an upgrade.
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get clean
+
+FROM builder
+RUN pip install .
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_inline_comment_exempts(self) -> None:
+        df = "FROM vendor/proprietary:1.4  # RATIONALE: not redistributable digest-pinned\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_preceding_comment_exempts(self) -> None:
+        df = """# RATIONALE: vendor image, not available as a digest-pinned ref
+FROM vendor/proprietary:1.4
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_platform_flag_is_stripped(self) -> None:
+        df = f"""FROM --platform=linux/amd64 node:20-alpine{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class ProhibitedShapesFlagged(unittest.TestCase):
+    def test_floating_tag_flagged(self) -> None:
+        # WRONG (floating tag): no digest, no upgrade — both defenses missing.
+        violations = check_dockerfile_text("Dockerfile", "FROM nginx:alpine\n")
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(any("not digest-pinned" in v for v in violations))
+        self.assertTrue(any("Alpine upgrade" in v for v in violations))
+
+    def test_pin_only_alpine_missing_upgrade(self) -> None:
+        # INSUFFICIENT (pin-only): tag frozen but Alpine packages drift — the
+        # exact shape isnad-graph#853 hit.
+        df = f"FROM nginx:stable-alpine3.23{_DIGEST}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Alpine upgrade", violations[0])
+
+    def test_apk_only_missing_digest(self) -> None:
+        # INSUFFICIENT (apk-only): upgrade present but base layer is unpinned.
+        df = "FROM nginx:alpine\nRUN apk upgrade --no-cache\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("not digest-pinned", violations[0])
+
+    def test_debian_pinned_missing_apt_upgrade(self) -> None:
+        df = f"FROM python:3.12-slim{_DIGEST}\nRUN pip install .\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_apt_update_only_is_not_an_upgrade(self) -> None:
+        # `apt-get update` is not `apt-get upgrade`; pin present, upgrade absent.
+        df = f"FROM debian:bookworm-slim{_DIGEST}\nRUN apt-get update\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_line_number_reported(self) -> None:
+        df = """# header comment
+FROM nginx:alpine
+RUN apk upgrade --no-cache
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("Dockerfile:2:", violations[0])
+
+
+class MultiStageMixed(unittest.TestCase):
+    def test_compliant_builder_but_bad_runtime_flags_only_runtime(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM nginx:alpine
+COPY --from=builder /app /app
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        # builder is clean; only the floating runtime FROM is flagged (pin+upgrade).
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(all("FROM nginx:alpine" in v for v in violations))
+
+
+class ParserBehavior(unittest.TestCase):
+    def test_parse_collects_stage_names_and_images(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+FROM scratch
+"""
+        froms = parse_froms(df)
+        self.assertEqual(len(froms), 2)
+        self.assertEqual(froms[0].stage, "builder")
+        self.assertTrue(froms[0].image.startswith("python:3.12-slim@sha256:"))
+        self.assertEqual(froms[1].image, "scratch")
+
+    def test_from_keyword_case_insensitive(self) -> None:
+        df = f"from nginx:alpine{_DIGEST} as web\nRUN apk upgrade --no-cache\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class CliBehavior(unittest.TestCase):
+    def test_clean_file_exits_zero(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write(f"FROM nginx:stable-alpine3.23{_DIGEST}\nRUN apk upgrade --no-cache\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_violating_file_exits_one(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write("FROM nginx:alpine\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 1)
+        finally:
+            Path(name).unlink()
+
+    def test_no_args_is_usage_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py"]), 2)
+
+    def test_missing_file_is_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py", "/no/such/Dockerfile"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -355,6 +355,64 @@ class DriftDirection(unittest.TestCase):
         self.assertEqual(stricter, set())
 
 
+class DockerfileBasePinKindClassification(unittest.TestCase):
+    """The #744 base-pin gate is a real kind: a CI run invoking
+    check_dockerfile_base_pin.py and a pre-commit hook running the same script —
+    so a CI base-pin gate with no local mirror is harmful drift, not silence."""
+
+    def test_dockerfile_base_pin_ci_run_classified(self) -> None:
+        wf = """
+jobs:
+  base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile workers/dedup/Dockerfile
+"""
+        self.assertIn("dockerfile-base-pin", kinds_from_ci(wf))
+
+    def test_dockerfile_base_pin_precommit_id_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile
+"""
+        self.assertIn("dockerfile-base-pin", kinds_from_precommit(cfg))
+
+    def test_ci_base_pin_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("dockerfile-base-pin", harmful)
+
+    def test_ci_base_pin_without_precommit_mirror_is_harmful(self) -> None:
+        wf = """
+jobs:
+  base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("dockerfile-base-pin", harmful)
+
+
 class RealParentRepoHasNoDrift(unittest.TestCase):
     """The parent noorinalabs-main config must mirror its CI kinds — this is
     the gate running against the very repo that ships it."""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,27 @@ jobs:
         env:
           ENVIRONMENT: test
 
+  base-pin:
+    # Charter-prose→code gate rolled in by #744 (built in noorinalabs-main#735):
+    # every Dockerfile FROM must be digest-pinned (image:tag@sha256:<digest>) AND
+    # carry the matching distro upgrade (apt for these slim images). Invokes the
+    # stdlib-only `.claude/lib/check_dockerfile_base_pin.py` — no uv/node needed —
+    # and is mirrored by the `dockerfile-base-pin` pre-commit hook. The
+    # precommit-ci-sync gate classifies this kind, so dropping either the CI step
+    # or the local hook is harmful drift. Kept as a single-line `run:` so the
+    # line-scanner sync classifier registers the script name. Covers the top-level
+    # multi-worker image and the four per-stage worker images. (No fixture-realism
+    # step: this repo carries no Arabic NER/graph-load data fixtures.)
+    name: Base-image pin + upgrade
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Dockerfile base-image pin + upgrade
+        run: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile workers/dedup/Dockerfile workers/enrich/Dockerfile workers/ingest/Dockerfile workers/normalize/Dockerfile
+
   precommit-ci-sync:
     # Phase-3 end-state criterion #6 (noorinalabs-main#327): the local
     # .pre-commit-config.yaml MUST mirror what CI enforces, so a developer's
@@ -90,9 +111,13 @@ jobs:
           python-version: "3.12"
       - name: Pre-commit ⇄ CI sync-drift gate
         run: python3 .claude/lib/pre_commit_ci_sync.py .
-      - name: Install pytest for the gate's unit tests
-        # The gate itself is stdlib-only; its tests use pytest. This job does NOT
+      - name: Install pytest for the .claude/lib unit tests
+        # The gates are stdlib-only; their tests use pytest. This job does NOT
         # `uv sync` (it does not need the project deps), so install pytest alone.
         run: python3 -m pip install --quiet pytest
-      - name: Sync-drift gate unit tests
-        run: python3 -m pytest .claude/lib/tests/test_pre_commit_ci_sync.py -q
+      - name: .claude/lib unit tests (sync-drift gate + base-pin check)
+        # The main suite is testpaths = ["tests"], so the stdlib-only gate tests
+        # under .claude/lib/tests/ (sync-drift classifier + check_dockerfile_base_pin)
+        # are not collected by the `test` job. Run the whole dir here so both
+        # gates' tests gate the PR.
+        run: python3 -m pytest .claude/lib/tests/ -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,11 +85,29 @@ repos:
         args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
         files: ^(\.claude/team/charter\.md|RUNBOOK\.md|workers/README\.md)$
 
-  # Heavier checks run at pre-push (mirror CI's mypy + test + security-audit
-  # jobs). Run as `local`/`system` hooks via `uv run` so the pinned tools from
-  # uv.lock are used and never drift from CI.
+  # Local stdlib gates + the heavier pre-push checks.
   - repo: local
     hooks:
+      # Base-image pinning gate (charter tech-decisions.md § Base Image Pinning,
+      # noorinalabs-main#735 / #744). Every Dockerfile FROM must be digest-pinned
+      # (image:tag@sha256:<digest>) AND carry the matching distro upgrade (apt for
+      # these python:slim images). Mirrors the `base-pin` job in ci.yml; the
+      # precommit-ci-sync sync-drift gate classifies the `dockerfile-base-pin`
+      # kind so this local mirror is mandatory (#684 parity). Commit-stage
+      # (stdlib-only, fast — no uv/Docker). Scoped to the five Dockerfiles so it
+      # only runs when one changes; the entry still lists all five so a CI run and
+      # the local run check the same set.
+      - id: dockerfile-base-pin
+        name: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile workers/dedup/Dockerfile workers/enrich/Dockerfile workers/ingest/Dockerfile workers/normalize/Dockerfile
+        language: system
+        pass_filenames: false
+        files: ^(Dockerfile|workers/(dedup|enrich|ingest|normalize)/Dockerfile)$
+        stages: [pre-commit]
+
+      # Heavier checks run at pre-push (mirror CI's mypy + test + security-audit
+      # jobs). Run via `uv run` so the pinned tools from uv.lock are used and
+      # never drift from CI.
       - id: pip-audit
         name: pip-audit (pre-push)
         # Mirrors ci.yml's `security-audit` job verbatim: export the frozen

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,12 @@
 # compose (docker-compose.yaml); this top-level Dockerfile is the one the
 # deployed stack consumes.
 
-FROM python:3.14-slim
+# Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
+# noorinalabs-main#735 / #744). The @sha256 digest freezes the starting layer
+# against floating-tag drift; the `apt-get -y upgrade` below closes the second
+# failure mode (within-tag package drift — the shape isnad-graph#853 hit). The
+# digest is kept in lockstep with the sibling repos' python:3.14-slim pin.
+FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -26,6 +31,7 @@ ENV PYTHONUNBUFFERED=1 \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
+ && apt-get -y upgrade \
  && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -14,25 +14,43 @@ procedures are in [`RUNBOOK.md`](RUNBOOK.md).
 - `workers/` — the Kafka-driven streaming workers and their shared runtime.
 - `docker-compose.yaml` — local Kafka / MinIO / Neo4j stack for development.
 
-## Git hooks (required)
+## Local hooks (required)
 
-This repo mirrors its CI checks locally via [pre-commit](https://pre-commit.com/).
-After cloning, install BOTH hook stages once:
+This repo ships a `.pre-commit-config.yaml` that **mirrors the complete CI
+check-set** (`.github/workflows/ci.yml` + `docs.yml`) so a local commit/push
+fails fast instead of surfacing a lint/type/test/spell error only after a PR is
+opened (Phase-3 end-state criterion #6 / noorinalabs-main#327). After cloning,
+install BOTH hook stages once:
 
 ```bash
-pre-commit install                       # commit-stage checks
-pre-commit install --hook-type pre-push  # push-stage checks
+pre-commit install                       # commit-stage hooks
+pre-commit install --hook-type pre-push  # push-stage hooks
 ```
 
-- **Commit stage** runs: `ruff-format` and `ruff-lint` (with `--fix`) over
-  `src/ workers/ tests/`, plus `actionlint` over the workflows.
-- **Pre-push stage** runs: `pip-audit` (dependency-vulnerability scan, mirroring
-  `ci.yml`'s `security-audit` job — exports the frozen deps and runs
-  `pip-audit --strict --desc`), then `mypy --strict` over `src/`, then the
-  `pytest` suite (unit only — `-m "not integration"`, so no Docker daemon is
-  needed locally).
+- **Commit stage (every commit)** — fast, no Docker daemon:
+  - `ruff-format` + `ruff-lint` (with `--fix`) over `src/ workers/ tests/`
+  - `actionlint` over the workflows (mirrors `docs.yml`)
+  - `cspell` over the authored-prose docs (mirrors `docs.yml`'s spellcheck job)
+  - `dockerfile-base-pin` — every Dockerfile `FROM` (the top-level multi-worker
+    image + the four per-stage worker images) must be digest-pinned
+    (`image:tag@sha256:<digest>`) and carry the matching `apt-get -y upgrade`
+    (charter § Base Image Pinning, noorinalabs-main#735 / #744)
+- **Pre-push stage (every push)** — the heavier checks:
+  - `pip-audit` — dependency-vulnerability scan, mirroring `ci.yml`'s
+    `security-audit` job (exports the frozen deps and runs
+    `pip-audit --strict --desc`)
+  - `mypy --strict` over `src/`
+  - the `pytest` suite (unit only — `-m "not integration"`, so no Docker daemon
+    is needed locally)
 
-These mirror `.github/workflows/ci.yml` so failures surface locally before a PR
-(org-wide local⇄CI parity, noorinalabs-main#684). Never bypass with
-`--no-verify`. If `pre-commit install` "cowardly refuses" because
-`core.hooksPath` is set, run `git config --unset core.hooksPath` first.
+**Sync-drift gate:** the `precommit-ci-sync` CI job
+(`.claude/lib/pre_commit_ci_sync.py`) fails the build if a check CI enforces
+(ruff / mypy / pytest / actionlint / cspell / `dockerfile-base-pin` / …) is NOT
+mirrored in `.pre-commit-config.yaml`, so the local⇄CI mirror cannot rot. Run it
+locally with `python3 .claude/lib/pre_commit_ci_sync.py .`.
+
+These mirror CI so failures surface locally before a PR (org-wide local⇄CI
+parity, noorinalabs-main#684). **Never** bypass with `--no-verify`, and never
+push or merge with a known-failing check. If `pre-commit install` "cowardly
+refuses" because `core.hooksPath` is set, run `git config --unset core.hooksPath`
+first.

--- a/workers/dedup/Dockerfile
+++ b/workers/dedup/Dockerfile
@@ -1,7 +1,10 @@
 # dedup-worker image.
 # Build from repo root: docker build -f workers/dedup/Dockerfile -t dedup-worker .
 
-FROM python:3.14-slim
+# Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
+# noorinalabs-main#735 / #744). Digest kept in lockstep with the top-level
+# Dockerfile and the sibling repos' python:3.14-slim pin.
+FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -10,6 +13,7 @@ ENV PYTHONUNBUFFERED=1 \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
+ && apt-get -y upgrade \
  && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
 

--- a/workers/enrich/Dockerfile
+++ b/workers/enrich/Dockerfile
@@ -1,7 +1,10 @@
 # enrich-worker image.
 # Build from repo root: docker build -f workers/enrich/Dockerfile -t enrich-worker .
 
-FROM python:3.14-slim
+# Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
+# noorinalabs-main#735 / #744). Digest kept in lockstep with the top-level
+# Dockerfile and the sibling repos' python:3.14-slim pin.
+FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -10,6 +13,7 @@ ENV PYTHONUNBUFFERED=1 \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
+ && apt-get -y upgrade \
  && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
 

--- a/workers/ingest/Dockerfile
+++ b/workers/ingest/Dockerfile
@@ -1,7 +1,10 @@
 # ingest-worker image (Neo4j terminal stage).
 # Build from repo root: docker build -f workers/ingest/Dockerfile -t ingest-worker .
 
-FROM python:3.14-slim
+# Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
+# noorinalabs-main#735 / #744). Digest kept in lockstep with the top-level
+# Dockerfile and the sibling repos' python:3.14-slim pin.
+FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -10,6 +13,7 @@ ENV PYTHONUNBUFFERED=1 \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
+ && apt-get -y upgrade \
  && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
 

--- a/workers/normalize/Dockerfile
+++ b/workers/normalize/Dockerfile
@@ -1,7 +1,10 @@
 # normalize-worker image.
 # Build from repo root: docker build -f workers/normalize/Dockerfile -t normalize-worker .
 
-FROM python:3.14-slim
+# Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
+# noorinalabs-main#735 / #744). Digest kept in lockstep with the top-level
+# Dockerfile and the sibling repos' python:3.14-slim pin.
+FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -10,6 +13,7 @@ ENV PYTHONUNBUFFERED=1 \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
+ && apt-get -y upgrade \
  && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Ingest-platform slice of the cross-repo base-pin + local-hooks-docs rollout
(parent meta noorinalabs-main#744 + #718, gates built in #735). Wires the
charter-prose→code **base-image-pin** gate into this repo's CI, pre-commit, and
sync-drift classifier; fix-forwards the Dockerfiles it flags; and refreshes the
README local-hooks docs.

Closes #114.

## What changed

**#744 — base-pin gate**
- Vendored `.claude/lib/check_dockerfile_base_pin.py` (+ its unit tests) from the
  parent template.
- `.github/workflows/ci.yml`: new `base-pin` job running the check over all five
  worker images (top-level multi-worker `Dockerfile` + `workers/{dedup,enrich,
  ingest,normalize}/Dockerfile`). The `precommit-ci-sync` job now runs the whole
  `.claude/lib/tests/` dir so the new check's tests gate the PR.
- `.pre-commit-config.yaml`: new commit-stage `dockerfile-base-pin` hook over the
  same five files.
- `.claude/lib/pre_commit_ci_sync.py`: classify the `dockerfile-base-pin` kind so
  a CI gate with no local mirror is harmful drift, not silence (#684 parity).
- **Fix-forward** the 5 Dockerfiles the first run flagged (10 violations):
  digest-pin `python:3.14-slim@sha256:44dd…50061` (digest kept in lockstep with
  the sibling repos' pin) and add `apt-get -y upgrade`.

**#718 — README local-hooks docs**
- Refreshed the README "Local hooks" section, mirroring noorinalabs-main
  CLAUDE.md § Local Hooks: both install stages, the full commit/push check-set
  (now including cspell + `dockerfile-base-pin`), and the sync-drift gate.

## fixture-realism — not applicable

`check_fixture_realism.py` was **not** wired and its kind was **not** classified:
this repo carries no Arabic NER/graph-load **data** fixtures — Arabic appears
only inline in `tests/test_parse/*.py` unit sources, and there is no curated-
fixture directory. The slice therefore scopes to base-pin + docs.

## Evidence (local, all green)

- `check_dockerfile_base_pin.py` over the 5 Dockerfiles: `OK` (was 10 violations
  before the fix-forward).
- `pre_commit_ci_sync.py .`: `OK: pre-commit config mirrors all CI-enforced checks.`
- `pytest .claude/lib/tests/`: 52 passed.
- `pre-commit run --hook-stage pre-commit`: actionlint + dockerfile-base-pin Passed.
- `pre-commit run --hook-stage pre-push`: ruff, actionlint, cspell, pip-audit,
  mypy-strict, pytest all Passed.
- `markdownlint-cli2`: 0 errors.

## Reviewers

- Peer reviewer: **Petra Vidović** (tech_lead_petra)
- Secondary reviewer: **Fatima Bensalah** (devops_engineer_fatima)

## Provenance

- noorinalabs-main#744 — roll base-pin + fixture-realism checks out to child-repo CI (from #735)
- noorinalabs-main#718 — README local-hooks docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7PudS35xmg2FW6tJekTGP
