### PR TITLE
fix(ci): clear pip-audit CVE drift (kafka-python, pyasn1, click)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,26 @@ dependencies = [
     "tqdm>=4.66",
     "tenacity>=8.2",
     "rapidfuzz>=3.6",
-    "kafka-python>=2.0",
+    # PYSEC-2026-2191: SCRAM iteration-count DoS (unbounded pbkdf2_hmac), fixed in
+    # 2.3.2. Held to the 2.x line — >=2.3.2 alone lets the resolver jump to 3.0.x
+    # (a major API break for the worker consumer/offset path); the CVE is cleared
+    # on 2.x, so bump minimally and defer any 3.x migration to its own change.
+    "kafka-python>=2.3.2,<3",
     "boto3>=1.34",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "python-jose[cryptography]>=3.3",
     "starlette>=1.3.1",  # CVE-2026-54283 (urlencoded-form DoS) + CVE-2026-54282 (request.url host spoof); transitive via fastapi
     "cryptography>=48.0.1",  # GHSA-537c-gmf6-5ccf (statically-linked OpenSSL in wheels); transitive via python-jose[cryptography]
+    # pyasn1 is transitive via python-jose[cryptography] -> rsa -> pyasn1. Pin a
+    # direct floor to clear the 0.6.3 quadratic-decode DoS advisories
+    # PYSEC-2026-3455/3456/3457 (long-form tag, OID/RELATIVE-OID arcs, univ.Real
+    # exponent), all fixed in 0.6.4.
+    "pyasn1>=0.6.4",
+    # click is transitive via uvicorn[standard] (and typer). Pin a direct floor
+    # to clear PYSEC-2026-2132 (command injection in click.edit()), fixed in
+    # 8.3.3.
+    "click>=8.3.3",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -317,14 +317,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -818,11 +818,11 @@ wheels = [
 
 [[package]]
 name = "kafka-python"
-version = "2.3.1"
+version = "2.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/98/cbecbe20ec9e4e6f978c42229e7c777f498eec5061f986b4acfa34a7ec46/kafka_python-2.3.1.tar.gz", hash = "sha256:90f1caa12d8faa9fd059852b0c73adf169b979279aa2e3ff370f9fe615d654b6", size = 357302, upload-time = "2026-04-09T21:10:22.861Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/7e/9eb4363e5018b71edf77de3d2fbd687f1e3a55d43101138a5b7f2ca56d97/kafka_python-2.3.2.tar.gz", hash = "sha256:2d2469bcabc2551be7eaf7fb512e1241484d358800f2665b90e7e24fea84259d", size = 357589, upload-time = "2026-06-03T22:46:49.022Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/83/6f79b5e03f7d259cba60d3e48c97f7b76a86d20486a515e8ffadea97434e/kafka_python-2.3.1-py2.py3-none-any.whl", hash = "sha256:4908865da9e57f0f966a83788c71cb0ae91c33451a26ab6e6984a00b15c6ed71", size = 326065, upload-time = "2026-04-09T21:10:24.685Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/db/cfe23cfacc9aabeef59e349aa6c2738d195df1d56ccf8c31362abdd68ddb/kafka_python-2.3.2-py2.py3-none-any.whl", hash = "sha256:e8a5e6f2c4ce13a8041669337038d5125e0e09e6d6f0911902ae5939e5b9595e", size = 326623, upload-time = "2026-06-03T22:46:47.417Z" },
 ]
 
 [[package]]
@@ -1142,6 +1142,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "bleach" },
     { name = "boto3" },
+    { name = "click" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -1152,6 +1153,7 @@ dependencies = [
     { name = "pandas" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pyarrow" },
+    { name = "pyasn1" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -1192,16 +1194,18 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "bleach", specifier = ">=6.4.0" },
     { name = "boto3", specifier = ">=1.34" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "kafka-python", specifier = ">=2.0" },
+    { name = "kafka-python", specifier = ">=2.3.2,<3" },
     { name = "kaggle", specifier = ">=1.6" },
     { name = "lxml", specifier = ">=5.1" },
     { name = "neo4j", specifier = ">=5.15" },
     { name = "pandas", specifier = ">=2.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pyarrow", specifier = ">=15.0" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pydantic-settings", specifier = ">=2.1" },
     { name = "python-dotenv", specifier = ">=1.0" },
@@ -1646,11 +1650,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why
The `pip-audit` pre-push gate was failing on freshly-published advisory-DB CVEs in transitive/direct deps, **blocking ALL pushes to the ip repo** (Phase 10 Wave 28). This is a standalone `fix(ci)` to unblock the repo. Precedent: `ba8e843`.

## What
Dep-floor bumps + `uv lock` regen only — no code changes.

| Package | From | To | Advisory | Notes |
|---|---|---|---|---|
| kafka-python | 2.3.1 | 2.3.2 | PYSEC-2026-2191 | **capped `<3`** to stay on the vetted 2.x major (open floor otherwise floated to 3.0.9) |
| pyasn1 | 0.6.3 | 0.6.4 | PYSEC-2026-3455/3456/3457 | transitive via `rsa` ← `python-jose` |
| click | 8.3.2 | 8.4.2 | PYSEC-2026-2132 | `click.edit()` command injection; transitive via uvicorn/typer |

**Scope note:** the original diagnosis was kafka-python + pyasn1 only. Running the exact gate command surfaced a third same-batch advisory — **click PYSEC-2026-2132** — that also fails the gate. It has an upstream fix (8.3.3), so per the "bump-not-ignore" policy it's included here; without it the gate stays red and nothing unblocks.

**Not touched:** `ecdsa` PYSEC-2026-1325 remains `--ignore-vuln` (unreachable Minerva P-256 primitive, no upstream fix) per the existing gate policy — unchanged.

## Verification
- Exact pre-push gate command → `No known vulnerabilities found, 1 ignored` (exit 0).
- Push gate green: pip-audit + mypy-strict + pytest (unit) all **Passed**.
- Diff limited to `pyproject.toml` + `uv.lock`; lock shows only the 3 intended version bumps, no collateral resolution churn.

## Impact
Unblocks all ip wave-28 pushes. **ip#140 and ip#141 are waiting to rebase on this** — please prioritize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z