### PR TITLE
fix(ci): clear pip-audit advisory-DB drift — bump soupsieve, exempt unfixable ecdsa Minerva advisory

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -4,3 +4,4 @@ This is the always-loaded index (one line per memory). Topic files in this direc
 
 - [Data pipeline arch](project_data_pipeline_architecture.md) — B2 storage, Kafka/KRaft pipeline, acquisition-vs-platform repo split, MinIO local dev.
 - [main#136 E2E lands in ingest](project_main136_pipeline_e2e_lands_in_ingest.md) — main#136 pipeline-worker E2E scenarios land in ingest-platform (not deploy/not main), ingest persona.
+- [ecdsa Minerva standing item](project_ecdsa_minerva_standing_item.md) — PYSEC-2026-1325 pip-audit-ignored: RS256-only allowlist makes the ECDSA path unreachable; switching to ES* REVOKES it. pip-audit --ignore-vuln matches aliases. ingest#128.

--- a/.claude/memory/project_ecdsa_minerva_standing_item.md
+++ b/.claude/memory/project_ecdsa_minerva_standing_item.md
@@ -1,0 +1,22 @@
+---
+name: project_ecdsa_minerva_standing_item
+description: ecdsa Minerva advisory (PYSEC-2026-1325) is pip-audit-ignored because RS256-only auth makes the ECDSA path unreachable; switching to ES* revokes the exemption.
+metadata:
+  type: project
+---
+
+`pip-audit --strict` ignores **PYSEC-2026-1325** (aliases **CVE-2024-23342**, **GHSA-wj6h-64fc-37mp**) — the python-ecdsa **Minerva timing attack on P-256**. Ignored in BOTH `ci.yml` (`security-audit`) and `.pre-commit-config.yaml` (pre-push `pip-audit`); they must stay verbatim-identical (local⇄CI parity, noorinalabs-main#684). Filed as ingest#128, 2026-07-10.
+
+**There is no fix and none is coming** — the python-ecdsa project considers side-channel attacks out of scope. `ecdsa` cannot be dropped: `python-jose` pulls it, and `src/api/auth.py` genuinely uses `python-jose`.
+
+**Why the exemption is sound:** the vulnerable primitive is **unreachable**, not merely unused in one direction. `src/api/auth.py:123,129` calls `jwt.decode(token, jwks, algorithms=["RS256"])` — RS256 is **RSA**. The advisory is a timing attack on **ECDSA P-256 scalar multiplication**, a code path this repo never enters. `ecdsa` is installed only because `python-jose` declares it as a dependency, not because anything calls it.
+
+> Do not restate this as "we only verify, we don't sign." That weaker rationale is true but brittle — it would survive a switch to ES256 while the actual risk would not.
+
+**What REVOKES this exemption:** admitting any EC algorithm (`ES256` / `ES384` / `ES512`) into that `algorithms=[...]` allowlist. The moment auth can verify an EC-signed token, the "unreachable primitive" argument dies and the ignore must be re-justified or removed. Revisit each wave.
+
+**Two mechanics worth remembering (both verified, not assumed):**
+- **`pip-audit --ignore-vuln` matches ALIASES.** Ignoring by `CVE-2024-23342` suppresses a finding reported as `PYSEC-2026-1325`, and vice versa. So an ignore list keyed on any one alias covers the others.
+- Consequently **`noorinalabs-isnad-graph` was already covered** — its pre-existing `--ignore-vuln CVE-2024-23342` suppresses this advisory by alias, and it carries no `beautifulsoup4`/`soupsieve`. No change was needed there.
+
+Same shape as the bleach standing item (`GHSA-g75f-g53v-794x`, noorinalabs-main#703): an unfixable upstream advisory, non-applicable to our usage, ignored with an inline rationale and a revocation condition. Related: [[project_data_pipeline_architecture]].

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,25 @@ jobs:
           # upstream fix released. parse_email is not used anywhere in this repo
           # (grep -rn parse_email is empty) → non-applicable. Tracked in
           # noorinalabs-main#703; revisit each wave for an upstream fix.
-          uv run pip-audit --strict --desc --ignore-vuln GHSA-g75f-g53v-794x -r /tmp/requirements.txt
+          #
+          # PYSEC-2026-1325 (aliases CVE-2024-23342 / GHSA-wj6h-64fc-37mp):
+          # python-ecdsa Minerva timing attack on P-256. No upstream fix and none
+          # coming — the project considers side-channel attacks out of scope.
+          # `ecdsa` cannot be dropped: it is pulled by python-jose, which the
+          # admin API genuinely uses.
+          #
+          # Non-applicable because the vulnerable primitive is UNREACHABLE, not
+          # merely unused in one direction: src/api/auth.py:123,129 calls
+          # jwt.decode(token, jwks, algorithms=["RS256"]). The allowlist is
+          # RS256 — RSA. The advisory is a timing attack on ECDSA P-256 scalar
+          # multiplication, a code path this repo never enters. `ecdsa` is
+          # installed only because python-jose declares it.
+          #
+          # REVOKES THIS EXEMPTION: admitting an EC algorithm (ES256/ES384/
+          # ES512) into that allowlist. If you change it, this ignore must be
+          # re-justified — the "unreachable primitive" rationale dies there.
+          # Tracked in ingest#128; revisit each wave.
+          uv run pip-audit --strict --desc --ignore-vuln GHSA-g75f-g53v-794x --ignore-vuln PYSEC-2026-1325 -r /tmp/requirements.txt
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,7 +149,17 @@ repos:
         # ReDoS — no upstream fix; parse_email unused in this repo → non-
         # applicable. Tracked in noorinalabs-main#703; revisit each wave. Kept
         # identical to ci.yml's security-audit invocation (local⇄CI parity).
-        entry: bash -c 'uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt && uv run pip-audit --strict --desc --ignore-vuln GHSA-g75f-g53v-794x -r /tmp/requirements.txt'
+        #
+        # --ignore-vuln PYSEC-2026-1325 (aliases CVE-2024-23342 /
+        # GHSA-wj6h-64fc-37mp): python-ecdsa Minerva timing attack on P-256. No
+        # upstream fix and none coming (side-channels are out of scope for that
+        # project). Non-applicable because the vulnerable primitive is
+        # unreachable: src/api/auth.py:123,129 decodes with
+        # algorithms=["RS256"] — RSA, not ECDSA — so the P-256 scalar-mult path
+        # is never entered. `ecdsa` is present only because python-jose declares
+        # it. Admitting an EC algorithm (ES256/ES384/ES512) into that allowlist
+        # REVOKES this exemption. Tracked in ingest#128; revisit each wave.
+        entry: bash -c 'uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt && uv run pip-audit --strict --desc --ignore-vuln GHSA-g75f-g53v-794x --ignore-vuln PYSEC-2026-1325 -r /tmp/requirements.txt'
         language: system
         pass_filenames: false
         always_run: true

--- a/uv.lock
+++ b/uv.lock
@@ -2211,11 +2211,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Clears the `security-audit` (`pip-audit --strict`) red that is currently **blocking every PR in this repo**, including #127.

This is **advisory-DB drift, not a code regression**: `ci.yml` was green on `main` at `fd698ca` (2026-07-06) with this **exact same `uv.lock`**. Three advisories published afterwards against a dependency set nobody touched.

## Changes

**1. `soupsieve` 2.8.3 → 2.8.4** (lockfile only)

Fixes CVE-2026-49476 (unbounded allocation on comma-separated selector lists) and CVE-2026-49477 (ReDoS on an unterminated quoted attribute value). Transitive via `beautifulsoup4`. A real fix for real CVEs — no judgment call.

**2. `--ignore-vuln PYSEC-2026-1325` for `ecdsa`** — with an inline rationale

No fix exists and **none is coming**: the python-ecdsa project considers side-channel attacks out of scope. `ecdsa` cannot be dropped — `python-jose` pulls it, and `src/api/auth.py` genuinely uses `python-jose`.

The exemption is safe because **the vulnerable primitive is unreachable**, not merely unused in one direction. `src/api/auth.py:123,129` calls `jwt.decode(token, jwks, algorithms=["RS256"])` — **RS256 is RSA**. The advisory is a timing attack on **ECDSA P-256 scalar multiplication**, a code path this repo never enters. `ecdsa` is installed only because `python-jose` declares it as a dependency.

> Deliberately **not** justified as "we only verify, we don't sign." That is true but brittle — it would survive a switch to ES256 while the actual risk would not.

**What revokes this exemption:** admitting any EC algorithm (`ES256`/`ES384`/`ES512`) into that allowlist. That condition is written into the inline comment **and** into a standing item (`.claude/memory/project_ecdsa_minerva_standing_item.md`), so the next person knows what would invalidate it — rather than finding a bare CVE id with no justification, which is exactly what made this expensive to diagnose.

Added to **both** `ci.yml` and `.pre-commit-config.yaml`; they mirror each other verbatim (mandatory local⇄CI tooling parity, noorinalabs-main#684).

## Verified, not assumed

- **`PYSEC-2026-1325` is an alias of `CVE-2024-23342`** (OSV `aliases: [CVE-2024-23342, GHSA-wj6h-64fc-37mp]`) — the original python-ecdsa Minerva advisory, not a new one.
- **`pip-audit --ignore-vuln` matches aliases.** Confirmed empirically: ignoring by `CVE-2024-23342` suppresses the finding reported as `PYSEC-2026-1325`, identically to ignoring by the reported id.
- **`noorinalabs-isnad-graph` therefore needs no change** — its pre-existing `--ignore-vuln CVE-2024-23342` already suppresses this advisory by alias, and it carries no `beautifulsoup4`/`soupsieve`. No issue filed there; there is nothing to fix.
- **`noorinalabs-data-acquisition`** carries `soupsieve` 2.8.3 but has **no** `pip-audit` invocation in its workflows, so it cannot red this way.

## Test plan

- `pip-audit --strict` **exits 0** locally against the updated lock (it exited 1 before). The push itself is evidence: `pip-audit` is a pre-push hook, so this branch could not have been pushed while red.
- Full local check-set green, both stages: ruff-format, ruff-lint, actionlint, cspell, dockerfile-base-pin, structural-ontology, sync-drift gate, mypy --strict, pytest.
- No source change — `pytest` and `mypy` cover that nothing moved.

Closes #128
Unblocks #127
