### PR TITLE
docs: fix stale Kafka topic names in CLAUDE.md worker topology table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,10 @@ docker compose up --build
 
 | Worker | Consumes | Produces | Ported from |
 |---|---|---|---|
-| `dedup-worker` | `pipeline.raw.new` | `pipeline.dedup.done` | `src/resolve/` |
+| `dedup-worker` | `pipeline.raw.landed` | `pipeline.dedup.done` | `src/resolve/` |
 | `enrich-worker` | `pipeline.dedup.done` | `pipeline.enrich.done` | `src/enrich/` |
-| `normalize-worker` | `pipeline.enrich.done` | `pipeline.norm.done` | (new) |
-| `ingest-worker` | `pipeline.norm.done` | Neo4j (terminal) | `src/graph/` |
+| `normalize-worker` | `pipeline.enrich.done` | `pipeline.normalize.done` | (new) |
+| `ingest-worker` | `pipeline.normalize.done` | Neo4j (terminal) | `src/graph/` |
 
 All failures route to `pipeline.dlq`. Each worker is its own container; the shared consume/fetch/process/write/publish/DLQ loop, the pointer-message schema, the S3 client, checkpointing, and metrics live in `workers/lib/`. A single multi-stage image (top-level `Dockerfile`) is the artifact the deployed stack pulls; the stage is selected at start time by the compose service's `command:`. The per-stage `workers/<stage>/Dockerfile` images remain for the self-contained local-dev compose.
 


### PR DESCRIPTION
## Summary

`workers/lib/topics.py` is the declared single source of truth for pipeline Kafka topic names. The always-loaded `CLAUDE.md` § Architecture → Streaming-worker topology table had drifted onto three retired topic names:

| Line | Cell | Was | Now |
|---|---|---|---|
| 77 | `dedup-worker` consumes | `pipeline.raw.new` | `pipeline.raw.landed` |
| 79 | `normalize-worker` produces | `pipeline.norm.done` | `pipeline.normalize.done` |
| 80 | `ingest-worker` consumes | `pipeline.norm.done` | `pipeline.normalize.done` |

`enrich-worker`'s row was already correct and is untouched. Per `ontology/conventions.md` § "code is the arbiter of truth" (#768), the doc is corrected to match `topics.py`, not the reverse.

Fixes #152

## Test plan

- [x] `rg -n "pipeline\.[a-z]+\.[a-z]+" CLAUDE.md` — confirms only the three intended cells changed, diff is exactly a 3-line swap
- [x] Local pre-commit (commit stage) + pre-push (pip-audit, mypy --strict, pytest unit) all green
- [x] No other files touched

🤖 Generated with a spawned Claude Code teammate (Yusuke Inoue)
