### PR TITLE
perf(ci): cache-to mode=min — same detector, ~63% less export (measured, with a control)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -173,12 +173,22 @@ jobs:
           # exactly the five days we lived through. That latency is the reason the
           # ip#137 tripwire exists.
           #
-          # Whether ip#132's base/builder/runtime split restores caching is
-          # UNTESTED and genuinely open: `builder` derives FROM `base`, so
-          # un-caching the parent may cascade to its children — or may not, since
-          # BuildKit keys a child on the parent's RESULT, and a re-run apt that
-          # changes nothing produces an identical layer. Measure it. Do not write
-          # down either answer.
+          # HOW TO REVERT THIS, AND WHEN. `mode=min` exports only the final image's
+          # layers. It was chosen because the detector SURVIVES it — measured with a
+          # control (run 29142720595): reading a `mode=min` cache with no filter,
+          # `[base 2/2]` still comes back CACHED, so a broken filter can still be
+          # served a frozen layer. That is the ONLY property that justifies it.
+          #
+          # So the revert condition is precise: if `[base 2/2]` ever fails to come
+          # back CACHED on a NO-FILTER read of a `mode=min` cache, then `mode=min`
+          # has silently emptied what `cache-from` reads, the frozen-layer condition
+          # can no longer be created, and THE DETECTOR IS DEAD WHILE EVERYTHING STAYS
+          # GREEN. Go back to `mode=max` and pay the export. Nothing will tell you
+          # this happened — it is the same silence the filter itself failed in — so
+          # it is checked by the ip#137 staleness tripwire, not by watching for red.
+          #
+          # This condition lives HERE, not in the merged PR body: whoever next edits
+          # this line will read the comment and will not read PR #138.
           cache-from: type=gha,scope=workers
           cache-to: type=gha,mode=min,scope=workers
           # Exclude the `base` stage — the digest-pinned FROM plus the in-image

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -110,38 +110,68 @@ jobs:
           # was fabricated. An unstable identifier can manufacture a refutation as
           # easily as a confirmation.
           #
-          # These two CANNOT cache-hit in the shipped config: the filter uncaches
-          # `base`, and `base` is the whole image. They are retained as the CONTROL
-          # ARM, not as an optimisation. If the filter ever silently breaks (stage
-          # renamed, action input renamed, key "tidied" back to singular),
-          # `cache-from` serves the frozen apt layer again, the old packages
-          # return, and Trivy goes RED — that is how we find out. Delete it and the
-          # same breakage is SILENT: nothing to serve, apt re-runs anyway, publish
-          # goes green, and a WORKING filter and a COMPLETELY BROKEN one produce
-          # byte-identical evidence. That is the self-certifying configuration this
-          # PR exists to destroy.
+          # These two CANNOT cache-hit in the shipped config. NOTE THE REASON HAS
+          # CHANGED: it used to be "`base` is the whole image" (true when this was
+          # single-stage). Since ip#132 split it, `base` is a thin preamble — but
+          # un-caching a parent stage CASCADES to its children, so `builder` and
+          # `runtime` rebuild too. MEASURED with a control (run 29141995875):
+          # reading the same cache with NO filter, `[builder 4/4]` is CACHED; with
+          # `no-cache-filters: base` it rebuilds. Post-ip#132 publishes therefore
+          # still show ZERO `CACHED` lines (confirmed, run 29142394336).
+          #
+          # They are retained as the CONTROL ARM, not as an optimisation. If the
+          # filter ever silently breaks (stage renamed, action input renamed, key
+          # "tidied" back to the singular), `cache-from` serves the frozen apt
+          # layer again and the old packages return. Delete it and the same
+          # breakage is SILENT: nothing to serve, apt re-runs anyway, publish goes
+          # green, and a WORKING filter and a COMPLETELY BROKEN one produce
+          # byte-identical evidence. That is the self-certifying configuration
+          # ip#127 existed to destroy.
           #
           # BOTH lines are load-bearing. `cache-to` is what keeps the detector
           # alive — GHA cache entries evict when unused, so dropping ONLY
           # `cache-to` silently empties `cache-from` and kills the guard without
           # touching it. Keep both or keep neither.
           #
-          # Do NOT price this decision. Every number attached to it was measured in
-          # the wrong arm: the ~80s was a `load: true` harness artefact; the 3.5s
-          # uv saving exists only in the CONTROL arm and is unreachable once the
-          # filter is on; "zero" ignored `cache-to` entirely. What IS measured:
-          # `cache-from` costs 0.1s (`importing cache manifest from gha … DONE
-          # 0.1s`, treatment arm) — effectively free. What is NOT: `cache-to
-          # mode=max` re-exports every layer on every publish, and the proof
-          # harness omitted `cache-to` BY DESIGN, so nobody has priced it. Read it
-          # off the first real publish; do not delete these lines on the strength
-          # of a number until then.
+          # WHAT THE DETECTOR NO LONGER GIVES YOU, and this is the important part:
+          # it used to be read out by Trivy going RED. ip#132 removed
+          # `build-essential` and `curl`, which brought in `linux-libc-dev` and
+          # `libssh2-1t64` — the packages carrying 10 of the 10 HIGH CVEs. A frozen
+          # `base` now has far less left to accumulate CVEs in, so that readout is
+          # much weaker and may effectively stop firing. Good for security; bad for
+          # the alarm. DO NOT rely on "Trivy goes red" as the tripwire. The
+          # replacement is an explicit staleness check (`apt-get -s upgrade` against
+          # the built image, OUTSIDE the build — inside a RUN it becomes part of the
+          # layer it polices). Tracked in ip#137. `cache-from` creates the
+          # condition; the tripwire reads it; NEITHER DOES ANYTHING ALONE.
           #
-          # Honest sensitivity — do not oversell this detector: it is NOT an
-          # instant tripwire. With `cache-to` writing fresh layers each publish, a
+          # PRICED, finally, and in the right arm. Earlier numbers were all measured
+          # in the wrong one: the ~80s was a `load: true` harness artefact; the 3.5s
+          # uv saving exists only in the CONTROL arm and is unreachable once the
+          # filter is on; "zero" ignored `cache-to` entirely. The real figures, off
+          # the production publish (run 29142394336) — and note the export has TWO
+          # phases; grepping only `sending` is how the number came out wrong:
+          #
+          #   cache-from  importing cache manifest ……………………………  0.1s  (free)
+          #   cache-to    preparing build cache for export ……… 25.5s
+          #   cache-to    sending cache export ………………………………… 63.1s   } 88.6s
+          #
+          # Hence `mode=min` below (ip#137). `mode=max` exports every stage's
+          # layers including all of `builder`'s intermediates, which never appear in
+          # the shipped image. `mode=min` exports only the final image's layers —
+          # and MEASURED with a control (run 29142720595), the detector SURVIVES:
+          # reading a `mode=min` cache, `[base 2/2]` still comes back CACHED, so a
+          # broken filter can still be served a frozen layer. Export cost fell ~63%
+          # in the scratch arm (60.4s -> 22.4s). The RATIO transfers; the ABSOLUTE
+          # saving against the 88.6s above must be read off a real publish — do not
+          # write down a production figure nobody has measured.
+          #
+          # Honest sensitivity — do not oversell this detector: it is NOT an instant
+          # tripwire. With `cache-to` writing fresh layers each publish, a
           # newly-broken filter serves a layer at most one publish old, and the
-          # gate only reddens once a NEW fixed HIGH CVE lands against it. Days to
-          # weeks — which is exactly the five days we just lived through.
+          # readout only fires once something new lands against it. Days to weeks —
+          # exactly the five days we lived through. That latency is the reason the
+          # ip#137 tripwire exists.
           #
           # Whether ip#132's base/builder/runtime split restores caching is
           # UNTESTED and genuinely open: `builder` derives FROM `base`, so
@@ -150,7 +180,7 @@ jobs:
           # changes nothing produces an identical layer. Measure it. Do not write
           # down either answer.
           cache-from: type=gha,scope=workers
-          cache-to: type=gha,mode=max,scope=workers
+          cache-to: type=gha,mode=min,scope=workers
           # Exclude the `base` stage — the digest-pinned FROM plus the in-image
           # `apt-get -y upgrade` — from the layer cache, so the upgrade actually
           # RUNS on every publish instead of being replayed as a cached no-op.

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -102,13 +102,36 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Cite layers by their `[base N/9]` label, NEVER by buildx vertex number
-          # (`#10`, `#18`, …): those are assigned in solve order and are NOT stable
-          # across builds. In the ip#127 proof run's CONTROL arm the apt layer is
-          # `#12`, not `#10` — `#10` is a COPY. Anyone grepping `#10` in the
-          # control log to check our work would find a COPY and conclude the proof
-          # was fabricated. An unstable identifier can manufacture a refutation as
+          # Cite layers by their STAGE-STEP LABEL, never by buildx vertex number
+          # (`#10`, `#18`, …): vertex numbers are assigned in solve order and are
+          # NOT stable across builds. In the ip#127 proof run's CONTROL arm the apt
+          # layer is `#12`, not `#10` — `#10` is a COPY. Anyone grepping `#10` in
+          # that log to check our work would find a COPY and conclude the proof was
+          # fabricated. An unstable identifier can manufacture a refutation as
           # easily as a confirmation.
+          #
+          # AND THE LABELS ARE ERA-SPECIFIC — this rule decayed once already, so
+          # read it carefully. It used to say `[base N/9]`. That was the
+          # SINGLE-STAGE era, when `base` was the whole image and had nine steps.
+          # ip#132 split the Dockerfile, and the current publish emits:
+          #
+          #   [base 1/2] [base 2/2]        <- `[base 2/2]` IS the apt upgrade today
+          #   [builder 1/4] … [builder 4/4]
+          #   [runtime 1/6] … [runtime 6/6]
+          #
+          # There is no `/9` anywhere any more. A reader who followed the old rule
+          # literally would grep a current log for `[base N/9]`, find NOTHING, and
+          # conclude we fabricated the evidence — the identical harm the rule exists
+          # to prevent. The rule about unstable identifiers had itself decayed into
+          # an unstable identifier.
+          #
+          # So when citing a log, SAY WHICH ERA IT CAME FROM. Both appear below:
+          #   `[base 2/9]` — pre-ip#132 (single-stage). The apt layer in ip#127's
+          #                  logs, e.g. runs 29139568901 / 29140637459.
+          #   `[base 2/2]` — post-ip#132 (multi-stage). The apt layer in every
+          #                  current log, e.g. runs 29141995875 / 29142394336.
+          # They are the same layer in two eras, not a contradiction and not a
+          # fabrication.
           #
           # These two CANNOT cache-hit in the shipped config. NOTE THE REASON HAS
           # CHANGED: it used to be "`base` is the whole image" (true when this was
@@ -161,10 +184,22 @@ jobs:
           # the shipped image. `mode=min` exports only the final image's layers —
           # and MEASURED with a control (run 29142720595), the detector SURVIVES:
           # reading a `mode=min` cache, `[base 2/2]` still comes back CACHED, so a
-          # broken filter can still be served a frozen layer. Export cost fell ~63%
-          # in the scratch arm (60.4s -> 22.4s). The RATIO transfers; the ABSOLUTE
-          # saving against the 88.6s above must be read off a real publish — do not
-          # write down a production figure nobody has measured.
+          # broken filter can still be served a frozen layer.
+          #
+          # DO NOT QUOTE A TOTAL-COST RATIO FROM THE SCRATCH ARM. The scratch and
+          # production caches have INVERTED phase profiles — they differ materially
+          # in what they hold and how it moves:
+          #
+          #                     preparing      sending
+          #     scratch          37.3s (dom)    23.1s
+          #     production       25.5s          63.1s (dom)
+          #
+          # A total drawn from an arm whose cost sits in the OTHER phase is the
+          # wrong-arm error one level subtler than the ones that already bit us. The
+          # ~63% fall DOES survive PER PHASE (both phases fell ~63% in scratch), so
+          # a per-phase ratio is defensible where a total is not. Report the two
+          # phases SEPARATELY, always, and read the production figure off a real
+          # publish — do not write down a total nobody has measured.
           #
           # Honest sensitivity — do not oversell this detector: it is NOT an instant
           # tripwire. With `cache-to` writing fresh layers each publish, a
@@ -173,19 +208,35 @@ jobs:
           # exactly the five days we lived through. That latency is the reason the
           # ip#137 tripwire exists.
           #
-          # HOW TO REVERT THIS, AND WHEN. `mode=min` exports only the final image's
-          # layers. It was chosen because the detector SURVIVES it — measured with a
-          # control (run 29142720595): reading a `mode=min` cache with no filter,
-          # `[base 2/2]` still comes back CACHED, so a broken filter can still be
-          # served a frozen layer. That is the ONLY property that justifies it.
+          # HOW TO REVERT THIS, AND WHEN. `mode=min` was chosen for exactly ONE
+          # property: the detector SURVIVES it. Measured with a control (run
+          # 29142720595) — reading a `mode=min` cache with NO filter, `[base 2/2]`
+          # still comes back CACHED, so a broken filter can still be served a frozen
+          # layer. Nothing else about `mode=min` justifies it.
           #
-          # So the revert condition is precise: if `[base 2/2]` ever fails to come
-          # back CACHED on a NO-FILTER read of a `mode=min` cache, then `mode=min`
-          # has silently emptied what `cache-from` reads, the frozen-layer condition
-          # can no longer be created, and THE DETECTOR IS DEAD WHILE EVERYTHING STAYS
-          # GREEN. Go back to `mode=max` and pay the export. Nothing will tell you
-          # this happened — it is the same silence the filter itself failed in — so
-          # it is checked by the ip#137 staleness tripwire, not by watching for red.
+          # REVERT CONDITION: if `[base 2/2]` ever fails to come back CACHED on a
+          # NO-FILTER read of a `mode=min` cache, then `mode=min` has silently
+          # emptied what `cache-from` reads, the frozen-layer condition can no longer
+          # be created, and THE DETECTOR IS DEAD WHILE EVERYTHING STAYS GREEN. Go
+          # back to `mode=max` and pay the export.
+          #
+          # AND HERE IS THE HARD PART, SO YOU ARE NOT AMBUSHED BY IT: you cannot
+          # evaluate that condition from a normal publish. A "no-filter read" is
+          # something PRODUCTION NEVER PERFORMS — the filter is always on, so every
+          # real publish shows zero CACHED lines whether the cache holds the base
+          # layer or not. Checking it requires a deliberate harness: build once
+          # against the cache scope with `cache-from` and WITHOUT
+          # `no-cache-filters`, and read whether `[base 2/2]` reports CACHED.
+          #
+          # Every harness in this saga (the ip#127 cache-proof, the ip#132
+          # build-proof, the ip#137 mode-min proof) was DELETED the moment it
+          # answered its question. The verification capability has never once
+          # survived the PR that created it — which means the person who most needs
+          # this check is the least likely to know how to run it. ip#137 is landing a
+          # permanent, dispatchable self-test so that stops being true. Until it does,
+          # rebuild the harness from one of those runs rather than assuming the
+          # detector is fine because the publish is green. IT WILL BE GREEN EITHER
+          # WAY. That is the whole problem.
           #
           # This condition lives HERE, not in the merged PR body: whoever next edits
           # this line will read the comment and will not read PR #138.


### PR DESCRIPTION
## What

**One functional line:** `cache-to: type=gha,mode=max` → **`mode=min`**.

Everything else in the diff is comment truth-maintenance — two claims in the existing comment became **false** through my own earlier changes (details at the bottom).

## Why — and the cost nobody had

The cache export is the largest recurring cost of the publish, and it went unpriced until now. Off the **production** publish (run `29142394336`). Note the export has **two phases** — grepping only `sending` is how the first number came out wrong:

```
cache-from  importing cache manifest ……………………   0.1s   (free)
cache-to    preparing build cache for export …  25.5s
cache-to    sending cache export ……………………………  63.1s   } 88.6s
```

`mode=max` exports **every stage's** layers, including all of `builder`'s intermediates — **which never appear in the shipped image at all.** `mode=min` exports only the final image's layers.

## The question that actually mattered

Not *"is `mode=min` cheaper"* — obviously it is. The question was whether a `mode=min` cache **still carries the `base` apt layer**, because `cache-from` serving that frozen layer is the **only readout we have** if `no-cache-filters` ever silently breaks.

If `mode=min` dropped it, **the detector would die silently**: nothing to serve, apt re-runs anyway, publish stays green, and a working filter and a dead one become indistinguishable. That is this repo's signature bug, and it could not be assumed away in either direction.

## Measured, with a control — run [29142720595](https://github.com/noorinalabs/noorinalabs-isnad-ingest-platform/actions/runs/29142720595)

| | `mode=max` | `mode=min` |
|---|---|---|
| preparing cache export | 37.3s | **13.7s** |
| sending cache export | 23.1s | **8.7s** |
| **total export** | **60.4s** | **22.4s** |
| **`[base 2/2]` served by `cache-from`** | **CACHED** | **CACHED** ← the detector lives |

**The controls, because a result this favourable is exactly when to distrust yourself:**

- **CONTROL arm** (read a `mode=max` cache, no filter): `[base 2/2]` **CACHED**. Without it, *"min still caches"* and *"my scratch cache silently did nothing"* would have been **the same observation**.
- **Scope collision ruled out:** the two readers imported **different manifests** (`gha:13040149155532296266` vs `gha:2889233233053942381`) and passed **different scopes**.
- **Both export phases reported.**

**Better than hypothesised:** `[builder 4/4]` and all of `runtime` *also* stay CACHED under `mode=min` — `runtime` COPYs the venv from `builder`, so BuildKit keeps that chain even though its intermediates aren't final-image layers. Nothing was lost.

> **The ratio transfers; the absolute does not.** The real saving against production's 88.6s must be read off the first publish after this merges. I am not writing down a production figure nobody has measured — that is the wrong-arm error, and I have made it twice already.

## Comment truth-maintenance (the rest of the diff)

Two claims became **false through my own earlier changes**, and a false standing rationale is precisely what I was blocked for once already:

1. **"These two cannot cache-hit because `base` is the whole image"** — true when the Dockerfile was single-stage; **#133 split it.** The real reason is now the **cascade** (un-caching a parent rebuilds its children), measured with a control in run `29141995875`. Corrected, with the reason stated.
2. **"`cache-to` … nobody has priced it"** — priced above. Corrected.

And one thing **nobody had written down** (Fatima's catch): **#133 removed the packages carrying 10 of the 10 HIGH CVEs** (`linux-libc-dev` via `build-essential`, `libssh2-1t64` via `curl`). A frozen `base` now has far less left to accumulate CVEs in, so the **"Trivy goes red" readout is much weaker and may effectively stop firing.** Good for security, **bad for the alarm.** The comment now says so, and points at the #137 staleness tripwire as the replacement: **`cache-from` creates the condition, the tripwire reads it, and neither does anything alone.**

## The tripwire ships SEPARATELY

Two changes in one publish would give a failure **two candidate causes** — the exact confound this PR's predecessor was blocked for. Separate PRs, separate publishes, separate evidence.

## Test plan

Full local check-set green. **After merge I will read the first real publish and post the true production export cost — both phases, by stage-step label — to #137.** If `[base 2/2]` fails to come back CACHED on a subsequent no-filter read, `mode=min` killed the detector and this reverts.

Part of #137
