### PR TITLE
hardening(docker): stop shipping the build toolchain (build-essential + curl) in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,14 @@
 # workers/<stage>/Dockerfile images remain for the self-contained local-dev
 # compose (docker-compose.yaml); this top-level Dockerfile is the one the
 # deployed stack consumes.
+#
+# Multi-stage (ip#132): the runtime image ships ONLY the base OS + the resolved
+# virtualenv + application source. It carries no compiler and no curl — see the
+# `builder` stage for why neither is needed.
 
+# ---------------------------------------------------------------------------
+# base — the OS layer that actually ships.
+# ---------------------------------------------------------------------------
 # Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
 # noorinalabs-main#735 / #744). The @sha256 digest freezes the starting layer
 # against floating-tag drift; the `apt-get -y upgrade` below closes the second
@@ -33,30 +40,82 @@
 # Renaming or removing this stage silently re-freezes the apt layer, and
 # check_dockerfile_base_pin.py will stay green while it happens — that gate
 # proves the upgrade LINE exists, not that it RUNS.
+#
+# READING THE FIRST PUBLISH LOG AFTER THIS CHANGE: the apt layer's CONTENT
+# changes here (the toolchain is gone), so it rebuilds on CONTENT grounds
+# whether or not the filter works. This publish therefore does NOT independently
+# re-prove `no-cache-filters`, and must not be cited as if it did. ip#127 already
+# proved it, on a diff that left this layer byte-identical: run 29140637459 —
+# `[base 2/9]` DONE 11.1s, ZERO build-phase CACHED lines, Trivy 10 -> 0.
 FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061 AS base
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
  && apt-get -y upgrade \
- && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# builder — resolve dependencies into a self-contained virtualenv.
+# ---------------------------------------------------------------------------
+# No build toolchain is installed here, and none is needed: every one of the 64
+# packages in the non-dev resolution ships either a pure-python wheel or a
+# prebuilt manylinux x86_64 wheel (pyarrow, pandas, lxml, rapidfuzz,
+# psycopg-binary, cryptography, numpy included), so nothing is compiled from an
+# sdist. Verified against uv.lock with this stage's own `uv export` command:
+# zero packages resolve sdist-only.
+#
+# Do NOT read `--require-hashes` as an sdist *guard* — it is not one. uv.lock
+# carries hashes for sdists too, so a hashed sdist would pass the hash check, be
+# attempted, and then fail at COMPILE time for want of a toolchain. The safety
+# property still holds (a new sdist-only dependency breaks the build loudly, it
+# does not silently ship), but the mechanism is the missing compiler, not the
+# hash check.
+FROM base AS builder
+
+ENV UV_LINK_MODE=copy
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
- && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+RUN uv venv /app/.venv \
+ && uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --python /app/.venv/bin/python --require-hashes -r /tmp/requirements.txt \
  && rm /tmp/requirements.txt
+
+# ---------------------------------------------------------------------------
+# runtime — the published image. No compiler, no curl.
+# ---------------------------------------------------------------------------
+# `build-essential` pulled libc6-dev -> linux-libc-dev (7 of the 10 HIGH CVEs in
+# ip#127 — kernel headers, in a container that will never compile a kernel) and
+# `curl` pulled libssh2-1t64 (the other 3). Neither ships now. No consumer needs
+# curl: none of the four worker services in noorinalabs-deploy
+# compose/docker-compose.prod.yml defines a healthcheck, the repo's own
+# docker-compose.yaml is likewise healthcheck-free, and curl appears nowhere in
+# src/ or workers/.
+FROM base AS runtime
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src ./src
 COPY workers ./workers
+
+# Fail the BUILD, not the deployed container, if a stage stops importing. The
+# four `command:` entrypoints the compose stack invokes are exactly these
+# modules; each is import-safe (env vars are read inside build_runner(), and
+# kafka/boto3/faiss/transformers are imported lazily), so importing all four is
+# a cheap proof that the runtime image can start every stage with only the venv.
+#
+# This guard is NOT inert: the processors import pyarrow/structlog at module
+# level, so a venv that failed to COPY forward fails the build here.
+RUN python -c "import workers.dedup.main, workers.enrich.main, workers.normalize.main, workers.ingest.main"
 
 RUN useradd --uid 1000 --create-home --shell /bin/bash worker \
  && chown -R worker:worker /app

--- a/workers/dedup/Dockerfile
+++ b/workers/dedup/Dockerfile
@@ -1,5 +1,17 @@
 # dedup-worker image.
 # Build from repo root: docker build -f workers/dedup/Dockerfile -t dedup-worker .
+#
+# Local-dev image only: the DEPLOYED stack pulls the top-level multi-worker
+# Dockerfile and selects the stage via the compose `command:` (ip#83, and
+# noorinalabs-deploy compose/docker-compose.prod.yml). This file exists for the
+# self-contained local compose (docker-compose.yaml).
+#
+# Kept structurally in lockstep with the top-level Dockerfile (ip#132): same
+# base/builder/runtime split, same digest, no build toolchain and no curl in the
+# runtime layer. Nothing here needs a compiler — every non-dev dependency ships a
+# pure-python or prebuilt manylinux wheel — and no consumer shells curl (neither
+# the prod compose nor this repo's own docker-compose.yaml defines a healthcheck
+# against these workers).
 
 # Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
 # noorinalabs-main#735 / #744). Digest kept in lockstep with the top-level
@@ -16,26 +28,38 @@ FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
  && apt-get -y upgrade \
- && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
+
+FROM base AS builder
+
+ENV UV_LINK_MODE=copy
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
- && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+RUN uv venv /app/.venv \
+ && uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --python /app/.venv/bin/python --require-hashes -r /tmp/requirements.txt \
  && rm /tmp/requirements.txt
+
+FROM base AS runtime
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src ./src
 COPY workers ./workers
+
+# Fail the build, not the container, if this stage stops importing.
+RUN python -c "import workers.dedup.main"
 
 RUN useradd --uid 1000 --create-home --shell /bin/bash worker \
  && chown -R worker:worker /app

--- a/workers/enrich/Dockerfile
+++ b/workers/enrich/Dockerfile
@@ -1,5 +1,17 @@
 # enrich-worker image.
 # Build from repo root: docker build -f workers/enrich/Dockerfile -t enrich-worker .
+#
+# Local-dev image only: the DEPLOYED stack pulls the top-level multi-worker
+# Dockerfile and selects the stage via the compose `command:` (ip#83, and
+# noorinalabs-deploy compose/docker-compose.prod.yml). This file exists for the
+# self-contained local compose (docker-compose.yaml).
+#
+# Kept structurally in lockstep with the top-level Dockerfile (ip#132): same
+# base/builder/runtime split, same digest, no build toolchain and no curl in the
+# runtime layer. Nothing here needs a compiler — every non-dev dependency ships a
+# pure-python or prebuilt manylinux wheel — and no consumer shells curl (neither
+# the prod compose nor this repo's own docker-compose.yaml defines a healthcheck
+# against these workers).
 
 # Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
 # noorinalabs-main#735 / #744). Digest kept in lockstep with the top-level
@@ -16,26 +28,38 @@ FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
  && apt-get -y upgrade \
- && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
+
+FROM base AS builder
+
+ENV UV_LINK_MODE=copy
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
- && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+RUN uv venv /app/.venv \
+ && uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --python /app/.venv/bin/python --require-hashes -r /tmp/requirements.txt \
  && rm /tmp/requirements.txt
+
+FROM base AS runtime
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src ./src
 COPY workers ./workers
+
+# Fail the build, not the container, if this stage stops importing.
+RUN python -c "import workers.enrich.main"
 
 RUN useradd --uid 1000 --create-home --shell /bin/bash worker \
  && chown -R worker:worker /app

--- a/workers/ingest/Dockerfile
+++ b/workers/ingest/Dockerfile
@@ -1,5 +1,17 @@
 # ingest-worker image (Neo4j terminal stage).
 # Build from repo root: docker build -f workers/ingest/Dockerfile -t ingest-worker .
+#
+# Local-dev image only: the DEPLOYED stack pulls the top-level multi-worker
+# Dockerfile and selects the stage via the compose `command:` (ip#83, and
+# noorinalabs-deploy compose/docker-compose.prod.yml). This file exists for the
+# self-contained local compose (docker-compose.yaml).
+#
+# Kept structurally in lockstep with the top-level Dockerfile (ip#132): same
+# base/builder/runtime split, same digest, no build toolchain and no curl in the
+# runtime layer. Nothing here needs a compiler — every non-dev dependency ships a
+# pure-python or prebuilt manylinux wheel — and no consumer shells curl (neither
+# the prod compose nor this repo's own docker-compose.yaml defines a healthcheck
+# against these workers).
 
 # Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
 # noorinalabs-main#735 / #744). Digest kept in lockstep with the top-level
@@ -16,26 +28,38 @@ FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
  && apt-get -y upgrade \
- && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
+
+FROM base AS builder
+
+ENV UV_LINK_MODE=copy
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
- && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+RUN uv venv /app/.venv \
+ && uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --python /app/.venv/bin/python --require-hashes -r /tmp/requirements.txt \
  && rm /tmp/requirements.txt
+
+FROM base AS runtime
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src ./src
 COPY workers ./workers
+
+# Fail the build, not the container, if this stage stops importing.
+RUN python -c "import workers.ingest.main"
 
 RUN useradd --uid 1000 --create-home --shell /bin/bash worker \
  && chown -R worker:worker /app

--- a/workers/normalize/Dockerfile
+++ b/workers/normalize/Dockerfile
@@ -1,5 +1,17 @@
 # normalize-worker image.
 # Build from repo root: docker build -f workers/normalize/Dockerfile -t normalize-worker .
+#
+# Local-dev image only: the DEPLOYED stack pulls the top-level multi-worker
+# Dockerfile and selects the stage via the compose `command:` (ip#83, and
+# noorinalabs-deploy compose/docker-compose.prod.yml). This file exists for the
+# self-contained local compose (docker-compose.yaml).
+#
+# Kept structurally in lockstep with the top-level Dockerfile (ip#132): same
+# base/builder/runtime split, same digest, no build toolchain and no curl in the
+# runtime layer. Nothing here needs a compiler — every non-dev dependency ships a
+# pure-python or prebuilt manylinux wheel — and no consumer shells curl (neither
+# the prod compose nor this repo's own docker-compose.yaml defines a healthcheck
+# against these workers).
 
 # Digest-pinned base + in-image apt upgrade (charter § Base Image Pinning,
 # noorinalabs-main#735 / #744). Digest kept in lockstep with the top-level
@@ -16,26 +28,38 @@ FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy \
     INGEST_CHECKPOINT_BACKEND=pg
 
 RUN apt-get update \
  && apt-get -y upgrade \
- && apt-get install -y --no-install-recommends build-essential curl \
  && rm -rf /var/lib/apt/lists/*
+
+FROM base AS builder
+
+ENV UV_LINK_MODE=copy
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
- && uv pip install --system --require-hashes -r /tmp/requirements.txt \
+RUN uv venv /app/.venv \
+ && uv export --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
+ && uv pip install --python /app/.venv/bin/python --require-hashes -r /tmp/requirements.txt \
  && rm /tmp/requirements.txt
+
+FROM base AS runtime
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src ./src
 COPY workers ./workers
+
+# Fail the build, not the container, if this stage stops importing.
+RUN python -c "import workers.normalize.main"
 
 RUN useradd --uid 1000 --create-home --shell /bin/bash worker \
  && chown -R worker:worker /app


### PR DESCRIPTION
> **Merge #130 first.** This branch is built on top of #130's commit, so until #130 lands, the diff below shows **both** changes. Once #130 merges to `main`, this PR's diff narrows on its own to the toolchain removal alone.
>
> Base is `main` **deliberately**: `ci.yml` triggers on `pull_request: branches: [main, 'deployments/**']`, so a PR stacked against a feature branch gets **zero CI** — an empty `statusCheckRollup`, which is a hard not-ready, not a pass. Targeting `main` is what makes this PR actually verified.

## What

The top-level `Dockerfile` is **single-stage** and installs `build-essential curl` into the image that **ships**. Neither is needed at runtime, and together they are the source of **all 10** HIGH CVEs that reddened the publish in #127:

| Package | Pulls in | CVEs |
|---|---|---|
| `build-essential` | `libc6-dev` → **`linux-libc-dev`** | **7 of 10** — kernel headers, in a container that will never compile a kernel |
| `curl` | **`libssh2-1t64`** | **3 of 10** |

Split `base` → `builder` → `runtime`; the runtime layer carries only the resolved venv plus application source. This deletes the CVE surface at the source rather than chasing it upgrade-by-upgrade, and shrinks the image.

## Why this is split out of #127 — this is the important part

Bundling the two **destroys the proof of the cache fix**, and it took Tomás Carvalho's review to see it.

#127's claim is that `no-cache-filter: base` makes the frozen apt layer actually rebuild. Shipping this alongside it confounds **both** signals that would demonstrate that:

- **The `CACHED` signal.** BuildKit keys a layer on its parent-vertex hash **plus its own instruction text**. This rewrite changes the `ENV` above the apt `RUN` (dropping `UV_SYSTEM_PYTHON`/`UV_LINK_MODE`) *and* the `RUN` text itself (dropping `build-essential curl`). Either alone is a cache miss on **content** grounds — so the layer rebuilds whether or not `no-cache-filter` does anything, and the log line proves nothing.
- **The Trivy signal.** This deletes the very packages all 10 CVEs live in, so Trivy could go green even if the flag were completely inert.

A silently-inert flag and a working one would produce **byte-identical evidence**. So #127 ships **first and alone**, keeping `build-essential`/`curl` **installed** — which is precisely what makes its Trivy result independently meaningful (those packages are still in the image and still scanned; they clear if and only if apt actually upgraded them).

This PR lands after #127 has proven the mechanism. By then its own "apt layer still not `CACHED`" observation is a *real* one, because #127's base content is the cached predecessor.

## Verified, not assumed

- **No compiler is needed.** All **64** packages in the non-dev resolution ship a pure-python wheel (48) or a prebuilt manylinux x86_64 wheel (16 — `pyarrow`, `pandas`, `lxml`, `rapidfuzz`, `psycopg-binary`, `cryptography`, `numpy` included). **Zero sdist-only**, checked against `uv.lock` with the Dockerfile's own `uv export` command.
- **No consumer needs `curl`.** None of the four worker services in `noorinalabs-deploy compose/docker-compose.prod.yml` defines a healthcheck; all four run `python -m workers.<stage>.main`. The repo's own `docker-compose.yaml` — which drives the four `workers/*/Dockerfile` images — is **likewise healthcheck-free** (a consumer I had missed; Tomás checked it). `curl` appears nowhere in `src/` or `workers/`.

### Correction carried in from review: `--require-hashes` is NOT an sdist guard

An earlier draft of this claimed a stray sdist "would fail the install rather than silently reach for a compiler." **That is wrong**, and the Dockerfile comment now says so explicitly. `uv.lock` carries hashes for **sdists too**, so a hashed sdist would *pass* the hash check, be attempted, and fail at **compile** time for want of a toolchain.

The safety conclusion is unchanged — a new sdist-only dependency breaks the build **loudly** rather than silently shipping — but the mechanism is the **missing compiler**, not the hash check. Fixed so nobody later relies on `--require-hashes` for a guarantee it does not provide.

## Import guard, and it is not inert

The runtime stage imports all four worker mains at build time, so a stage that stops importing fails the **build** rather than the deployed container. Confirmed non-vacuous: the processors pull `pyarrow`/`structlog` at module level, so a failed venv `COPY` fails the build. (The ML deps — `faiss`, `transformers` — and `boto3` are imported lazily inside functions, so importing all four mains needs only the base dependency set.)

## Test plan

Local check-set green, both stages (ruff, actionlint, cspell, dockerfile-base-pin, structural-ontology, sync-drift, mypy --strict, pytest, pip-audit).

After #127 and this land, from the real `main` publish log:
- Trivy **still** 0 HIGH/CRITICAL on the digest.
- Apt layer **still** not `CACHED`.
- Image measurably smaller.
- All four stages still import (enforced by the build-time guard above).

Closes #132
Part of noorinalabs-main#947
